### PR TITLE
fix: 모집 중이 아닌 동아리에 대한 정렬 기준 수정

### DIFF
--- a/src/main/java/gg/agit/konect/club/repository/ClubQueryRepository.java
+++ b/src/main/java/gg/agit/konect/club/repository/ClubQueryRepository.java
@@ -134,6 +134,7 @@ public class ClubQueryRepository {
         if (isRecruiting) {
             return clubRecruitment.endDate.asc();
         }
-        return null;
+
+        return club.id.asc();
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 모집 중이 아닌 동아리의 정렬 기준을 수정한다.

- [이슈](https://linear.app/cambodia/issue/CAM-76/모집중이-아닌-동아리에-대한-정렬-기준-수정)

---

### 🚀 주요 변경 내용

* 모집 중이 아닌 동아리의 정렬 기준이 `null`이면 `orderBy()`에서 `NPE`가 발생하여 `id`를 기준으로 오름차순으로 조회할 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
