### PR TITLE
fix: 리프레시 토큰 서버에서 관리하지 않도록 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/user/controller/UserController.java
+++ b/src/main/java/gg/agit/konect/domain/user/controller/UserController.java
@@ -25,9 +25,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/users")
 public class UserController implements UserApi {
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
-
     private final UserService userService;
     private final SignupTokenService signupTokenService;
     private final JwtProvider jwtProvider;
@@ -67,9 +64,6 @@ public class UserController implements UserApi {
     @Override
     @PublicApi
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = authCookieService.getCookieValue(request, AuthCookieService.REFRESH_TOKEN_COOKIE);
-        refreshTokenService.revoke(refreshToken);
-
         authCookieService.clearRefreshToken(request, response);
         authCookieService.clearSignupToken(request, response);
 
@@ -86,14 +80,6 @@ public class UserController implements UserApi {
         authCookieService.setRefreshToken(request, response, rotated.refreshToken(), refreshTokenService.refreshTtl());
 
         return ResponseEntity.ok(new UserAccessTokenResponse(accessToken));
-    }
-
-    private String resolveBearerToken(HttpServletRequest request) {
-        String authorization = request.getHeader(AUTHORIZATION_HEADER);
-        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
-            return null;
-        }
-        return authorization.substring(BEARER_PREFIX.length());
     }
 
     @Override


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 리프레시 토큰을 레디스에서 관리하지 않고 클라이언트의 쿠키에만 관리하도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
