### PR TITLE
fix: 유니크 제약조건 제거 전 인덱스 추가

### DIFF
--- a/src/main/resources/db/migration/V49__remove_unique_constraint_on_user_student_number.sql
+++ b/src/main/resources/db/migration/V49__remove_unique_constraint_on_user_student_number.sql
@@ -1,2 +1,3 @@
 ALTER TABLE users
+    ADD INDEX idx_users_university_id (university_id),
     DROP INDEX uq_users_university_id_student_number_active;


### PR DESCRIPTION
### 🔍 개요

* `users` 테이블에 `FOREIGN KEY (university_id) REFERENCES university (id)` 외래 키 존재
  
* 외래 키 제약 조건은 `university_id` 컬럼에 대한 인덱스를 필요로 함
 
* 제거한 제약조건의 유니크 인덱스의 첫 번째 컬럼이 `university_id`라서 외래 키가 이 인덱스를 사용

* 인덱스 삭제 시도 → 외래 키가 인덱스 필요 → 삭제 불가

- close #이슈번호

---

### 🚀 주요 변경 내용

* 유니크 제약조건 삭제 전 `university_id` 컬럼에 대한 인덱스를 추가합니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
