### PR TITLE
refactor: 채팅 알림 뮤트 기능 1대1 채팅에서도 적용

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/unified/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/unified/controller/ChatApi.java
@@ -104,10 +104,11 @@ public interface ChatApi {
         @UserId Integer userId
     );
 
-    @Operation(summary = "단체 채팅 알림 음소거를 토글한다.")
-    @PostMapping("/groups/{clubId}/mute")
+    @Operation(summary = "채팅 알림 기능 유무를 토글한다.")
+    @PostMapping("rooms/{chatRoomId}/mute")
     ResponseEntity<GroupChatMuteResponse> toggleGroupChatMute(
-        @PathVariable(value = "clubId") Integer clubId,
+        @RequestParam(name = "type") ChatType type,
+        @PathVariable(value = "chatRoomId") Integer chatRoomId,
         @UserId Integer userId
     );
 }

--- a/src/main/java/gg/agit/konect/domain/chat/unified/controller/ChatController.java
+++ b/src/main/java/gg/agit/konect/domain/chat/unified/controller/ChatController.java
@@ -73,11 +73,11 @@ public class ChatController implements ChatApi {
 
     @Override
     public ResponseEntity<GroupChatMuteResponse> toggleGroupChatMute(
-        @PathVariable(value = "clubId") Integer clubId,
+        @RequestParam(name = "type") ChatType type,
+        @PathVariable(value = "chatRoomId") Integer chatRoomId,
         @UserId Integer userId
     ) {
-        Boolean isMuted = groupChatService.toggleMute(clubId, userId);
+        Boolean isMuted = groupChatService.toggleMute(userId, type, chatRoomId);
         return ResponseEntity.ok(new GroupChatMuteResponse(isMuted));
     }
-
 }

--- a/src/main/java/gg/agit/konect/domain/notification/enums/NotificationTargetType.java
+++ b/src/main/java/gg/agit/konect/domain/notification/enums/NotificationTargetType.java
@@ -1,5 +1,6 @@
 package gg.agit.konect.domain.notification.enums;
 
 public enum NotificationTargetType {
+    DIRECT_CHAT_ROOM,
     GROUP_CHAT_ROOM
 }


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 기존에는 단체 채팅에서만 알림 뮤트 기능이 있었으나 1대1 채팅에서도 뮤트할 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
