### PR TITLE
fix: 순공 시간 랭킹 스케줄러 주기 단축

### DIFF
--- a/src/main/java/gg/agit/konect/domain/studytime/scheduler/StudyTimeScheduler.java
+++ b/src/main/java/gg/agit/konect/domain/studytime/scheduler/StudyTimeScheduler.java
@@ -1,6 +1,6 @@
 package gg.agit.konect.domain.studytime.scheduler;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,7 +16,7 @@ public class StudyTimeScheduler {
 
     private final StudyTimeSchedulerService studyTimeSchedulerService;
 
-    @Scheduled(fixedDelay = 5, timeUnit = MINUTES)
+    @Scheduled(fixedDelay = 5, timeUnit = SECONDS)
     public void updateClubStudyTimeRanking() {
         try {
             log.info("동아리 공부 시간 랭킹 업데이트 시작");
@@ -27,7 +27,7 @@ public class StudyTimeScheduler {
         }
     }
 
-    @Scheduled(fixedDelay = 5, timeUnit = MINUTES)
+    @Scheduled(fixedDelay = 5, timeUnit = SECONDS)
     public void updatePersonalStudyTimeRanking() {
         try {
             log.info("개인 공부 시간 랭킹 업데이트 시작");
@@ -38,7 +38,7 @@ public class StudyTimeScheduler {
         }
     }
 
-    @Scheduled(fixedDelay = 5, timeUnit = MINUTES)
+    @Scheduled(fixedDelay = 5, timeUnit = SECONDS)
     public void updateStudentNumberStudyTimeRanking() {
         try {
             log.info("학번별 공부 시간 랭킹 업데이트 시작");


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 스케줄러 주기를 5분 -> 5초로 단축했습니다.

* 추후에 여유 생기면 더미 데이터를 충분히 넣은 상태에서 성능 테스트를 해봐야 할 것 같습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
