### PR TITLE
hotfix: 인터셉터가 인터페이스 Auth/PublicApi 어노테이션을 인식하지 못하는 문제 해결 (develop)

### DIFF
--- a/src/main/java/gg/agit/konect/global/auth/web/AuthorizationInterceptor.java
+++ b/src/main/java/gg/agit/konect/global/auth/web/AuthorizationInterceptor.java
@@ -58,14 +58,14 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
 
     private Auth findAuthAnnotation(HandlerMethod handlerMethod) {
         Auth methodAnnotation = AnnotatedElementUtils.findMergedAnnotation(
-                handlerMethod.getMethod(), Auth.class);
+            handlerMethod.getMethod(), Auth.class);
 
         if (methodAnnotation != null) {
             return methodAnnotation;
         }
 
         return AnnotatedElementUtils.findMergedAnnotation(
-                handlerMethod.getBeanType(), Auth.class);
+            handlerMethod.getBeanType(), Auth.class);
     }
 
     // 요청자의 권한과 @Auth에서 지정된 권한을 비교하여 검증

--- a/src/main/java/gg/agit/konect/global/auth/web/LoginCheckInterceptor.java
+++ b/src/main/java/gg/agit/konect/global/auth/web/LoginCheckInterceptor.java
@@ -52,9 +52,9 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 
     private boolean isPublicEndpoint(HandlerMethod handlerMethod) {
         return AnnotatedElementUtils.findMergedAnnotation(
-                handlerMethod.getMethod(), PublicApi.class) != null
+            handlerMethod.getMethod(), PublicApi.class) != null
             || AnnotatedElementUtils.findMergedAnnotation(
-                handlerMethod.getBeanType(), PublicApi.class) != null;
+            handlerMethod.getBeanType(), PublicApi.class) != null;
     }
 
     private String resolveBearerToken(HttpServletRequest request) {


### PR DESCRIPTION
### 🔍 개요

* 인터셉터에서 인터페이스에 정의된 `@Auth` 및 `@PublicApi` 어노테이션을 인식하지 못하는 문제를 해결합니다.


---

### 🚀 주요 변경 내용

### AuthorizationInterceptor.java
- `findAuthAnnotation()` 메서드에서 클래스 레벨 어노테이션 검색 시 `AnnotatedElementUtils.findMergedAnnotation()` 사용
- 인터페이스에 정의된 `@Auth` 어노테이션도 탐색 가능하도록 수정

### LoginCheckInterceptor.java
- `isPublicEndpoint()` 메서드에서 메서드/클래스 레벨 어노테이션 검색 시 `AnnotatedElementUtils.findMergedAnnotation()` 사용
- 인터페이스에 정의된 `@PublicApi` 어노테이션도 탐색 가능하도록 수정


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
