### PR TITLE
fix: 메시지 전송시간 포멧 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessageResponse.java
@@ -19,8 +19,8 @@ public record ChatMessageResponse(
     @Schema(description = "메시지 내용", example = "투명 케이스가 끼워져 있었어요!", requiredMode = REQUIRED)
     String content,
 
-    @Schema(description = "메시지 전송 시간", example = "2025.07.23 15:53", requiredMode = REQUIRED)
-    @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
+    @Schema(description = "메시지 전송 시간", example = "2025.07.23 15:53:12.123", requiredMode = REQUIRED)
+    @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss.SSS")
     LocalDateTime createdAt,
 
     @Schema(description = "읽음 여부", example = "false", requiredMode = REQUIRED)

--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessagesResponse.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessagesResponse.java
@@ -38,8 +38,8 @@ public record ChatMessagesResponse(
         @Schema(description = "메시지 내용", example = "투명 케이스가 끼워져 있었어요!", requiredMode = REQUIRED)
         String content,
 
-        @Schema(description = "메시지 전송 시간", example = "2025.07.23 15:53", requiredMode = REQUIRED)
-        @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
+        @Schema(description = "메시지 전송 시간", example = "2025.07.23 15:53:12.123", requiredMode = REQUIRED)
+        @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss.SSS")
         LocalDateTime createdAt,
 
         @Schema(description = "읽음 여부", example = "false", requiredMode = REQUIRED)


### PR DESCRIPTION
### 🔍 개요

* 채팅 메시지 전송 시간 포멧을 수정한다.
- [이슈](https://linear.app/cambodia/issue/CAM-121/채팅-생성-시간-포멧-수정)

---

### 🚀 주요 변경 내용

#### 채팅 메시지 전송시간 포멧 수정
- 밀리초까지 나오도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
