### PR TITLE
fix: 관리자 조회가 id순 첫 활성 사용자 1명만 반환되도록 제한

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -116,7 +116,7 @@ public class ChatService {
 
     @Transactional
     public ChatRoomResponse createOrGetAdminChatRoom(Integer currentUserId) {
-        User adminUser = userRepository.findFirstByRoleOrderByIdAsc(UserRole.ADMIN)
+        User adminUser = userRepository.findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole.ADMIN)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_USER));
 
         return createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(adminUser.getId()));

--- a/src/main/java/gg/agit/konect/domain/user/repository/UserRepository.java
+++ b/src/main/java/gg/agit/konect/domain/user/repository/UserRepository.java
@@ -22,14 +22,7 @@ public interface UserRepository extends Repository<User, Integer> {
         """)
     Optional<User> findById(@Param("id") Integer id);
 
-    @Query("""
-        SELECT u
-        FROM User u
-        WHERE u.role = :role
-        AND u.deletedAt IS NULL
-        ORDER BY u.id ASC
-        """)
-    Optional<User> findFirstByRoleOrderByIdAsc(@Param("role") UserRole role);
+    Optional<User> findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole role);
 
     default User getById(Integer id) {
         return findById(id).orElseThrow(() ->

--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -110,7 +110,7 @@ public class UserService {
 
     private void sendWelcomeMessage(User newUser) {
         try {
-            User operator = userRepository.findFirstByRoleOrderByIdAsc(UserRole.ADMIN)
+            User operator = userRepository.findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole.ADMIN)
                 .orElse(null);
             if (operator == null) {
                 return;


### PR DESCRIPTION
### 🔍 개요

* `findFirstByRoleOrderByIdAsc` 메소드가 네이밍에는 단건 조회처럼 보이나, 실제로는 해당 조건에 맞는 레코드가 여럿 존재하여 문제가 발생

- close #364

---

### 🚀 주요 변경 내용

* 관리자 조회 시 id순으로 첫 번째 사용자만 반환할 수 있도록 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
