### PR TITLE
fix: isRecruitmentEnabled가 false일 때 GET /clubs 모집 상태를 CLOSED로 처리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubQueryRepository.java
@@ -106,7 +106,8 @@ public class ClubQueryRepository {
 
     private BooleanExpression createOngoingRecruitmentCondition() {
         LocalDate today = LocalDate.now();
-        return clubRecruitment.id.isNotNull()
+        return club.isRecruitmentEnabled.isTrue()
+            .and(clubRecruitment.id.isNotNull())
             .and(
                 clubRecruitment.isAlwaysRecruiting.isTrue()
                     .or(clubRecruitment.startDate.loe(today).and(clubRecruitment.endDate.goe(today)))
@@ -162,9 +163,13 @@ public class ClubQueryRepository {
         return clubs.stream()
             .map(club -> {
                 ClubRecruitment recruitment = club.getClubRecruitment();
-                RecruitmentStatus status = RecruitmentStatus.of(recruitment);
+                boolean isRecruitmentEnabled = Boolean.TRUE.equals(club.getIsRecruitmentEnabled());
+                RecruitmentStatus status = isRecruitmentEnabled
+                    ? RecruitmentStatus.of(recruitment)
+                    : RecruitmentStatus.CLOSED;
 
-                boolean isAlwaysRecruiting = recruitment != null
+                boolean isAlwaysRecruiting = isRecruitmentEnabled
+                    && recruitment != null
                     && Boolean.TRUE.equals(recruitment.getIsAlwaysRecruiting());
                 LocalDate applicationDeadline = (recruitment != null && !isAlwaysRecruiting)
                     ? recruitment.getEndDate()


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed club recruitment status determination to properly respect the recruitment enabled setting.
  * Corrected application deadline and ongoing recruitment calculations to align with the recruitment enabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->