### PR TITLE
refactor: 어드민 채팅방에서 일반회원이 메시지 보냈을 때만 Slack 알림 발생하도록 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -376,7 +376,10 @@ public class ChatService {
         updateMemberLastReadAt(roomId, userId, chatMessage.getCreatedAt());
 
         notificationService.sendChatNotification(receiver.getId(), roomId, sender.getName(), request.content());
-        publishAdminChatEventIfNeeded(chatRoom, sender, request.content());
+
+        boolean isSystemAdminRoom = memberInfos.stream()
+            .anyMatch(info -> info.userId().equals(SYSTEM_ADMIN_ID));
+        publishAdminChatEventIfNeeded(isSystemAdminRoom, sender, request.content());
 
         return new ChatMessageDetailResponse(
             chatMessage.getId(),
@@ -621,8 +624,8 @@ public class ChatService {
         return null;
     }
 
-    private void publishAdminChatEventIfNeeded(ChatRoom chatRoom, User sender, String content) {
-        if (isSystemAdminRoom(chatRoom) && sender.getRole() != UserRole.ADMIN) {
+    private void publishAdminChatEventIfNeeded(boolean isSystemAdminRoom, User sender, String content) {
+        if (isSystemAdminRoom && sender.getRole() != UserRole.ADMIN) {
             eventPublisher.publishEvent(AdminChatReceivedEvent.of(sender.getId(), sender.getName(), content));
         }
     }


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Admin direct-message event publishing now triggers only for rooms that include the system admin, and only when the sender is not an administrator.
  * The room membership check determining system-admin rooms is evaluated at the decision point.
  * This reduces unnecessary admin notifications and refines in-app notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->