### PR TITLE
refactor: 공개/차단 경로 상수 분리 및 인터셉터 제외 경로 적용

### DIFF
--- a/src/main/java/gg/agit/konect/global/auth/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/gg/agit/konect/global/auth/interceptor/LoginCheckInterceptor.java
@@ -1,11 +1,7 @@
 package gg.agit.konect.global.auth.interceptor;
 
-import java.util.List;
-
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
-import org.springframework.util.PathMatcher;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -19,28 +15,9 @@ import jakarta.servlet.http.HttpSession;
 @Component
 public class LoginCheckInterceptor implements HandlerInterceptor {
 
-    private static final List<String> PUBLIC_PATHS = List.of(
-        "/oauth2/**",
-        "/login/**",
-        "/swagger-ui/**",
-        "/swagger-ui.html",
-        "/v3/api-docs/**",
-        "/swagger-resources/**",
-        "/error"
-    );
-
-    private final PathMatcher pathMatcher = new AntPathMatcher();
-
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         if (HttpMethod.OPTIONS.matches(request.getMethod())) {
-            return true;
-        }
-
-        String requestUri = request.getRequestURI();
-        boolean isAllowed = PUBLIC_PATHS.stream().anyMatch(pattern -> pathMatcher.match(pattern, requestUri));
-
-        if (isAllowed) {
             return true;
         }
 
@@ -48,22 +25,22 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        if (!isPublicEndpoint(handlerMethod)) {
-            HttpSession session = request.getSession(false);
-            Object userId = session == null ? null : session.getAttribute("userId");
+        if (isPublicEndpoint(handlerMethod)) {
+            return true;
+        }
 
-            if (!(userId instanceof Integer)) {
-                throw CustomException.of(ApiResponseCode.INVALID_SESSION);
-            }
+        HttpSession session = request.getSession(false);
+        Object userId = session == null ? null : session.getAttribute("userId");
+
+        if (!(userId instanceof Integer)) {
+            throw CustomException.of(ApiResponseCode.INVALID_SESSION);
         }
 
         return true;
     }
 
     private boolean isPublicEndpoint(HandlerMethod handlerMethod) {
-        boolean methodPublic = handlerMethod.hasMethodAnnotation(PublicApi.class);
-        boolean controllerPublic = handlerMethod.getBeanType().isAnnotationPresent(PublicApi.class);
-
-        return methodPublic || controllerPublic;
+        return handlerMethod.hasMethodAnnotation(PublicApi.class)
+            || handlerMethod.getBeanType().isAnnotationPresent(PublicApi.class);
     }
 }

--- a/src/main/java/gg/agit/konect/global/config/SecurityConfig.java
+++ b/src/main/java/gg/agit/konect/global/config/SecurityConfig.java
@@ -28,22 +28,27 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        // TODO 테스트 이후 접근 가능 경로 막아두기
         http
             .csrf(AbstractHttpConfigurer::disable)
             .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(SecurityPaths.DENY_PATHS).denyAll()
+                .requestMatchers(SecurityPaths.PUBLIC_PATHS).permitAll()
+                .anyRequest().permitAll()
+            )
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint((request, response, authException) -> {
                     response.sendError(UNAUTHORIZED.value());
                 })
-            ).oauth2Login(oauth2 -> oauth2
+            )
+            .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo
                     .userService(userRequest -> {
                         String registrationId = userRequest.getClientRegistration().getRegistrationId();
                         return oAuthServices.get(registrationId).loadUser(userRequest);
                     })
-                ).successHandler(oAuth2LoginSuccessHandler)
+                )
+                .successHandler(oAuth2LoginSuccessHandler)
             );
 
         return http.build();

--- a/src/main/java/gg/agit/konect/global/config/SecurityPaths.java
+++ b/src/main/java/gg/agit/konect/global/config/SecurityPaths.java
@@ -1,0 +1,19 @@
+package gg.agit.konect.global.config;
+
+public final class SecurityPaths {
+
+    public static final String[] PUBLIC_PATHS = {
+        "/oauth2/**",
+        "/login/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/v3/api-docs/**",
+        "/swagger-resources/**",
+        "/error"
+    };
+
+    public static final String[] DENY_PATHS = {};
+
+    private SecurityPaths() {
+    }
+}

--- a/src/main/java/gg/agit/konect/global/config/WebConfig.java
+++ b/src/main/java/gg/agit/konect/global/config/WebConfig.java
@@ -40,6 +40,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginCheckInterceptor)
-            .addPathPatterns("/**");
+            .addPathPatterns("/**")
+            .excludePathPatterns(SecurityPaths.PUBLIC_PATHS);
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 

- [이슈](https://linear.app/cambodia/issue/CAM-132/인증인가-정책-코드-정리)

---

### 🚀 주요 변경 내용

* 기존에는 가능 경로를 인터셉터에서 관리했으나, 이를 분리하여 `SecurityPaths`에서 관리하도록 했습니다.
  * 추후에는 `yml`에 분리하지 않을까 싶습니다.

* `@PublicApi`에 대한 처리는 인터셉터, `SecurityConfig`에서 경로를 지정한다면 필터에서 처리되므로 아래와 같이 코드를 수정했으며 공개 경로(스웨거, 헬스 체크 등)에 대해서는 인터셉터를 거치지 않도록 했습니다.
```
authorizeHttpRequests(auth -> auth
    .requestMatchers(SecurityPaths.DENY_PATHS).denyAll()
    .requestMatchers(SecurityPaths.PUBLIC_PATHS).permitAll()
    .anyRequest().permitAll()
)
```
```
public void addInterceptors(InterceptorRegistry registry) {
        registry.addInterceptor(loginCheckInterceptor)
            .addPathPatterns("/**")
            .excludePathPatterns(SecurityPaths.PUBLIC_PATHS);
    }
```
---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
