### PR TITLE
feat: 학번 공부 시간 랭킹 업데이트 스케쥴링 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/studytime/scheduler/StudyTimeScheduler.java
+++ b/src/main/java/gg/agit/konect/domain/studytime/scheduler/StudyTimeScheduler.java
@@ -33,4 +33,13 @@ public class StudyTimeScheduler {
             log.error("개인 공부 시간 랭킹 업데이트 과정에서 오류가 발생했습니다.", e);
         }
     }
+
+    @Scheduled(fixedDelay = 5, timeUnit = MINUTES)
+    public void studentNumberStudyTimeRankingUpdate() {
+        try {
+            studyTimeSchedulerService.updateStudentNumberStudyTimeRanking();
+        } catch (Exception e) {
+            log.error("학번별 공부 시간 랭킹 업데이트 과정에서 오류가 발생했습니다.", e);
+        }
+    }
 }

--- a/src/main/java/gg/agit/konect/domain/user/repository/UserRepository.java
+++ b/src/main/java/gg/agit/konect/domain/user/repository/UserRepository.java
@@ -1,8 +1,11 @@
 package gg.agit.konect.domain.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 
 import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
@@ -23,6 +26,17 @@ public interface UserRepository extends Repository<User, Integer> {
     boolean existsByUniversityIdAndStudentNumberAndIdNot(Integer universityId, String studentNumber, Integer id);
 
     boolean existsByUniversityIdAndStudentNumber(Integer universityId, String studentNumber);
+
+    @Query("""
+        SELECT u
+        FROM User u
+        WHERE u.university.id = :universityId
+        AND u.studentNumber LIKE CONCAT(:year, '%')
+        """)
+    List<User> findUserIdsByUniversityAndStudentYear(
+        @Param("universityId") Integer universityId,
+        @Param("year") String year
+    );
 
     boolean existsByPhoneNumberAndIdNot(String phoneNumber, Integer id);
 


### PR DESCRIPTION
### 🔍 개요

* 학번 공부 시간 랭킹 업데이트 스케줄러를 추가합니다.
- [이슈](https://linear.app/cambodia/issue/CAM-153/학번-순공-시간-스케쥴링-작업)

---

### 🚀 주요 변경 내용
#### 학번 공부 시간 랭킹 업데이트 스케줄러 추가
- 5분에 한 번씩 스케줄러가 돕니다.
- `랭킹에 등록된 (대학, 입학년도) 조합 조회 -> 각 조합별 학생 조회 -> 학생들의 공부시간(일간, 월간) 조회 -> 조합별 합산 -> 학번 랭킹 업데이트` 플로우로 진행됩니다.

---

### 💬 참고 사항

* 코드 정리는 내일 진행하겠습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
