### PR TITLE
refactor: 로그인한 유저의 대학교 동아리 접근만 가능하도록 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubApi.java
@@ -27,6 +27,7 @@ import jakarta.validation.Valid;
 public interface ClubApi {
 
     @Operation(summary = "페이지 네이션으로 동아리 리스트를 조회한다.", description = """
+        - 로그인한 유저의 대학교에 속한 동아리만 조회합니다.
         - isRecruiting가 true일 경우, 모집일이 빠른 순으로 정렬됩니다.
         - status은 BEFORE(모집 전), ONGOING(모집 중), CLOSED(모집 마감)으로 반환됩니다.
         """)
@@ -35,7 +36,8 @@ public interface ClubApi {
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
         @RequestParam(name = "query", defaultValue = "", required = false) String query,
-        @RequestParam(name = "isRecruiting", defaultValue = "false", required = false) Boolean isRecruiting
+        @RequestParam(name = "isRecruiting", defaultValue = "false", required = false) Boolean isRecruiting,
+        @UserId Integer userId
     );
 
     @Operation(summary = "동아리의 상세 정보를 조회한다.", description = """
@@ -56,7 +58,8 @@ public interface ClubApi {
     @Operation(summary = "동아리 멤버 리스트를 조회한다.")
     @GetMapping("/{clubId}/members")
     ResponseEntity<ClubMembersResponse> getClubMembers(
-        @PathVariable(name = "clubId") Integer clubId
+        @PathVariable(name = "clubId") Integer clubId,
+        @UserId Integer userId
     );
 
     @Operation(summary = "동아리 가입 신청을 한다.", description = """
@@ -90,7 +93,8 @@ public interface ClubApi {
     @Operation(summary = "동아리 가입 문항을 조회한다.")
     @GetMapping("/{clubId}/questions")
     ResponseEntity<ClubApplyQuestionsResponse> getApplyQuestions(
-        @PathVariable(name = "clubId") Integer clubId
+        @PathVariable(name = "clubId") Integer clubId,
+        @UserId Integer userId
     );
 
     @Operation(summary = "동아리 모집 정보를 조회한다.", description = """

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubController.java
@@ -33,9 +33,10 @@ public class ClubController implements ClubApi {
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "10", required = false) Integer limit,
         @RequestParam(name = "query", defaultValue = "", required = false) String query,
-        @RequestParam(name = "isRecruiting", defaultValue = "false", required = false) Boolean isRecruiting
+        @RequestParam(name = "isRecruiting", defaultValue = "false", required = false) Boolean isRecruiting,
+        @UserId Integer userId
     ) {
-        ClubsResponse response = clubService.getClubs(page, limit, query, isRecruiting);
+        ClubsResponse response = clubService.getClubs(page, limit, query, isRecruiting, userId);
         return ResponseEntity.ok(response);
     }
 
@@ -56,9 +57,10 @@ public class ClubController implements ClubApi {
 
     @GetMapping("/{clubId}/members")
     public ResponseEntity<ClubMembersResponse> getClubMembers(
-        @PathVariable(name = "clubId") Integer clubId
+        @PathVariable(name = "clubId") Integer clubId,
+        @UserId Integer userId
     ) {
-        ClubMembersResponse response = clubService.getClubMembers(clubId);
+        ClubMembersResponse response = clubService.getClubMembers(clubId, userId);
         return ResponseEntity.ok(response);
     }
 
@@ -83,9 +85,10 @@ public class ClubController implements ClubApi {
 
     @Override
     public ResponseEntity<ClubApplyQuestionsResponse> getApplyQuestions(
-        @PathVariable(name = "clubId") Integer clubId
+        @PathVariable(name = "clubId") Integer clubId,
+        @UserId Integer userId
     ) {
-        ClubApplyQuestionsResponse response = clubService.getApplyQuestions(clubId);
+        ClubApplyQuestionsResponse response = clubService.getApplyQuestions(clubId, userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubQueryRepository.java
@@ -33,8 +33,13 @@ public class ClubQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public Page<ClubSummaryInfo> findAllByFilter(PageRequest pageable, String query, Boolean isRecruiting) {
-        BooleanBuilder filter = clubSearchFilter(query, isRecruiting);
+    public Page<ClubSummaryInfo> findAllByFilter(
+        PageRequest pageable,
+        Integer universityId,
+        String query,
+        Boolean isRecruiting
+    ) {
+        BooleanBuilder filter = clubSearchFilter(universityId, query, isRecruiting);
         OrderSpecifier<?> sort = clubSort(isRecruiting);
 
         List<Tuple> clubData = fetchClubs(pageable, filter, sort);
@@ -112,8 +117,9 @@ public class ClubQueryRepository {
             .fetchOne();
     }
 
-    private BooleanBuilder clubSearchFilter(String query, Boolean isRecruiting) {
+    private BooleanBuilder clubSearchFilter(Integer universityId, String query, Boolean isRecruiting) {
         BooleanBuilder builder = new BooleanBuilder();
+        builder.and(club.university.id.eq(universityId));
 
         if (!StringUtils.isEmpty(query)) {
             String normalizedQuery = query.trim().toLowerCase();

--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
@@ -12,8 +12,15 @@ public interface ClubRepository extends Repository<Club, Integer> {
 
     Optional<Club> findById(Integer id);
 
+    Optional<Club> findByIdAndUniversityId(Integer id, Integer universityId);
+
     default Club getById(Integer id) {
         return findById(id).orElseThrow(() ->
+            CustomException.of(ApiResponseCode.NOT_FOUND_CLUB));
+    }
+
+    default Club getByIdAndUniversityId(Integer id, Integer universityId) {
+        return findByIdAndUniversityId(id, universityId).orElseThrow(() ->
             CustomException.of(ApiResponseCode.NOT_FOUND_CLUB));
     }
 }

--- a/src/main/java/gg/agit/konect/domain/user/repository/UserRepository.java
+++ b/src/main/java/gg/agit/konect/domain/user/repository/UserRepository.java
@@ -22,6 +22,8 @@ public interface UserRepository extends Repository<User, Integer> {
 
     boolean existsByUniversityIdAndStudentNumberAndIdNot(Integer universityId, String studentNumber, Integer id);
 
+    boolean existsByUniversityIdAndStudentNumber(Integer universityId, String studentNumber);
+
     boolean existsByPhoneNumberAndIdNot(String phoneNumber, Integer id);
 
     User save(User user);


### PR DESCRIPTION
### 🔍 개요

* 

- [이슈](https://linear.app/cambodia/issue/CAM-124/로그인한-유저의-학교-동아리만-접근할-수-있도록-수정)

---

### 🚀 주요 변경 내용

* `ClubServicd`의`getClubForUser()` 메소드를 통해 로그인한 유저의 학교를 조회하고 조회한 학교의 동아리에 대해서만 접근할 수 있도록 제한했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
