### PR TITLE
fix: SSE 환경에서 커넥션 점유 방지를 위해 open-in-view 비활성화

### DIFF
--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -19,6 +19,7 @@ spring:
           time_zone: Asia/Seoul
     hibernate:
       ddl-auto: validate
+    open-in-view: false
 
   data:
     redis:


### PR DESCRIPTION
### 🔍 개요

* SSE를 도입하면서 커넥션 풀이 고갈하는 문제가 빈번하게 발생

* Spring JPA 옵션에 open-in-view가 있는데, 기본값으로 true임

* 이는 HTTP 요청이 끝나기 전까지 DB 세션을 유지하므로 연결을 유지하는 SSE에서 커넥션을 계속 점유하게 됨

* SSE 연결하는 클라이언트의 수가 많아지면 커넥션 풀을 모두 사용하게 됨

---

### 🚀 주요 변경 내용

* `open-in-view` 설정을 `false`로 지정했습니다.



---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
