### PR TITLE
fix: 클럽 설정 컬럼 기본값을 false로 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubCreateRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubCreateRequest.java
@@ -49,6 +49,9 @@ public record ClubCreateRequest(
             .location(location)
             .clubCategory(clubCategory)
             .university(university)
+            .isRecruitmentEnabled(false)
+            .isApplicationEnabled(false)
+            .isFeeRequired(false)
             .build();
     }
 }

--- a/src/main/resources/db/migration/V33__align_club_toggle_defaults_to_false.sql
+++ b/src/main/resources/db/migration/V33__align_club_toggle_defaults_to_false.sql
@@ -1,0 +1,8 @@
+ALTER TABLE club
+    MODIFY COLUMN is_recruitment_enabled TINYINT(1) NOT NULL DEFAULT 0;
+
+ALTER TABLE club
+    MODIFY COLUMN is_application_enabled TINYINT(1) NOT NULL DEFAULT 0;
+
+ALTER TABLE club
+    MODIFY COLUMN is_fee_required TINYINT(1) DEFAULT 0;


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 동아리 처음 생성 시 관리 페이지에 있는 3개의 토글 버튼 상태를 `false`로 지정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned default values for club recruitment, application, and fee settings to disabled state. These settings now consistently default to off when creating new clubs, ensuring predictable behavior across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->