### PR TITLE
feat: 배치 사이즈 설정 추가

### DIFF
--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -17,6 +17,9 @@ spring:
         format_sql: true
         jdbc:
           time_zone: Asia/Seoul
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
     hibernate:
       ddl-auto: validate
     open-in-view: false


### PR DESCRIPTION
### 🔍 개요

* `saveAll()` 같은 메소드는 내부적으로 `insert` 쿼리문을 엔티티의 수 만큼 전송함

* `jpa.batch_size` 옵션을 주어 사이즈 만큼 쿼리문을 묶어 전송하도록 함


---

### 🚀 주요 변경 내용

* 배치 사이즈를 100으로 지정하여 최대 100개의 엔티티를 일괄 처리합니다.


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
