### PR TITLE
feat: Google Drive 권한 연결 URL 조회 API 추가

### DIFF
--- a/src/main/java/gg/agit/konect/infrastructure/oauth/GoogleDriveOAuthController.java
+++ b/src/main/java/gg/agit/konect/infrastructure/oauth/GoogleDriveOAuthController.java
@@ -11,15 +11,27 @@ import org.springframework.web.bind.annotation.RestController;
 
 import gg.agit.konect.global.auth.annotation.PublicApi;
 import gg.agit.konect.global.auth.annotation.UserId;
+import gg.agit.konect.infrastructure.oauth.dto.GoogleDriveAuthorizationUrlResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth/oauth/google/drive")
+@Tag(name = "(Normal) OAuth - Google Drive")
 public class GoogleDriveOAuthController {
 
     private final GoogleDriveOAuthService googleDriveOAuthService;
 
+    @Operation(summary = "Google Drive 권한 연결 URL 조회")
+    @GetMapping("/authorize-url")
+    public ResponseEntity<GoogleDriveAuthorizationUrlResponse> getAuthorizationUrl(@UserId Integer userId) {
+        String authUrl = googleDriveOAuthService.buildAuthorizationUrl(userId);
+        return ResponseEntity.ok(new GoogleDriveAuthorizationUrlResponse(authUrl));
+    }
+
+    @Operation(summary = "Google Drive 권한 연결 페이지로 리다이렉트")
     @GetMapping("/authorize")
     public ResponseEntity<Void> authorize(@UserId Integer userId) {
         String authUrl = googleDriveOAuthService.buildAuthorizationUrl(userId);
@@ -27,6 +39,7 @@ public class GoogleDriveOAuthController {
     }
 
     @PublicApi
+    @Operation(summary = "Google Drive OAuth callback 처리")
     @GetMapping("/callback")
     public ResponseEntity<Void> callback(
         @RequestParam("code") String code,

--- a/src/main/java/gg/agit/konect/infrastructure/oauth/dto/GoogleDriveAuthorizationUrlResponse.java
+++ b/src/main/java/gg/agit/konect/infrastructure/oauth/dto/GoogleDriveAuthorizationUrlResponse.java
@@ -1,0 +1,15 @@
+package gg.agit.konect.infrastructure.oauth.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GoogleDriveAuthorizationUrlResponse(
+    @Schema(
+        description = "Google Drive 권한 연결을 위해 브라우저를 이동시킬 authorize URL",
+        example = "https://accounts.google.com/o/oauth2/v2/auth?client_id=example&redirect_uri=https://api.stage.agit.gg/auth/oauth/google/drive/callback&response_type=code&scope=https://www.googleapis.com/auth/drive&access_type=offline&prompt=consent&state=example-state",
+        requiredMode = REQUIRED
+    )
+    String authorizationUrl
+) {
+}

--- a/src/test/java/gg/agit/konect/integration/infrastructure/oauth/GoogleDriveOAuthControllerTest.java
+++ b/src/test/java/gg/agit/konect/integration/infrastructure/oauth/GoogleDriveOAuthControllerTest.java
@@ -1,0 +1,46 @@
+package gg.agit.konect.integration.infrastructure.oauth;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import gg.agit.konect.infrastructure.oauth.GoogleDriveOAuthService;
+import gg.agit.konect.support.IntegrationTestSupport;
+
+class GoogleDriveOAuthControllerTest extends IntegrationTestSupport {
+
+    @MockitoBean
+    private GoogleDriveOAuthService googleDriveOAuthService;
+
+    private static final Integer USER_ID = 100;
+    private static final String AUTHORIZATION_URL =
+        "https://accounts.google.com/o/oauth2/v2/auth?client_id=test-client&state=test-state";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockLoginUser(USER_ID);
+    }
+
+    @Nested
+    @DisplayName("GET /auth/oauth/google/drive/authorize-url - Google Drive 권한 연결 URL 조회")
+    class GetAuthorizationUrl {
+
+        @Test
+        @DisplayName("로그인 사용자의 authorize URL을 JSON으로 반환한다")
+        void getAuthorizationUrl() throws Exception {
+            given(googleDriveOAuthService.buildAuthorizationUrl(eq(USER_ID)))
+                .willReturn(AUTHORIZATION_URL);
+
+            performGet("/auth/oauth/google/drive/authorize-url")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authorizationUrl").value(AUTHORIZATION_URL));
+        }
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* Google Drive 권한 재연결 흐름에서 프론트가 바로 사용할 수 있도록 authorize URL을 JSON으로 내려주는 백엔드 API를 추가했습니다.


---

### 🚀 주요 변경 내용

* `GoogleDriveOAuthController`에 `GET /auth/oauth/google/drive/authorize-url` 엔드포인트를 추가해 로그인 사용자의 Google Drive authorize URL을 JSON으로 반환하도록 구현했습니다.
* `GoogleDriveAuthorizationUrlResponse` DTO를 추가해 프론트가 `authorizationUrl` 필드를 그대로 사용해 브라우저 이동할 수 있게 했습니다.
* `GoogleDriveOAuthControllerTest`를 추가해 새 엔드포인트가 로그인 사용자 기준 authorize URL을 정상 반환하는지 검증했습니다.


---

### 💬 참고 사항

* 기존 `GET /auth/oauth/google/drive/authorize`의 302 redirect 방식은 그대로 유지했습니다.
* 프론트는 새 엔드포인트 호출 후 응답의 `authorizationUrl`로 `window.location` 이동만 해주면 됩니다.
* 검증은 `./gradlew.bat test --tests "gg.agit.konect.integration.infrastructure.oauth.GoogleDriveOAuthControllerTest"`로 확인했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)