### PR TITLE
feat: 배포 전 stage/prod DB 자동 백업 단계 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -68,6 +68,54 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Backup prod database before deploy
+        uses: appleboy/ssh-action@v0.1.8
+        with:
+          host: ${{ secrets.PROD_SERVER_IP }}
+          username: ${{ secrets.PROD_SERVER_USER }}
+          key: ${{ secrets.PROD_SERVER_SSH_KEY }}
+          port: ${{ secrets.PROD_SERVER_PORT }}
+          script: |
+            set -euo pipefail
+  
+            cd "${{ secrets.PROD_WORK_DIR }}"
+            
+            set -a
+            source .env
+            set +a
+            
+            BACKUP_DIR="${PWD}/dumps"
+            TS="$(date '+%Y%m%d_%H%M%S')"
+            DUMP_FILE="${BACKUP_DIR}/${TS}.sql"
+            
+            mkdir -p "${BACKUP_DIR}"
+            
+            # n일 지난 백업 정리 (원하면 주석 해제)
+            find "${BACKUP_DIR}" -type f -name "*.sql" -mtime +5 -delete
+            cleanup() { unset MYSQL_PWD || true; }
+            trap cleanup EXIT
+            
+            : "${MYSQL_HOST:?MYSQL_HOST is required}"
+            : "${MYSQL_PORT:=3306}"
+            : "${MYSQL_USERNAME:?MYSQL_USERNAME is required}"
+            : "${MYSQL_PASSWORD:?MYSQL_PASSWORD is required}"
+            : "${MYSQL_DATABASE:?MYSQL_DATABASE is required}"
+            
+            export MYSQL_PWD="${MYSQL_PASSWORD}"
+            
+            mysqldump \
+            -h "${MYSQL_HOST}" \
+            -P "${MYSQL_PORT}" \
+            -u "${MYSQL_USERNAME}" \
+            --single-transaction --quick \
+            --routines --triggers --events \
+            --default-character-set=utf8mb4 \
+            --set-gtid-purged=OFF \
+            "${MYSQL_DATABASE}" > "${DUMP_FILE}"
+            
+            test -s "${DUMP_FILE}"
+            ls -lh "${DUMP_FILE}"
+
       - name: Deploy to prod server
         uses: appleboy/ssh-action@v0.1.8
         with:

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -68,6 +68,55 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Backup stage database before deploy
+        uses: appleboy/ssh-action@v0.1.8
+        with:
+          host: ${{ secrets.STAGE_SERVER_IP }}
+          username: ${{ secrets.STAGE_SERVER_USER }}
+          key: ${{ secrets.STAGE_SERVER_SSH_KEY }}
+          port: ${{ secrets.STAGE_SERVER_PORT }}
+          envs: DB_HOST,DB_PORT,DB_USER,DB_PASSWORD,DB_NAME,DB_BACKUP_DIR
+          script: |
+            set -euo pipefail
+            
+            cd "${{ secrets.STAGE_WORK_DIR }}"
+            
+            set -a
+            source .env
+            set +a
+            
+            BACKUP_DIR="${PWD}/dumps"
+            TS="$(date '+%Y%m%d_%H%M%S')"
+            DUMP_FILE="${BACKUP_DIR}/${TS}.sql"
+            
+            mkdir -p "${BACKUP_DIR}"
+            
+            # n일 지난 백업 정리 (원하면 주석 해제)
+            find "${BACKUP_DIR}" -type f -name "*.sql" -mtime +5 -delete
+            cleanup() { unset MYSQL_PWD || true; }
+            trap cleanup EXIT
+            
+            : "${MYSQL_HOST:?MYSQL_HOST is required}"
+            : "${MYSQL_PORT:=3306}"
+            : "${MYSQL_USERNAME:?MYSQL_USERNAME is required}"
+            : "${MYSQL_PASSWORD:?MYSQL_PASSWORD is required}"
+            : "${MYSQL_DATABASE:?MYSQL_DATABASE is required}"
+            
+            export MYSQL_PWD="${MYSQL_PASSWORD}"
+            
+            mysqldump \
+            -h "${MYSQL_HOST}" \
+            -P "${MYSQL_PORT}" \
+            -u "${MYSQL_USERNAME}" \
+            --single-transaction --quick \
+            --routines --triggers --events \
+            --default-character-set=utf8mb4 \
+            --set-gtid-purged=OFF \
+            "${MYSQL_DATABASE}" > "${DUMP_FILE}"
+            
+            test -s "${DUMP_FILE}"
+            ls -lh "${DUMP_FILE}"
+
       - name: Deploy to stage server
         uses: appleboy/ssh-action@v0.1.8
         with:


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 배포 전 깃허브 액션에서 DB 덤프 작업을 합니다.

* 덤프 파일은 최대 5일 보관합니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated database backup step to production and staging deployment workflows
  * Database backups are now created automatically before deployments begin
  * Old backups (older than 5 days) are automatically removed to manage storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->