### PR TITLE
fix: SSE 구독 인증 실패 시 ErrorResponse 직렬화 충돌

### DIFF
--- a/src/main/java/gg/agit/konect/global/auth/web/LoginCheckInterceptor.java
+++ b/src/main/java/gg/agit/konect/global/auth/web/LoginCheckInterceptor.java
@@ -16,6 +16,7 @@ import gg.agit.konect.global.auth.annotation.PublicApi;
 import gg.agit.konect.global.exception.CustomException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 로그인 체크 인터셉터.
@@ -24,6 +25,7 @@ import jakarta.servlet.http.HttpServletResponse;
  *
  * 예외 발생 시 HandlerExceptionResolver를 통해 GlobalExceptionHandler로 위임합니다.
  */
+@Slf4j
 @Component
 public class LoginCheckInterceptor implements HandlerInterceptor {
 
@@ -66,6 +68,13 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             return true;
         } catch (CustomException e) {
             if (isSseRequest(request, handlerMethod)) {
+                log.warn(
+                    "SSE authentication failed: method={} uri={} status={} code={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    e.getErrorCode().getHttpStatus().value(),
+                    e.getErrorCode().getCode()
+                );
                 response.setStatus(e.getErrorCode().getHttpStatus().value());
                 return false;
             }


### PR DESCRIPTION
### 🔍 개요

* SSE 구독 요청에서 인증 예외가 발생할 때 `GlobalExceptionHandler`가 `ErrorResponse`를 `text/event-stream` 응답으로 직렬화하려다 `HttpMessageNotWritableException`이 발생하던 문제를 수정했습니다.

* 일반 HTTP 요청과 SSE 요청의 인증 실패 응답 경계를 분리해, SSE 요청은 HTTP 상태 코드로만 종료하고 기존 JSON 에러 응답은 일반 API 흐름에만 유지하도록 조정했습니다.


---

### 🚀 주요 변경 내용

* `src/main/java/gg/agit/konect/global/auth/web/LoginCheckInterceptor.java`에 `isSseRequest()`를 추가해 `Accept: text/event-stream` 헤더와 handler `produces` 설정을 기준으로 SSE 요청을 식별하도록 했습니다.

* `LoginCheckInterceptor`에서 `CustomException`이 발생한 경우, SSE 요청은 `HandlerExceptionResolver`로 위임하지 않고 `response.setStatus(...)` 후 요청을 종료하도록 변경했습니다.

* SSE 요청에서 인터셉터에 예외가 발생했다면 실패 로그(`warn`)를 남기도록 했습니다.

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
