### PR TITLE
fix: pre-member 등록 시 학번, 이름 제약 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberAddRequest.java
@@ -17,7 +17,7 @@ public record ClubPreMemberAddRequest(
     String studentNumber,
 
     @NotEmpty(message = "이름은 필수 입력입니다.")
-    @Size(min = 2, max = 5, message = "이름은 2자 이상 5자 이하 입니다.")
+    @Size(min = 2, max = 5, message = "이름은 2자 이상 5자 이하입니다.")
     @Pattern(regexp = "^[가-힣]+$", message = "이름은 완성된 한글만 입력할 수 있습니다.")
     @Schema(description = "사전 등록할 회원 이름", example = "홍길동", requiredMode = REQUIRED)
     String name,


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Revised validation rules for club pre-member requests. Student ID numbers must now contain only numeric characters and be between 4-20 characters in length. Member names must consist exclusively of Korean characters and be between 2-5 characters in length. These validation changes apply to all pre-member addition operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->