### PR TITLE
fix: @valid 필드 에러 시 반환하는 대표 메시지 수정

### DIFF
--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -244,14 +244,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         }
     }
 
-    private String getFirstFieldErrorMessage(List<ErrorResponse.FieldError> fields, String defaultMessage) {
-        if (fields.isEmpty()) {
-            return defaultMessage;
-        }
-
-        return fields.get(0).message();
-    }
-
     private List<ErrorResponse.FieldError> getFieldErrors(MethodArgumentNotValidException ex) {
         return ex.getBindingResult()
             .getFieldErrors()


### PR DESCRIPTION
### 🔍 개요

* @valid 필드 에러 시 반환하는 대표 메시지 수정한다.

- [이슈](https://linear.app/cambodia/issue/CAM-81/valid-필드-에러-시-반환하는-대표-에러-메시지-수정)

---

### 🚀 주요 변경 내용

* `@Valid`에서 검증되는 필드 에러 시 반환하는 대표 메시지가 하위 요소인 `fieldErrors`의 첫 번째 에러 메시지를 반환하는 문제가 있어 이를 수정했습니다.

### (수정 전)
<img width="360" height="240" alt="image" src="https://github.com/user-attachments/assets/302ad9d7-27a8-4d84-9cf7-f8110505354f" />

### (수정 후)
<img width="360" height="240" alt="image" src="https://github.com/user-attachments/assets/f130a724-692e-4f8c-92ec-9edd7bd6c7f4" />


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
