### PR TITLE
fix: 유저 이름, 학번 길이 제한 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/user/dto/SignupRequest.java
+++ b/src/main/java/gg/agit/konect/domain/user/dto/SignupRequest.java
@@ -10,7 +10,8 @@ import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
     @NotEmpty(message = "이름은 필수 입력입니다.")
-    @Size(max = 50, message = "이름은 최대 50자 입니다.")
+    @Size(max = 30, message = "이름은 최대 30자 입니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣]+$", message = "이름은 영어와 한글만 입력할 수 있습니다.")
     @Schema(description = "회원 이름", example = "홍길동", requiredMode = REQUIRED)
     String name,
 
@@ -19,8 +20,8 @@ public record SignupRequest(
     Integer universityId,
 
     @NotEmpty(message = "학번은 필수 입력입니다.")
-    @Size(max = 20, message = "학번은 최대 20자 입니다.")
-    @Pattern(regexp = "^\\S+$", message = "학번은 공백을 포함할 수 없습니다.")
+    @Size(min = 4, max = 20, message = "학번은 4자 이상 20자 이하입니다.")
+    @Pattern(regexp = "^[0-9-]+$", message = "학번은 숫자와 -만 입력할 수 있습니다.")
     @Schema(description = "회원 학번", example = "20250001", requiredMode = REQUIRED)
     String studentNumber,
 

--- a/src/main/java/gg/agit/konect/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/gg/agit/konect/domain/user/dto/UserUpdateRequest.java
@@ -11,13 +11,14 @@ import jakarta.validation.constraints.Size;
 
 public record UserUpdateRequest(
     @NotEmpty(message = "이름은 필수 입력입니다.")
-    @Size(max = 50, message = "이름은 최대 50자 입니다.")
+    @Size(max = 30, message = "이름은 최대 30자 입니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣]+$", message = "이름은 영어와 한글만 입력할 수 있습니다.")
     @Schema(description = "회원 이름", example = "이동훈", requiredMode = REQUIRED)
     String name,
 
     @NotEmpty(message = "학번은 필수 입력입니다.")
-    @Size(max = 20, message = "학번은 최대 20자 입니다.")
-    @Pattern(regexp = "^\\S+$", message = "학번은 공백을 포함할 수 없습니다.")
+    @Size(min = 4, max = 20, message = "학번은 4자 이상 20자 이하입니다.")
+    @Pattern(regexp = "^[0-9-]+$", message = "학번은 숫자와 -만 입력할 수 있습니다.")
     @Schema(description = "회원 학번", example = "2021136091", requiredMode = REQUIRED)
     String studentNumber,
 

--- a/src/main/java/gg/agit/konect/domain/user/model/User.java
+++ b/src/main/java/gg/agit/konect/domain/user/model/User.java
@@ -50,7 +50,7 @@ public class User extends BaseEntity {
     @Column(name = "email", length = 100, nullable = false)
     private String email;
 
-    @Column(name = "name", length = 50, nullable = false)
+    @Column(name = "name", length = 30, nullable = false)
     private String name;
 
     @Column(name = "phone_number", length = 20, unique = true)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE users
     id                     INT AUTO_INCREMENT PRIMARY KEY,
     university_id          INT                                 NOT NULL,
     email                  VARCHAR(100)                        NOT NULL,
-    name                   VARCHAR(50)                         NOT NULL,
+    name                   VARCHAR(30)                         NOT NULL,
     phone_number           VARCHAR(20) UNIQUE,
     student_number         VARCHAR(20)                         NOT NULL,
     provider               ENUM('GOOGLE', 'KAKAO', 'NAVER')    NOT NULL,


### PR DESCRIPTION
### 🔍 개요

* 유저의 이름과 학번에 대한 유효성 검증을 수정했습니다.

- [이슈](https://linear.app/cambodia/issue/CAM-125/유저-학번-이름-유효성-검증-수정)

---

### 🚀 주요 변경 내용

* 이름은 영어와 한글만 가능, 글자 수는 최대 30자 이내로 가능합니다.

* 학번은 숫자와 하이픈(-)만 가능하며 4~20자 이내로 가능합니다.


---

### 💬 참고 사항

* QA 끝나고 반영하겠습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
