### PR TITLE
feat: 스웨거 인증 과정 자동화

### DIFF
--- a/src/main/java/gg/agit/konect/global/config/SwaggerUiResourceController.java
+++ b/src/main/java/gg/agit/konect/global/config/SwaggerUiResourceController.java
@@ -1,0 +1,23 @@
+package gg.agit.konect.global.config;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SwaggerUiResourceController {
+
+    private static final String SWAGGER_INITIALIZER_PATH = "static/swagger-ui/swagger-initializer.js";
+
+    @GetMapping(value = "/swagger-ui/swagger-initializer.js", produces = "application/javascript")
+    public ResponseEntity<Resource> swaggerInitializer() {
+        Resource resource = new ClassPathResource(SWAGGER_INITIALIZER_PATH);
+
+        return ResponseEntity.ok()
+            .contentType(MediaType.valueOf("application/javascript"))
+            .body(resource);
+    }
+}

--- a/src/main/resources/static/swagger-ui/swagger-initializer.js
+++ b/src/main/resources/static/swagger-ui/swagger-initializer.js
@@ -1,0 +1,197 @@
+window.onload = function () {
+  window.__KONECT_SWAGGER_INIT_LOADED__ = true;
+  window.__KONECT_SWAGGER_INIT_LOADED_AT__ = new Date().toISOString();
+
+  const SECURITY_SCHEME_NAME = "Jwt Authentication";
+  const EXPIRY_BUFFER_MS = 30 * 1000;
+
+  const appBasePath = detectAppBasePath();
+  const refreshEndpoint = appBasePath + "/users/refresh";
+  const swaggerConfigUrl = appBasePath + "/v3/api-docs/swagger-config";
+
+  let currentAccessToken = null;
+  let currentTokenExpiresAtMs = 0;
+  let refreshingPromise = null;
+
+  function detectAppBasePath() {
+    const pathname = window.location.pathname || "";
+    const marker = "/swagger-ui";
+    const markerIndex = pathname.indexOf(marker);
+
+    if (markerIndex < 0) {
+      return "";
+    }
+
+    return pathname.substring(0, markerIndex);
+  }
+
+  function parseJwtExpiryMs(token) {
+    try {
+      const payload = token.split(".")[1];
+      if (!payload) {
+        return 0;
+      }
+
+      const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+      const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+      const claims = JSON.parse(atob(padded));
+
+      if (typeof claims.exp !== "number") {
+        return 0;
+      }
+
+      return claims.exp * 1000;
+    } catch (error) {
+      return 0;
+    }
+  }
+
+  function hasUsableToken() {
+    if (!currentAccessToken || !currentTokenExpiresAtMs) {
+      return false;
+    }
+
+    return Date.now() + EXPIRY_BUFFER_MS < currentTokenExpiresAtMs;
+  }
+
+  function shouldSkipAuthInjection(url) {
+    if (!url) {
+      return true;
+    }
+
+    return url.includes("/v3/api-docs") || url.includes("/users/refresh");
+  }
+
+  function readAccessToken(responseBody) {
+    if (!responseBody || typeof responseBody !== "object") {
+      return null;
+    }
+
+    if (typeof responseBody.accessToken === "string") {
+      return responseBody.accessToken;
+    }
+
+    if (responseBody.data && typeof responseBody.data.accessToken === "string") {
+      return responseBody.data.accessToken;
+    }
+
+    return null;
+  }
+
+  function setAuthorizationHeader(request, token) {
+    const nextHeaders = {};
+
+    if (request.headers && typeof request.headers.forEach === "function") {
+      request.headers.forEach(function (value, key) {
+        nextHeaders[key] = value;
+      });
+    } else if (request.headers && typeof request.headers === "object") {
+      Object.assign(nextHeaders, request.headers);
+    }
+
+    nextHeaders.Authorization = "Bearer " + token;
+    delete nextHeaders.authorization;
+    request.headers = nextHeaders;
+  }
+
+  function setSwaggerAuthorization(token) {
+    if (!window.ui) {
+      return;
+    }
+
+    if (window.ui.authActions && typeof window.ui.authActions.authorize === "function") {
+      window.ui.authActions.authorize({
+        [SECURITY_SCHEME_NAME]: {
+          name: SECURITY_SCHEME_NAME,
+          schema: {
+            type: "http",
+            in: "header",
+            scheme: "Bearer",
+            bearerFormat: "JWT"
+          },
+          value: token
+        }
+      });
+    }
+
+    if (typeof window.ui.preauthorizeApiKey === "function") {
+      window.ui.preauthorizeApiKey(SECURITY_SCHEME_NAME, token);
+    }
+  }
+
+  async function refreshAccessToken() {
+    const response = await fetch(refreshEndpoint, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json"
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error("failed to refresh access token");
+    }
+
+    const responseBody = await response.json();
+    const nextToken = readAccessToken(responseBody);
+
+    if (!nextToken) {
+      throw new Error("missing access token in refresh response");
+    }
+
+    currentAccessToken = nextToken;
+    currentTokenExpiresAtMs = parseJwtExpiryMs(nextToken);
+    setSwaggerAuthorization(nextToken);
+    return nextToken;
+  }
+
+  async function ensureAccessToken() {
+    if (hasUsableToken()) {
+      return currentAccessToken;
+    }
+
+    if (!refreshingPromise) {
+      refreshingPromise = refreshAccessToken().finally(function () {
+        refreshingPromise = null;
+      });
+    }
+
+    return refreshingPromise;
+  }
+
+  window.ui = SwaggerUIBundle({
+    configUrl: swaggerConfigUrl,
+    dom_id: "#swagger-ui",
+    deepLinking: true,
+    persistAuthorization: true,
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+    layout: "StandaloneLayout",
+    requestInterceptor: async function (request) {
+      if (request && request.loadSpec) {
+        return request;
+      }
+
+      const requestUrl = typeof request.url === "string" ? request.url : String(request.url || "");
+      if (shouldSkipAuthInjection(requestUrl)) {
+        return request;
+      }
+
+      try {
+        const token = await ensureAccessToken();
+        if (token) {
+          setAuthorizationHeader(request, token);
+          request.headers["X-Swagger-Auth-Debug"] = "injected";
+        }
+      } catch (error) {
+        currentAccessToken = null;
+        currentTokenExpiresAtMs = 0;
+      }
+
+      return request;
+    }
+  });
+
+  ensureAccessToken().catch(function () {
+  });
+};


