### PR TITLE
refactor: 채팅 전송 시 현재 시간 보다 늦은 시간으로 기록되는 문제 수정

### DIFF
--- a/src/main/java/gg/agit/konect/KonectApplication.java
+++ b/src/main/java/gg/agit/konect/KonectApplication.java
@@ -8,8 +8,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-import jakarta.annotation.PostConstruct;
-
 @EnableAsync
 @EnableRetry
 @SpringBootApplication
@@ -17,11 +15,7 @@ import jakarta.annotation.PostConstruct;
 public class KonectApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(KonectApplication.class, args);
-    }
-
-    @PostConstruct
-    public void init() {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        SpringApplication.run(KonectApplication.class, args);
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 채팅 전송 시 현재 시간보다 늦은 시간으로 전송 시간이 기록되는 문제를 해결했습니다.

- close #이슈번호

---

### 🚀 주요 변경 내용

* 기존에 채팅을 전송하면 원래 시간보다 9시간 늦은 시간으로 전송 시간이 기록 됐었는데, 이것을 현재 시간으로 올바르게 기록될 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
