### PR TITLE
fix: 인터셉터 예외 핸들링 문제 해결

### DIFF
--- a/src/main/java/gg/agit/konect/global/auth/web/AuthorizationInterceptor.java
+++ b/src/main/java/gg/agit/konect/global/auth/web/AuthorizationInterceptor.java
@@ -1,5 +1,6 @@
 package gg.agit.konect.global.auth.web;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
@@ -28,7 +29,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
 
     public AuthorizationInterceptor(
         UserRepository userRepository,
-        HandlerExceptionResolver handlerExceptionResolver
+        @Lazy HandlerExceptionResolver handlerExceptionResolver
     ) {
         this.userRepository = userRepository;
         this.handlerExceptionResolver = handlerExceptionResolver;

--- a/src/main/java/gg/agit/konect/global/auth/web/LoginCheckInterceptor.java
+++ b/src/main/java/gg/agit/konect/global/auth/web/LoginCheckInterceptor.java
@@ -1,5 +1,6 @@
 package gg.agit.konect.global.auth.web;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
@@ -33,7 +34,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 
     public LoginCheckInterceptor(
         JwtProvider jwtProvider,
-        HandlerExceptionResolver handlerExceptionResolver
+        @Lazy HandlerExceptionResolver handlerExceptionResolver
     ) {
         this.jwtProvider = jwtProvider;
         this.handlerExceptionResolver = handlerExceptionResolver;

--- a/src/main/java/gg/agit/konect/global/config/WebConfig.java
+++ b/src/main/java/gg/agit/konect/global/config/WebConfig.java
@@ -2,15 +2,12 @@ package gg.agit.konect.global.config;
 
 import java.util.List;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
 
 import gg.agit.konect.global.auth.web.AuthorizationInterceptor;
 import gg.agit.konect.global.auth.web.LoginCheckInterceptor;
@@ -59,13 +56,4 @@ public class WebConfig implements WebMvcConfigurer {
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addViewController("/login").setViewName("forward:/login.html");
     }
-
-    /**
-     * 인터셉터 예외를 GlobalExceptionHandler로 위임하기 위한 ExceptionHandlerExceptionResolver 빈.
-     */
-    @Bean
-    public HandlerExceptionResolver handlerExceptionResolver() {
-        return new ExceptionHandlerExceptionResolver();
-    }
-
 }

--- a/src/test/java/gg/agit/konect/unit/global/auth/web/AuthorizationInterceptorTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/auth/web/AuthorizationInterceptorTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import gg.agit.konect.domain.user.enums.UserRole;
 import gg.agit.konect.domain.user.model.User;
@@ -29,11 +30,14 @@ class AuthorizationInterceptorTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private HandlerExceptionResolver handlerExceptionResolver;
+
     private AuthorizationInterceptor interceptor;
 
     @BeforeEach
     void setUp() {
-        interceptor = new AuthorizationInterceptor(userRepository);
+        interceptor = new AuthorizationInterceptor(userRepository, handlerExceptionResolver);
     }
 
     @Nested


### PR DESCRIPTION
### 🔍 개요

* SSE(Server-Sent Events) 도입 후 인터셉터에서 발생하는 예외가 `GlobalExceptionHandler`에서 처리되지 않는 문제가 발견됨.


---

### 🚀 주요 변경 내용


```
DispatcherServlet
    ↓
HandlerInterceptor.preHandle()  ← 예외 발생 지점
    ↓
Controller Method               ← @RestControllerAdvice가 처리하는 범위 시작
    ↓
@ExceptionHandler 적용
```

`@RestControllerAdvice`는 **컨트롤러 메서드에서 발생한 예외만 처리**함. `preHandle()`에서 발생한 예외는 컨트롤러 진입 전이므로 GlobalExceptionHandler가 캐치하지 못함.

#### HTTP 요청

```
요청 → 인터셉터 통과 (5분 내) → 즉시 응답 → 완료
```

#### SSE 요청

```
SSE 구독 요청 → 인터셉터 통과 → 연결 유지 (최대 30분)
                                    ↓
                               5분 후 토큰 만료
                                    ↓
                              연결 끊김/타임아웃
                                    ↓
                                재연결 시도
                                    ↓
                       인터셉터에서 EXPIRED_TOKEN 발생
                                    ↓
                        GlobalExceptionHandler 우회
```

**즉, 문제는 재연결 시 발생**:
1. 최초 SSE 연결 시 토큰 정상
2. 연결 유지 중 액세스 토큰 만료 (5분)
3. 네트워크 이슈, 타임아웃 등으로 연결 끊김
4. 클라이언트 재연결 시도 (여전히 만료된 토큰 사용)
5. 재연결 요청이 인터셉터 거침 → `EXPIRED_TOKEN` 발생
6. GlobalExceptionHandler 우회 → 명확하지 않은 에러 응답

---

### 해결 방안

* HandlerExceptionResolver 주입 + `@Lazy` 적용 (Lazy를 적용하지 않으면 순환 참조 발생)

* 인터셉터에 `HandlerExceptionResolver`를 주입받아 예외를 `GlobalExceptionHandler`로 위임.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
