### PR TITLE
fix: 운영 환경 배포 전 DB 백업 파일 보존 기간 5일 -> 30일로 확장

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -93,7 +93,7 @@ jobs:
             docker exec -e MYSQL_PWD="$MYSQL_PASSWORD" "$MYSQL_CONTAINER" \
               mysqldump --no-tablespaces -u"$MYSQL_USERNAME" "$MYSQL_DATABASE" > "$DUMP_FILE"
 
-            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +5 -delete
+            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +30 -delete
 
       - name: Deploy to prod server
         uses: appleboy/ssh-action@v0.1.8


### PR DESCRIPTION
### 🔍 개요

* 

- close #이슈번호

---

### 🚀 주요 변경 내용

* 


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
