### PR TITLE
fix: getUserInfo에서 운영진 여부 계산을 회장 전용에서 운영진 전체로 확장

### DIFF
--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package gg.agit.konect.domain.user.service;
 
 import static gg.agit.konect.domain.club.enums.ClubPosition.PRESIDENT;
+import static gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_DELETE_CLUB_PRESIDENT;
 
 import java.time.LocalDateTime;
@@ -192,7 +193,8 @@ public class UserService {
     public UserInfoResponse getUserInfo(Integer userId) {
         User user = userRepository.getById(userId);
         List<ClubMember> clubMembers = clubMemberRepository.findAllByUserId(user.getId());
-        boolean isClubManager = clubMembers.stream().anyMatch(ClubMember::isPresident);
+        boolean isClubManager = clubMembers.stream()
+            .anyMatch(clubMember -> MANAGERS.contains(clubMember.getClubPosition()));
         int joinedClubCount = clubMembers.size();
         Long unreadCouncilNoticeCount = councilNoticeReadRepository.countUnreadNoticesByUserId(user.getId());
         Long studyTime = studyTimeQueryService.getTotalStudyTime(userId);


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 이전에는 권한이 회장만 존재하였으나, 현재는 다양한 권한이 생겼으므로 동아리 관리 가능 여부 조회 로직을 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined manager role identification to recognize a broader set of managerial positions, not limited to club presidents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->