### PR TITLE
fix: 세션 쿠키 도메인 플레이스 홀더 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ server:
   servlet:
     session:
       cookie:
-        domain: agit.gg
+        domain: ${SESSION_COOKIE_DOMAIN}
         same-site: none
         secure: true
         http-only: true


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 로컬 환경에서도 세션 도메인이 실 서비스 도메인으로 지정되어 있기에 플레이스 홀더로 뺐습니다.

* 로컬에서는 `SESSION_COOKIE_DOMAIN` 값을 `localhost` 로 작성하시면 됩니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Session cookie domain configuration is now customizable through environment variables at runtime instead of a hard-coded value, enabling seamless deployment across multiple environments without requiring code modifications between deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->