### PR TITLE
refactor: 모든 사용자가 동아리 회비 정보에 접근할 수 있도록 변경

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationApi.java
@@ -18,6 +18,7 @@ import gg.agit.konect.domain.club.dto.ClubApplyQuestionsResponse;
 import gg.agit.konect.domain.club.dto.ClubApplyRequest;
 import gg.agit.konect.domain.club.dto.ClubFeeInfoReplaceRequest;
 import gg.agit.konect.domain.club.dto.ClubFeeInfoResponse;
+import gg.agit.konect.global.auth.annotation.PublicApi;
 import gg.agit.konect.global.auth.annotation.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -144,17 +145,15 @@ public interface ClubApplicationApi {
     );
 
     @Operation(summary = "동아리 회비 정보를 조회한다.", description = """
-        동아리 가입 신청을 완료했거나 동아리 관리자 권한이 있는 사용자만 회비 계좌 정보를 조회할 수 있습니다.
-        
+        동아리의 회비 계좌 정보를 조회합니다.
+
         ## 에러
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
-        - NOT_FOUND_USER (404): 유저를 찾을 수 없습니다.
-        - FORBIDDEN_CLUB_FEE_INFO (403): 회비 정보 조회 권한이 없습니다.
         """)
+    @PublicApi
     @GetMapping("/{clubId}/fee")
     ResponseEntity<ClubFeeInfoResponse> getFeeInfo(
-        @PathVariable(name = "clubId") Integer clubId,
-        @UserId Integer userId
+        @PathVariable(name = "clubId") Integer clubId
     );
 
     @Operation(summary = "동아리 회비 정보를 덮어써서 대체한다.", description = """

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationController.java
@@ -103,10 +103,9 @@ public class ClubApplicationController implements ClubApplicationApi {
 
     @Override
     public ResponseEntity<ClubFeeInfoResponse> getFeeInfo(
-        @PathVariable(name = "clubId") Integer clubId,
-        @UserId Integer userId
+        @PathVariable(name = "clubId") Integer clubId
     ) {
-        ClubFeeInfoResponse response = clubApplicationService.getFeeInfo(clubId, userId);
+        ClubFeeInfoResponse response = clubApplicationService.getFeeInfo(clubId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
@@ -1,6 +1,5 @@
 package gg.agit.konect.domain.club.service;
 
-import static gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS;
 import static gg.agit.konect.domain.club.enums.ClubPosition.MEMBER;
 import static gg.agit.konect.global.code.ApiResponseCode.*;
 
@@ -297,23 +296,8 @@ public class ClubApplicationService {
         );
     }
 
-    public ClubFeeInfoResponse getFeeInfo(Integer clubId, Integer userId) {
+    public ClubFeeInfoResponse getFeeInfo(Integer clubId) {
         Club club = clubRepository.getById(clubId);
-        User user = userRepository.getById(userId);
-
-        if (!user.isAdmin()) {
-            boolean isApplied = clubApplyRepository.existsByClubIdAndUserId(clubId, userId);
-            boolean isManager = clubMemberRepository.existsByClubIdAndUserIdAndPositionIn(
-                clubId,
-                userId,
-                MANAGERS
-            );
-
-            if (!isApplied && !isManager) {
-                throw CustomException.of(FORBIDDEN_CLUB_FEE_INFO);
-            }
-        }
-
         return ClubFeeInfoResponse.from(club);
     }
 


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 기존에는 가입 완료한사람 & 관리자만 동아리 회비 정보에 접근할 수 있었는데, 관련 검증 로직을 제거하여 모든 사용자가 회비 정보에 접근할 수 있도록 변경하였습니다.  


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
