### PR TITLE
fix: 채팅 메시지 발송 시 유저 지연 로딩으로 인한 문제 해결

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
@@ -41,6 +41,7 @@ public interface ChatRoomMemberRepository extends Repository<ChatRoomMember, Cha
     @Query("""
         SELECT crm
         FROM ChatRoomMember crm
+        JOIN FETCH crm.user
         WHERE crm.id.chatRoomId = :chatRoomId
         """)
     List<ChatRoomMember> findByChatRoomId(@Param("chatRoomId") Integer chatRoomId);


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* `sendDirectMessage`에서 `findByChatRoomId`를 통해 유저를 지연 로딩으로 불러옵니다.

* 그러나 `@Modifying(clearAutomatically = true)`로 지연 로딩된 유저를 불러와 쿼리를 전송하면서 에러가 발생

* 이를 해결하기 위해 `FETCH JOIN`을 사용


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database query performance for chat room member operations to reduce unnecessary data fetching overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->