### PR TITLE
refactor: deprecated된 OAuth2ClientAutoConfiguration 제거

### DIFF
--- a/src/test/java/gg/agit/konect/support/ControllerTestSupport.java
+++ b/src/test/java/gg/agit/konect/support/ControllerTestSupport.java
@@ -2,25 +2,19 @@ package gg.agit.konect.support;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -43,9 +37,7 @@ import jakarta.persistence.EntityManager;
 @Transactional
 @ActiveProfiles("test")
 @Import({TestSecurityConfig.class, TestJpaConfig.class, TestClaudeConfig.class})
-@EnableAutoConfiguration(exclude = {
-    OAuth2ClientAutoConfiguration.class
-})
+
 @TestPropertyConfig
 public abstract class ControllerTestSupport {
 

--- a/src/test/java/gg/agit/konect/support/IntegrationTestSupport.java
+++ b/src/test/java/gg/agit/konect/support/IntegrationTestSupport.java
@@ -1,8 +1,6 @@
 package gg.agit.konect.support;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -12,9 +10,7 @@ import jakarta.persistence.EntityManager;
 @SpringBootTest
 @ActiveProfiles("test")
 @Import({TestSecurityConfig.class, TestJpaConfig.class, TestClaudeConfig.class})
-@EnableAutoConfiguration(exclude = {
-    OAuth2ClientAutoConfiguration.class
-})
+
 @TestPropertyConfig
 public abstract class IntegrationTestSupport {
 


### PR DESCRIPTION
### 🔍 개요

* `OAuth2ClientAutoConfiguration` 는 스프링 부트 3.5.0 버전 이후로 지원 중지됨

* 현재 코넥트 프로젝트에서는 3.5.8 버전을 사용

* 테스트 실행 시 에러는 아니지만 경고가 뜨는 것을 발견하여 이를 해결

- close #이슈번호

---

### 🚀 주요 변경 내용



---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
