### PR TITLE
fix: 사전등록 회장 가입 시 기존 어드민 회장 멤버십 교체 처리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberApi.java
@@ -82,7 +82,8 @@ public interface ClubMemberApi {
     @Operation(summary = "서비스 미가입 회원을 동아리에 사전 등록한다.", description = """
         동아리 회장 또는 부회장만 미가입 회원을 사전 등록할 수 있습니다.
         서비스에 아직 가입하지 않은 학생을 학번과 이름으로 동아리에 미리 등록합니다.
-        사전 등록된 회원이 서비스에 가입하면 자동으로 동아리 일반회원(MEMBER)으로 전환됩니다.
+        사전 등록된 회원이 서비스에 가입하면 사전 등록한 직책(clubPosition)으로 자동 전환됩니다.
+        clubPosition이 PRESIDENT인 경우, 기존 회장 회원 정보는 제거되고 새 가입자가 회장으로 등록됩니다.
 
         ## 에러
         - ALREADY_CLUB_PRE_MEMBER (409): 이미 동아리에 사전 등록된 회원입니다.

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberAddRequest.java
@@ -1,7 +1,9 @@
 package gg.agit.konect.domain.club.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 
+import gg.agit.konect.domain.club.enums.ClubPosition;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
@@ -12,6 +14,9 @@ public record ClubPreMemberAddRequest(
 
     @NotBlank(message = "이름은 필수 입력입니다.")
     @Schema(description = "사전 등록할 회원의 이름", example = "홍길동", requiredMode = REQUIRED)
-    String name
+    String name,
+
+    @Schema(description = "사전 등록 회원의 가입 직책 (미입력 시 MEMBER)", example = "MEMBER", requiredMode = NOT_REQUIRED)
+    ClubPosition clubPosition
 ) {
 }

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberAddResponse.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberAddResponse.java
@@ -2,6 +2,7 @@ package gg.agit.konect.domain.club.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
+import gg.agit.konect.domain.club.enums.ClubPosition;
 import gg.agit.konect.domain.club.model.ClubPreMember;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -13,13 +14,17 @@ public record ClubPreMemberAddResponse(
     String studentNumber,
 
     @Schema(description = "이름", example = "홍길동", requiredMode = REQUIRED)
-    String name
+    String name,
+
+    @Schema(description = "가입 직책", example = "MEMBER", requiredMode = REQUIRED)
+    ClubPosition clubPosition
 ) {
     public static ClubPreMemberAddResponse from(ClubPreMember preMember) {
         return new ClubPreMemberAddResponse(
             preMember.getClub().getId(),
             preMember.getStudentNumber(),
-            preMember.getName()
+            preMember.getName(),
+            preMember.getClubPosition()
         );
     }
 }

--- a/src/main/java/gg/agit/konect/domain/club/model/ClubPreMember.java
+++ b/src/main/java/gg/agit/konect/domain/club/model/ClubPreMember.java
@@ -1,12 +1,15 @@
 package gg.agit.konect.domain.club.model;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import gg.agit.konect.domain.club.enums.ClubPosition;
 import gg.agit.konect.global.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -51,11 +54,17 @@ public class ClubPreMember extends BaseEntity {
     @Column(name = "name", length = 30, nullable = false)
     private String name;
 
+    @NotNull
+    @Enumerated(STRING)
+    @Column(name = "club_position", length = 20, nullable = false)
+    private ClubPosition clubPosition;
+
     @Builder
-    private ClubPreMember(Integer id, Club club, String studentNumber, String name) {
+    private ClubPreMember(Integer id, Club club, String studentNumber, String name, ClubPosition clubPosition) {
         this.id = id;
         this.club = club;
         this.studentNumber = studentNumber;
         this.name = name;
+        this.clubPosition = clubPosition;
     }
 }

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -82,6 +82,7 @@ public class ClubMemberManagementService {
 
         String studentNumber = request.studentNumber();
         String name = request.name();
+        ClubPosition clubPosition = request.clubPosition() == null ? MEMBER : request.clubPosition();
 
         if (clubPreMemberRepository.existsByClubIdAndStudentNumberAndName(clubId, studentNumber, name)) {
             throw CustomException.of(ALREADY_CLUB_PRE_MEMBER);
@@ -91,6 +92,7 @@ public class ClubMemberManagementService {
             .club(club)
             .studentNumber(studentNumber)
             .name(name)
+            .clubPosition(clubPosition)
             .build();
 
         ClubPreMember savedPreMember = clubPreMemberRepository.save(preMember);

--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -1,6 +1,6 @@
 package gg.agit.konect.domain.user.service;
 
-import static gg.agit.konect.domain.club.enums.ClubPosition.MEMBER;
+import static gg.agit.konect.domain.club.enums.ClubPosition.PRESIDENT;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_DELETE_CLUB_PRESIDENT;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_DELETE_USER_WITH_UNPAID_FEE;
 
@@ -148,10 +148,14 @@ public class UserService {
         }
 
         for (ClubPreMember preMember : preMembers) {
+            if (preMember.getClubPosition() == PRESIDENT) {
+                replaceCurrentPresident(preMember.getClub().getId(), user.getId());
+            }
+
             ClubMember clubMember = ClubMember.builder()
                 .club(preMember.getClub())
                 .user(user)
-                .clubPosition(MEMBER)
+                .clubPosition(preMember.getClubPosition())
                 .isFeePaid(false)
                 .build();
 
@@ -159,6 +163,12 @@ public class UserService {
         }
 
         clubPreMemberRepository.deleteAll(preMembers);
+    }
+
+    private void replaceCurrentPresident(Integer clubId, Integer newPresidentUserId) {
+        clubMemberRepository.findPresidentByClubId(clubId)
+            .filter(currentPresident -> !currentPresident.getId().getUserId().equals(newPresidentUserId))
+            .ifPresent(clubMemberRepository::delete);
     }
 
     public UserInfoResponse getUserInfo(Integer userId) {

--- a/src/main/resources/db/migration/V22__add_club_position_to_club_pre_member.sql
+++ b/src/main/resources/db/migration/V22__add_club_position_to_club_pre_member.sql
@@ -1,0 +1,2 @@
+ALTER TABLE club_pre_member
+    ADD COLUMN club_position VARCHAR(20) NOT NULL DEFAULT 'MEMBER' AFTER name;


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 기존에 `club_pre_member`는 일반 멤버에 대해서만 사전 처리를 했으나, 현재는 회장에 대해서도 처리할 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
