### PR TITLE
hotfix: 동아리 부원 탈퇴 관련 버그 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
@@ -61,7 +61,7 @@ public interface ChatRoomMemberRepository extends Repository<ChatRoomMember, Cha
         """)
     List<ChatRoomMember> findByUserId(@Param("userId") Integer userId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("""
         UPDATE ChatRoomMember crm
         SET crm.lastReadAt = :lastReadAt
@@ -75,7 +75,7 @@ public interface ChatRoomMemberRepository extends Repository<ChatRoomMember, Cha
         @Param("lastReadAt") LocalDateTime lastReadAt
     );
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("""
         DELETE FROM ChatRoomMember crm
         WHERE crm.id.chatRoomId = :chatRoomId

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -244,15 +244,18 @@ public class ClubMemberManagementService {
 
         clubPermissionValidator.validateLeaderAccess(clubId, requesterId);
 
-        ClubMember requester = clubMemberRepository.getByClubIdAndUserId(clubId, requesterId);
+        User requesterUser = userRepository.getById(requesterId);
         ClubMember target = clubMemberRepository.getByClubIdAndUserId(clubId, targetUserId);
 
         if (target.isPresident()) {
             throw CustomException.of(CANNOT_DELETE_CLUB_PRESIDENT);
         }
 
-        if (!requester.canManage(target)) {
-            throw CustomException.of(CANNOT_MANAGE_HIGHER_POSITION);
+        if (!requesterUser.isAdmin()) {
+            ClubMember requester = clubMemberRepository.getByClubIdAndUserId(clubId, requesterId);
+            if (!requester.canManage(target)) {
+                throw CustomException.of(CANNOT_MANAGE_HIGHER_POSITION);
+            }
         }
 
         if (target.getClubPosition() != MEMBER) {


### PR DESCRIPTION
### 🔍 개요

* 동아리 부원 탈퇴 관련 버그가 발생하여 이를 해결하였습니다.

- close #이슈번호

---

### 🚀 주요 변경 내용

두 가지 케이스(동아리 회장/어드민) 각각의 버그 원인이 있었습니다 .

동아리 회장
* 채팅방 삭제 시 걸려있는 `@Modifying(clearAutomatically = true)` 때문에 쓰기 지연 저장소에 예약된 동아리 회원 삭제 쿼리를 clear 하는 문제가 있었습니다. 이 때문에 동아리 부원 탈퇴 시 204 가 뜨지만 실제로는 부원이 탈퇴되지 않고 남아있던 것이었습니다. 때문에 관련 어노테이션들을 삭제했습니다.

어드민
* "로그인한 사람이 어드민인가?" && "로그인한 사람이 해당 동아리의 부원인가?" 라는 조건이 존재했었는데, 후자의 조건 때문에 어드민이 해당 동아리의 부원으로 들어가 있지 않으면 거기에서 404 가 나오고 동아리 탈퇴가 불가능했던 문제가 있었습니다. 따라서 조건 중 후자의 경우는 배제했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
