### PR TITLE
feat: 이미지 업로드 허용 확장자 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
+++ b/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
@@ -29,8 +29,10 @@ public class UploadService {
 
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
         "image/png",
+        "image/jpg",
         "image/jpeg",
-        "image/webp"
+        "image/webp",
+        "image/avif"
     );
 
     private final S3Client s3Client;
@@ -113,8 +115,10 @@ public class UploadService {
     private String extensionFromContentType(String contentType) {
         return switch (contentType) {
             case "image/png" -> "png";
+            case "image/jpg" -> "jpg";
             case "image/jpeg" -> "jpg";
             case "image/webp" -> "webp";
+            case "image/avif" -> "avif";
             default -> throw CustomException.of(ApiResponseCode.INVALID_FILE_CONTENT_TYPE);
         };
     }


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* `jpg`, `avif` 확장자도 업로드할 수 있도록 추가했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Extended image format support** - Users can now upload images in JPG and AVIF formats alongside the previously supported PNG, JPEG, and WebP formats. This enhancement expands the overall range of supported image file types on the platform, providing significantly greater flexibility for users uploading images from a diverse range of sources, devices, and applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->