### PR TITLE
fix: 동아리 한 줄 소개 컬럼 20자 제한으로 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubCreateRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubCreateRequest.java
@@ -17,7 +17,7 @@ public record ClubCreateRequest(
     @Schema(description = "동아리 한 줄 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
         requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "동아리 소개는 필수 입력입니다.")
-    @Size(max = 100, message = "동아리 소개는 100자 이하여야 합니다.")
+    @Size(max = 20, message = "동아리 소개는 20자 이하여야 합니다.")
     String description,
 
     @Schema(description = "동아리 상세 소개", example = "BCSD에서 얻을 수 있는 경험\n1. IT 실무 경험",

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubUpdateRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubUpdateRequest.java
@@ -15,7 +15,7 @@ public record ClubUpdateRequest(
     @Schema(description = "동아리 한 줄 소개", example = "즐겁게 일하고 열심히 노는 IT 특성화 동아리",
         requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "동아리 소개는 필수 입력입니다.")
-    @Size(max = 100, message = "동아리 소개는 100자 이하여야 합니다.")
+    @Size(max = 20, message = "동아리 소개는 20자 이하여야 합니다.")
     String description,
 
     @Schema(description = "동아리 로고 이미지 URL", example = "https://example.com/logo.png",

--- a/src/main/java/gg/agit/konect/domain/club/model/Club.java
+++ b/src/main/java/gg/agit/konect/domain/club/model/Club.java
@@ -53,7 +53,7 @@ public class Club extends BaseEntity {
     @Column(name = "name", length = 50, nullable = false)
     private String name;
 
-    @Column(name = "description", length = 100, nullable = false)
+    @Column(name = "description", length = 20, nullable = false)
     private String description;
 
     @Column(name = "introduce", columnDefinition = "TEXT", nullable = false)

--- a/src/main/resources/db/migration/V13__alter_club_description_column.sql
+++ b/src/main/resources/db/migration/V13__alter_club_description_column.sql
@@ -1,0 +1,6 @@
+UPDATE club
+SET description = LEFT(description, 30)
+WHERE CHAR_LENGTH(description) > 30;
+
+ALTER TABLE club
+    MODIFY description VARCHAR(30) NOT NULL;


### PR DESCRIPTION
### 🔍 개요

* 

- [이슈](https://linear.app/cambodia/issue/CAM-178/동아리-한-줄-소개-문자수-100-20자-제한)

---

### 🚀 주요 변경 내용

* 동아리 한 줄 소개를 100자에서 20자로 제한했습니다


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
