### PR TITLE
feat: OAuth 로그인 처리 시 리다이렉트 방식으로 변경

### DIFF
--- a/src/main/java/gg/agit/konect/security/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/gg/agit/konect/security/handler/OAuth2LoginSuccessHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -23,6 +24,9 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    @Value("${app.frontend.base-url}")
+    private String frontendBaseUrl;
 
     private final int TEMP_SESSION_EXPIRATION_SECONDS = 600;
 
@@ -58,7 +62,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         session.setAttribute("provider", provider);
         session.setMaxInactiveInterval(TEMP_SESSION_EXPIRATION_SECONDS);
 
-        response.sendRedirect("https://konect.kro.kr/signup");
+        response.sendRedirect(frontendBaseUrl + "/signup");
     }
 
     private void sendLoginSuccessResponse(HttpServletRequest request, HttpServletResponse response, User user,
@@ -66,7 +70,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         HttpSession session = request.getSession(true);
         session.setAttribute("userId", user.getId());
 
-        response.sendRedirect("https://konect.kro.kr");
+        response.sendRedirect(frontendBaseUrl);
     }
 
     private String extractEmail(OAuth2User oauthUser, Provider provider) {


### PR DESCRIPTION
### 🔍 개요

* 기존 방식인 OAuth 로그인 시 응답을 반환하는 구조에서 서버 단에서 직접 리다이렉트할 수 있도록 수정한다.

- [이슈](https://linear.app/cambodia/issue/CAM-77/oauth-로그인-리다이렉트-지정)

---

### 🚀 주요 변경 내용

* 로그인 후 추가 정보가 필요한 상황(회원가입 X)이라면 `https://konect.kro.kr/signup` 로 리다이렉트 합니다.

* 로그인을 성공(회원가입 O)했다면 `https://konect.kro.kr`로 리다이렉트 합니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
