### PR TITLE
fix: Expo 알림 토큰 추가 -> 업데이트 방식으로 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/notification/model/NotificationDeviceToken.java
+++ b/src/main/java/gg/agit/konect/domain/notification/model/NotificationDeviceToken.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(
     name = "notification_device_token",
     uniqueConstraints = {
-        @UniqueConstraint(name = "uq_notification_device_token_token", columnNames = "token")
+        @UniqueConstraint(name = "uq_notification_device_token_user_id", columnNames = "user_id")
     }
 )
 @NoArgsConstructor(access = PROTECTED)
@@ -37,7 +37,7 @@ public class NotificationDeviceToken extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "token", length = 255, nullable = false, unique = true)
+    @Column(name = "token", length = 255, nullable = false)
     private String token;
 
     private NotificationDeviceToken(Integer id, User user, String token) {
@@ -50,7 +50,7 @@ public class NotificationDeviceToken extends BaseEntity {
         return new NotificationDeviceToken(null, user, token);
     }
 
-    public void updateUser(User user) {
-        this.user = user;
+    public void updateToken(String token) {
+        this.token = token;
     }
 }

--- a/src/main/java/gg/agit/konect/domain/notification/repository/NotificationDeviceTokenRepository.java
+++ b/src/main/java/gg/agit/konect/domain/notification/repository/NotificationDeviceTokenRepository.java
@@ -11,7 +11,7 @@ import gg.agit.konect.domain.notification.model.NotificationDeviceToken;
 
 public interface NotificationDeviceTokenRepository extends Repository<NotificationDeviceToken, Integer> {
 
-    Optional<NotificationDeviceToken> findByToken(String token);
+    Optional<NotificationDeviceToken> findByUserId(Integer userId);
 
     @Query("""
         SELECT ndt
@@ -30,13 +30,6 @@ public interface NotificationDeviceTokenRepository extends Repository<Notificati
         WHERE ndt.user.id = :userId
         """)
     List<String> findTokensByUserId(@Param("userId") Integer userId);
-
-    @Query("""
-        SELECT ndt.user.id
-        FROM NotificationDeviceToken ndt
-        WHERE ndt.token = :token
-        """)
-    Optional<Integer> findUserIdByToken(@Param("token") String token);
 
     void save(NotificationDeviceToken notificationDeviceToken);
 

--- a/src/main/resources/db/migration/V34__change_notification_device_token_unique_to_user.sql
+++ b/src/main/resources/db/migration/V34__change_notification_device_token_unique_to_user.sql
@@ -1,0 +1,12 @@
+DELETE ndt1
+FROM notification_device_token ndt1
+    INNER JOIN notification_device_token ndt2
+        ON ndt1.user_id = ndt2.user_id
+        AND (
+            ndt1.updated_at < ndt2.updated_at
+            OR (ndt1.updated_at = ndt2.updated_at AND ndt1.id < ndt2.id)
+        );
+
+ALTER TABLE notification_device_token
+    DROP INDEX uq_notification_device_token_token,
+    ADD CONSTRAINT uq_notification_device_token_user_id UNIQUE (user_id);


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 한 명의 유저는 하나의 알림 토큰만 가질 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification token registration with simplified, more reliable logic.
  * Restructured token management to ensure only one active token per user, preventing conflicts and duplicate registrations.
  * Token registration now handles both new registrations and updates through a unified, idempotent flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->