### PR TITLE
fix: 단체 채팅 메시지 조회 시 동아리 가입 시점 이후가 아닌 모든 메시지 조회 가능하도록 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/group/repository/GroupChatMessageRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/group/repository/GroupChatMessageRepository.java
@@ -1,6 +1,5 @@
 package gg.agit.konect.domain.chat.group.repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,12 +22,10 @@ public interface GroupChatMessageRepository extends Repository<GroupChatMessage,
         FROM GroupChatMessage m
         JOIN FETCH m.sender
         WHERE m.room.id = :roomId
-        AND m.createdAt >= :joinedAt
         ORDER BY m.createdAt DESC
         """)
-    Page<GroupChatMessage> findByRoomIdAndCreatedAtGreaterThanEqualOrderByCreatedAtDesc(
+    Page<GroupChatMessage> findByRoomIdOrderByCreatedAtDesc(
         @Param("roomId") Integer roomId,
-        @Param("joinedAt") LocalDateTime joinedAt,
         Pageable pageable
     );
 
@@ -36,12 +33,8 @@ public interface GroupChatMessageRepository extends Repository<GroupChatMessage,
         SELECT COUNT(m)
         FROM GroupChatMessage m
         WHERE m.room.id = :roomId
-        AND m.createdAt >= :joinedAt
         """)
-    long countByRoomIdAndCreatedAtGreaterThanEqual(
-        @Param("roomId") Integer roomId,
-        @Param("joinedAt") LocalDateTime joinedAt
-    );
+    long countByRoomId(@Param("roomId") Integer roomId);
 
     @Query("""
         SELECT m

--- a/src/main/java/gg/agit/konect/domain/chat/group/service/GroupChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/group/service/GroupChatService.java
@@ -90,7 +90,6 @@ public class GroupChatService {
         validateClubMember(clubId, userId);
 
         GroupChatRoom room = groupChatRoomRepository.getByClubId(clubId);
-        LocalDateTime joinedAt = clubMemberRepository.getJoinedAtByClubIdAndUserId(clubId, userId);
         Integer roomId = room.getId();
 
         chatPresenceService.recordPresence(roomId, userId);
@@ -98,9 +97,9 @@ public class GroupChatService {
         updateLastReadAt(roomId, userId, LocalDateTime.now());
 
         PageRequest pageable = PageRequest.of(page - 1, limit);
-        long totalCount = groupChatMessageRepository.countByRoomIdAndCreatedAtGreaterThanEqual(roomId, joinedAt);
+        long totalCount = groupChatMessageRepository.countByRoomId(roomId);
         Page<GroupChatMessage> messagePage = groupChatMessageRepository
-            .findByRoomIdAndCreatedAtGreaterThanEqualOrderByCreatedAtDesc(roomId, joinedAt, pageable);
+            .findByRoomIdOrderByCreatedAtDesc(roomId, pageable);
         List<GroupChatMessage> messages = messagePage.getContent();
 
         List<ClubMember> members = clubMemberRepository.findAllByClubId(clubId);

--- a/src/main/java/gg/agit/konect/domain/chat/unified/controller/ChatController.java
+++ b/src/main/java/gg/agit/konect/domain/chat/unified/controller/ChatController.java
@@ -52,7 +52,7 @@ public class ChatController implements ChatApi {
     public ResponseEntity<UnifiedChatMessagesResponse> getChatRoomMessages(
         @RequestParam(name = "type") ChatType type,
         @RequestParam(name = "page", defaultValue = "1") Integer page,
-        @RequestParam(name = "limit", defaultValue = "20", required = false) Integer limit,
+        @RequestParam(name = "limit", defaultValue = "30", required = false) Integer limit,
         @PathVariable(value = "chatRoomId") Integer chatRoomId,
         @UserId Integer userId
     ) {


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
