### PR TITLE
feat: GET /users/me 응답값 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/notice/repository/CouncilNoticeReadRepository.java
+++ b/src/main/java/gg/agit/konect/domain/notice/repository/CouncilNoticeReadRepository.java
@@ -2,7 +2,9 @@ package gg.agit.konect.domain.notice.repository;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import gg.agit.konect.domain.notice.model.CouncilNoticeReadHistory;
 
@@ -13,4 +15,15 @@ public interface CouncilNoticeReadRepository extends Repository<CouncilNoticeRea
     List<CouncilNoticeReadHistory> findByUserIdAndCouncilNoticeIdIn(Integer userId, List<Integer> councilNoticeIds);
 
     void save(CouncilNoticeReadHistory councilNoticeReadHistory);
+
+    @Query("""
+        SELECT COUNT(cn)
+        FROM CouncilNotice cn
+        WHERE NOT EXISTS (
+                SELECT 1
+                FROM CouncilNoticeReadHistory cnrh
+                WHERE cnrh.councilNotice = cn AND cnrh.user.id = :userId
+                )
+        """)
+    Long countUnreadNoticesByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/gg/agit/konect/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/gg/agit/konect/domain/user/dto/UserInfoResponse.java
@@ -34,16 +34,19 @@ public record UserInfoResponse(
     LocalTime studyTime,
 
     @Schema(description = "읽지 않은 총 동아리 연합회 공지", example = "1", requiredMode = REQUIRED)
-    Integer unreadCouncilNoticeCount
+    Long unreadCouncilNoticeCount
 ) {
 
-    public static UserInfoResponse from(User user) {
+    public static UserInfoResponse from(User user, Integer joinedClubCount, Long unreadCouncilNoticeCount) {
         return new UserInfoResponse(
             user.getName(),
             user.getUniversity().getKoreanName(),
             user.getStudentNumber(),
             user.getPhoneNumber(),
-            user.getImageUrl()
+            user.getImageUrl(),
+            joinedClubCount,
+            LocalTime.of(0, 0, 0),
+            unreadCouncilNoticeCount
         );
     }
 }

--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.notice.repository.CouncilNoticeReadRepository;
 import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.domain.university.repository.UniversityRepository;
 import gg.agit.konect.domain.user.dto.SignupRequest;
@@ -26,6 +28,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final UnRegisteredUserRepository unRegisteredUserRepository;
     private final UniversityRepository universityRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final CouncilNoticeReadRepository councilNoticeReadRepository;
 
     @Transactional
     public Integer signup(String email, Provider provider, SignupRequest request) {
@@ -60,8 +64,10 @@ public class UserService {
 
     public UserInfoResponse getUserInfo(Integer userId) {
         User user = userRepository.getById(userId);
+        int joinedClubCount = clubMemberRepository.findAllByUserId(user.getId()).size();
+        Long unreadCouncilNoticeCount = councilNoticeReadRepository.countUnreadNoticesByUserId(user.getId());
 
-        return UserInfoResponse.from(user);
+        return UserInfoResponse.from(user, joinedClubCount, unreadCouncilNoticeCount);
     }
 
     @Transactional


### PR DESCRIPTION
### 🔍 개요

* 마이 페이지에서 보여줄 필드를 추가합니다.
- [이슈](https://linear.app/cambodia/issue/CAM-111/가입-동아리-and-읽지-않은-공지-조회-api)

---

### 🚀 주요 변경 내용

### GET /users/me 응답값 추가
- 가입 동아리, 순공 시간, 읽지 않은 공지 응답값을 추가했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
