### PR TITLE
fix: 어드민 채팅방 관련 버그(다른 어드민 메시지 안 보임, 채팅방 리스트 조회 불가) 수정 

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.user.enums.UserRole;
 
 public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
 
@@ -72,15 +73,15 @@ public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
               SELECT 1 FROM ChatRoomMember adminMember
               JOIN adminMember.user adminUser
               WHERE adminMember.id.chatRoomId = cr.id
-                AND adminUser.role = 'ADMIN'
+                AND adminUser.role = :adminRole
           )
           AND EXISTS (
               SELECT 1 FROM ChatRoomMember userMember
               JOIN userMember.user normalUser
               WHERE userMember.id.chatRoomId = cr.id
-                AND normalUser.role != 'ADMIN'
+                AND normalUser.role != :adminRole
           )
         ORDER BY cr.lastMessageSentAt DESC NULLS LAST, cr.id
         """)
-    List<ChatRoom> findAllAdminUserDirectRooms();
+    List<ChatRoom> findAllAdminUserDirectRooms(@Param("adminRole") UserRole adminRole);
 }

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -233,7 +233,7 @@ public class ChatService {
     private List<ChatRoomSummaryResponse> getAdminDirectChatRooms() {
         List<ChatRoomSummaryResponse> roomSummaries = new ArrayList<>();
 
-        List<ChatRoom> adminUserRooms = chatRoomRepository.findAllAdminUserDirectRooms();
+        List<ChatRoom> adminUserRooms = chatRoomRepository.findAllAdminUserDirectRooms(UserRole.ADMIN);
         Map<Integer, List<ChatRoomMember>> roomMembersMap = getRoomMembersMap(adminUserRooms);
         Map<Integer, Integer> adminUnreadCountMap = getAdminUnreadCountMap(extractChatRoomIds(adminUserRooms));
 


### PR DESCRIPTION
### 🔍 개요

* 어드민 채팅방 관련 버그를 수정했습니다.
* 어드민 채팅방 리스트 조회 불가
* 다른 어드민이 작성한 채팅 메시지 조회 불가

- close #이슈번호

---

### 🚀 주요 변경 내용

* 기존 로직은 본인이 멤버로 등록되어 있는 채팅방만 조회하도록 되어있어서, 다른 어드민이 대화한 채팅방은 조회할 수 없다는 문제가 있었습니다. 때문에 어드민이 채팅방 멤버로 포함되어 있기만 한다면 해당 채팅방을 모두 조회할 수 있도록 수정했습니다.
* 다른 어드민이 작성한 채팅 메시지를 조회할 수 없었던 문제와 같은 경우에는, 이 문제 또한 해당 채팅방 멤버일 경우에만 메시지들을 조회할 수 있도록 되어있기 때문에, 이를 채팅방 멤버가 아니더라도 다른 어드민의 메시지들을 조회할 수 있도록 수정했습니다. 또한 처음 접근하는 어드민 채팅방일 경우 자동으로 해당 채팅방의 멤버로 추가될 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Admins get improved discovery of admin–user direct chats and can be auto-joined into mixed admin/user rooms.
  * Direct chat summaries now show more accurate partner names, avatars and unread counts.
  * Direct chat lists are better organized and consistently sorted for timely message visibility.
  * Access control for direct chats tightened to ensure correct admin participation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->