### PR TITLE
fix: 동아리 페이지네이션 조회 API 응답값 카멜케이스 수정

### DIFF
--- a/src/main/java/com/example/konect/club/dto/ClubsResponse.java
+++ b/src/main/java/com/example/konect/club/dto/ClubsResponse.java
@@ -1,6 +1,5 @@
 package com.example.konect.club.dto;
 
-import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import java.util.List;
@@ -10,11 +9,9 @@ import org.springframework.data.domain.Page;
 
 import com.example.konect.club.model.Club;
 import com.example.konect.club.model.ClubTag;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@JsonNaming(value = SnakeCaseStrategy.class)
 public record ClubsResponse(
     @Schema(description = "조건에 해당하는 동아리 수", example = "10", requiredMode = REQUIRED)
     Long totalCount,
@@ -31,7 +28,6 @@ public record ClubsResponse(
     @Schema(description = "동아리 리스트", requiredMode = REQUIRED)
     List<InnerClubResponse> clubs
 ) {
-    @JsonNaming(value = SnakeCaseStrategy.class)
     public record InnerClubResponse(
         @Schema(description = "동아리 고유 ID", example = "1", requiredMode = REQUIRED)
         Integer id,


### PR DESCRIPTION
### 🔍 개요

- close #7 

---

### 🚀 주요 변경 내용

* 동아리 페이지네이션 조회 API 응답값을 카멜케이스로 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
