### PR TITLE
fix: 업로드 파일 용량 초과 에러 부모 핸들러 메소드 오버라이딩 방식으로 수정

### DIFF
--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -76,8 +76,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return buildErrorResponse(ApiResponseCode.CLIENT_ABORTED);
     }
 
-    @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<Object> handleMaxUploadSizeExceededException() {
+    @Override
+    protected ResponseEntity<Object> handleMaxUploadSizeExceededException(
+        MaxUploadSizeExceededException ex,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
         return buildErrorResponse(ApiResponseCode.PAYLOAD_TOO_LARGE);
     }
 


### PR DESCRIPTION
### 🔍 개요

* 


---

### 🚀 주요 변경 내용

* 이미 부모 핸들러에서 `MaxUploadSizeExceededException` 예외를 핸들링하고 있어, 커스텀 에러 핸들러에서 이를 오버라이딩하는 방식으로 수정했습니다.

* 굳이 오버라이딩 안하더라도 잘 캐치하겠지만, 에러 메시지를 한글로 사용하기 위해 위와 같이 수정했습니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
