### PR TITLE
feat: 배포 전 stage/prod DB 자동 백업 단계 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -68,6 +68,33 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Backup prod MySQL before deploy
+        uses: appleboy/ssh-action@v0.1.8
+        with:
+          host: ${{ secrets.PROD_SERVER_IP }}
+          username: ${{ secrets.PROD_SERVER_USER }}
+          key: ${{ secrets.PROD_SERVER_SSH_KEY }}
+          port: ${{ secrets.PROD_SERVER_PORT }}
+          script: |
+            set -euo pipefail
+
+            WORK_DIR="${{ secrets.PROD_WORK_DIR }}"
+            MYSQL_CONTAINER="mysql-prod"
+
+            set -a
+            source "$WORK_DIR/.env"
+            set +a
+
+            BACKUP_DIR="$WORK_DIR/db-backups/"
+
+            mkdir -p "$BACKUP_DIR"
+
+            DUMP_FILE="$BACKUP_DIR/$(date '+%Y%m%d_%H%M%S').sql"
+            docker exec -e MYSQL_PWD="$MYSQL_PASSWORD" "$MYSQL_CONTAINER" \
+              mysqldump -u"$MYSQL_USERNAME" "$MYSQL_DATABASE" > "$DUMP_FILE"
+
+            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +5 -delete
+
       - name: Deploy to prod server
         uses: appleboy/ssh-action@v0.1.8
         with:

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -68,6 +68,33 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Backup stage MySQL before deploy
+        uses: appleboy/ssh-action@v0.1.8
+        with:
+          host: ${{ secrets.STAGE_SERVER_IP }}
+          username: ${{ secrets.STAGE_SERVER_USER }}
+          key: ${{ secrets.STAGE_SERVER_SSH_KEY }}
+          port: ${{ secrets.STAGE_SERVER_PORT }}
+          script: |
+            set -euo pipefail
+
+            WORK_DIR="${{ secrets.STAGE_WORK_DIR }}"
+            MYSQL_CONTAINER="mysql-stage"
+
+            set -a
+            source "$WORK_DIR/.env"
+            set +a
+
+            BACKUP_DIR="$WORK_DIR/db-backups/"
+
+            mkdir -p "$BACKUP_DIR"
+
+            DUMP_FILE="$BACKUP_DIR/$(date '+%Y%m%d_%H%M%S').sql"
+            docker exec -e MYSQL_PWD="$MYSQL_PASSWORD" "$MYSQL_CONTAINER" \
+              mysqldump -u"$MYSQL_USERNAME" "$MYSQL_DATABASE" > "$DUMP_FILE"
+
+            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +5 -delete
+
       - name: Deploy to stage server
         uses: appleboy/ssh-action@v0.1.8
         with:


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 깃허브 액션으로 서버 배포하기 전 db를 백업합니다.

* 5일 지난 덤프 파일은 자동 제거합니다.

* 덤프 파일은 `{작업경로}/db-backups/` 내부에 저장됩니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
