### PR TITLE
fix: 동아리 목록 조회 시 모집 중인 곳을 먼저 보여주도록 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubApi.java
@@ -48,7 +48,8 @@ import jakarta.validation.Valid;
 public interface ClubApi {
 
     @Operation(summary = "페이지 네이션으로 동아리 리스트를 조회한다.", description = """
-        - isRecruiting가 true일 경우, 모집일이 빠른 순으로 정렬됩니다.
+        - isRecruiting가 true일 경우, 모집 중인 동아리만 조회하며 모집일(마감일)이 빠른 순으로 정렬됩니다.
+        - isRecruiting가 false일 경우, 전체 동아리를 조회하되 모집 중인 동아리를 먼저 보여줍니다.
         - status은 BEFORE(모집 전), ONGOING(모집 중), CLOSED(모집 마감)으로 반환됩니다.
         """)
     @GetMapping


### PR DESCRIPTION
### 🔍 개요

* 

- [이슈](https://linear.app/cambodia/issue/CAM-186/동아리-목록-조회-시-모집-중인-곳-먼저-나오도록-수정)

---

### 🚀 주요 변경 내용

* `GET /clubs` 에서 쿼리 파라미터인 `isRecruiting`이 `false`인 경우 모집 중인 동아리를 우선적으로 정렬하여 조회할 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