### PR DESCRIPTION
### 🔍 개요

* 스웨거로 API 테스트 시 매번 `/refresh` API로 액세스 토큰 발급 받아야 하는 번거로움이 존재

* 심지어 액세스 토큰은 유효 기간도 짧으므로 자주 반복해야 함

* 이 단순 반복 과정을 JS 코드로 해결

- close #이슈번호

---

### 🚀 주요 변경 내용

* 스웨거에는 `swagger-initializer.js` 라는 설정 파일을 제공

* 프로젝트의 `/swagger-ui/swagger-initializer.js` 를 추가해 기본 설정 파일을 덮어쓸 수 있도록 함

* 단순히 파일만 추가하면 새롭게 추가한 JS 파일을 로딩하지 못함
  *  스웨거 페이지 로딩 중 자동으로 불리는 정적 리소스를 우리가 커스텀한 파일로 제공하기 위해 컨트롤러 추가

* 그로 인해 스웨거로 API 테스트 시 자동으로 액세스 토큰을 요청 헤더에 담을 수 있게 됨

---

### 💬 참고 사항

* 이미 로그인하여 리프레시 토큰이 쿠키에 담겨 있는 상태에서만 작동합니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added JWT authentication support to Swagger API documentation with automatic token refresh, enabling seamless testing of protected endpoints directly in the interactive API docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->