### PR TITLE
fix: Sheet API 요청자 접근 권한 검증 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedService.java
@@ -23,8 +23,12 @@ public class ClubSheetIntegratedService {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
-        // OAuth 미연결이면 건너뛰고 계속 진행한다. Drive 초기화/인증 오류는 예외로 전파한다.
-        googleSheetPermissionService.tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+        // OAuth 미연결이면 기존 동작대로 검증을 건너뛴다.
+        // 다만 Drive OAuth가 연결된 경우에는 요청자 계정의 실제 시트 접근 권한을 먼저 검증한다.
+        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+            requesterId,
+            spreadsheetId
+        );
 
         SheetHeaderMapper.SheetAnalysisResult analysis =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedService.java
@@ -23,8 +23,8 @@ public class ClubSheetIntegratedService {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
-        // OAuth 미연결이면 기존 동작대로 검증을 건너뛴다.
-        // 다만 Drive OAuth가 연결된 경우에는 요청자 계정의 실제 시트 접근 권한을 먼저 검증한다.
+        // integrated 등록은 요청자 Google Drive OAuth 연결을 전제로 한다.
+        // 연결된 계정이 실제 시트 접근 권한을 가지는지 검증한 뒤 서비스 계정 권한을 맞춘다.
         googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
             requesterId,
             spreadsheetId

--- a/src/main/java/gg/agit/konect/domain/club/service/GoogleDrivePermissionHelper.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/GoogleDrivePermissionHelper.java
@@ -94,7 +94,8 @@ final class GoogleDrivePermissionHelper {
 
         do {
             Drive.Permissions.List request = driveService.permissions().list(fileId)
-                .setFields(PERMISSION_FIELDS);
+                .setFields(PERMISSION_FIELDS)
+                .setSupportsAllDrives(true);
             if (nextPageToken != null) {
                 request.setPageToken(nextPageToken);
             }
@@ -142,6 +143,7 @@ final class GoogleDrivePermissionHelper {
 
             userDriveService.permissions().create(fileId, permission)
                 .setSendNotificationEmail(false)
+                .setSupportsAllDrives(true)
                 .execute();
             log.info(
                 "Service account {} access granted. fileId={}, email={}",
@@ -165,6 +167,7 @@ final class GoogleDrivePermissionHelper {
 
         Permission updatedPermission = new Permission().setRole(targetRole);
         userDriveService.permissions().update(fileId, existingPermission.getId(), updatedPermission)
+            .setSupportsAllDrives(true)
             .execute();
         log.info(
             "Service account permission upgraded. fileId={}, fromRole={}, toRole={}, email={}",

--- a/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.model.File;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 
 import gg.agit.konect.domain.user.enums.Provider;
@@ -26,6 +27,30 @@ public class GoogleSheetPermissionService {
     private final GoogleSheetsConfig googleSheetsConfig;
     private final UserOAuthAccountRepository userOAuthAccountRepository;
 
+    public void validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+        Integer requesterId,
+        String spreadsheetId
+    ) {
+        String refreshToken = userOAuthAccountRepository
+            .findByUserIdAndProvider(requesterId, Provider.GOOGLE)
+            .map(account -> account.getGoogleDriveRefreshToken())
+            .filter(StringUtils::hasText)
+            .orElse(null);
+
+        if (refreshToken == null) {
+            log.warn(
+                "Skipping requester Drive access validation because Google Drive OAuth is not connected. "
+                    + "requesterId={}",
+                requesterId
+            );
+            return;
+        }
+
+        Drive userDriveService = buildUserDriveService(refreshToken, requesterId);
+        validateRequesterSpreadsheetAccess(userDriveService, requesterId, spreadsheetId);
+        tryGrantServiceAccountWriterAccess(userDriveService, requesterId, spreadsheetId);
+    }
+
     public boolean tryGrantServiceAccountWriterAccess(Integer requesterId, String spreadsheetId) {
         String refreshToken = userOAuthAccountRepository
             .findByUserIdAndProvider(requesterId, Provider.GOOGLE)
@@ -41,14 +66,15 @@ public class GoogleSheetPermissionService {
             return false;
         }
 
-        Drive userDriveService;
-        try {
-            userDriveService = googleSheetsConfig.buildUserDriveService(refreshToken);
-        } catch (IOException | GeneralSecurityException e) {
-            log.error("Failed to build user Drive service. requesterId={}", requesterId, e);
-            throw CustomException.of(ApiResponseCode.FAILED_INIT_GOOGLE_DRIVE);
-        }
+        Drive userDriveService = buildUserDriveService(refreshToken, requesterId);
+        return tryGrantServiceAccountWriterAccess(userDriveService, requesterId, spreadsheetId);
+    }
 
+    private boolean tryGrantServiceAccountWriterAccess(
+        Drive userDriveService,
+        Integer requesterId,
+        String spreadsheetId
+    ) {
         try {
             GoogleDrivePermissionHelper.ensureServiceAccountPermission(
                 userDriveService,
@@ -83,6 +109,61 @@ public class GoogleSheetPermissionService {
 
             log.error(
                 "Unexpected error while auto-sharing spreadsheet. requesterId={}, spreadsheetId={}",
+                requesterId,
+                spreadsheetId,
+                e
+            );
+            throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
+        }
+    }
+
+    private Drive buildUserDriveService(String refreshToken, Integer requesterId) {
+        try {
+            return googleSheetsConfig.buildUserDriveService(refreshToken);
+        } catch (IOException | GeneralSecurityException e) {
+            log.error("Failed to build user Drive service. requesterId={}", requesterId, e);
+            throw CustomException.of(ApiResponseCode.FAILED_INIT_GOOGLE_DRIVE);
+        }
+    }
+
+    private void validateRequesterSpreadsheetAccess(
+        Drive userDriveService,
+        Integer requesterId,
+        String spreadsheetId
+    ) {
+        try {
+            File file = userDriveService.files().get(spreadsheetId)
+                .setFields("id")
+                .execute();
+            if (file == null || !StringUtils.hasText(file.getId())) {
+                throw GoogleSheetApiExceptionHelper.accessDenied();
+            }
+        } catch (IOException e) {
+            if (GoogleSheetApiExceptionHelper.isInvalidGrant(e)) {
+                log.warn(
+                    "Google Drive OAuth token is invalid while validating spreadsheet access. requesterId={}, "
+                        + "spreadsheetId={}, cause={}",
+                    requesterId,
+                    spreadsheetId,
+                    GoogleSheetApiExceptionHelper.extractDetail(e)
+                );
+                throw GoogleSheetApiExceptionHelper.invalidGoogleDriveAuth(e);
+            }
+
+            if (GoogleSheetApiExceptionHelper.isAccessDenied(e)
+                || GoogleSheetApiExceptionHelper.isAuthFailure(e)
+                || GoogleSheetApiExceptionHelper.isNotFound(e)) {
+                log.warn(
+                    "Requester has no spreadsheet access. requesterId={}, spreadsheetId={}, cause={}",
+                    requesterId,
+                    spreadsheetId,
+                    e.getMessage()
+                );
+                throw GoogleSheetApiExceptionHelper.accessDenied();
+            }
+
+            log.error(
+                "Unexpected error while validating requester spreadsheet access. requesterId={}, spreadsheetId={}",
                 requesterId,
                 spreadsheetId,
                 e

--- a/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
@@ -32,21 +32,7 @@ public class GoogleSheetPermissionService {
         Integer requesterId,
         String spreadsheetId
     ) {
-        String refreshToken = userOAuthAccountRepository
-            .findByUserIdAndProvider(requesterId, Provider.GOOGLE)
-            .map(account -> account.getGoogleDriveRefreshToken())
-            .filter(StringUtils::hasText)
-            .orElse(null);
-
-        if (refreshToken == null) {
-            log.warn(
-                "Skipping requester Drive access validation because Google Drive OAuth is not connected. "
-                    + "requesterId={}",
-                requesterId
-            );
-            return;
-        }
-
+        String refreshToken = requireRefreshToken(requesterId);
         Drive userDriveService = buildUserDriveService(refreshToken, requesterId);
         validateRequesterSpreadsheetAccess(userDriveService, requesterId, spreadsheetId);
         boolean granted = tryGrantServiceAccountWriterAccess(userDriveService, requesterId, spreadsheetId);
@@ -56,11 +42,7 @@ public class GoogleSheetPermissionService {
     }
 
     public boolean tryGrantServiceAccountWriterAccess(Integer requesterId, String spreadsheetId) {
-        String refreshToken = userOAuthAccountRepository
-            .findByUserIdAndProvider(requesterId, Provider.GOOGLE)
-            .map(account -> account.getGoogleDriveRefreshToken())
-            .filter(StringUtils::hasText)
-            .orElse(null);
+        String refreshToken = resolveRefreshToken(requesterId);
 
         if (refreshToken == null) {
             log.warn(
@@ -72,6 +54,26 @@ public class GoogleSheetPermissionService {
 
         Drive userDriveService = buildUserDriveService(refreshToken, requesterId);
         return tryGrantServiceAccountWriterAccess(userDriveService, requesterId, spreadsheetId);
+    }
+
+    private String requireRefreshToken(Integer requesterId) {
+        return userOAuthAccountRepository.findByUserIdAndProvider(requesterId, Provider.GOOGLE)
+            .map(account -> account.getGoogleDriveRefreshToken())
+            .filter(StringUtils::hasText)
+            .orElseThrow(() -> {
+                log.warn(
+                    "Rejecting spreadsheet registration because Google Drive OAuth is not connected. requesterId={}",
+                    requesterId
+                );
+                return CustomException.of(ApiResponseCode.NOT_FOUND_GOOGLE_DRIVE_AUTH);
+            });
+    }
+
+    private String resolveRefreshToken(Integer requesterId) {
+        return userOAuthAccountRepository.findByUserIdAndProvider(requesterId, Provider.GOOGLE)
+            .map(account -> account.getGoogleDriveRefreshToken())
+            .filter(StringUtils::hasText)
+            .orElse(null);
     }
 
     private boolean tryGrantServiceAccountWriterAccess(

--- a/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GoogleSheetPermissionService {
 
     private final ServiceAccountCredentials serviceAccountCredentials;
+    private final Drive googleDriveService;
     private final GoogleSheetsConfig googleSheetsConfig;
     private final UserOAuthAccountRepository userOAuthAccountRepository;
 
@@ -48,7 +49,10 @@ public class GoogleSheetPermissionService {
 
         Drive userDriveService = buildUserDriveService(refreshToken, requesterId);
         validateRequesterSpreadsheetAccess(userDriveService, requesterId, spreadsheetId);
-        tryGrantServiceAccountWriterAccess(userDriveService, requesterId, spreadsheetId);
+        boolean granted = tryGrantServiceAccountWriterAccess(userDriveService, requesterId, spreadsheetId);
+        if (!granted) {
+            requireServiceAccountSpreadsheetAccess(spreadsheetId, requesterId);
+        }
     }
 
     public boolean tryGrantServiceAccountWriterAccess(Integer requesterId, String spreadsheetId) {
@@ -175,6 +179,39 @@ public class GoogleSheetPermissionService {
 
             log.error(
                 "Unexpected error while validating requester spreadsheet access. requesterId={}, spreadsheetId={}",
+                requesterId,
+                spreadsheetId,
+                e
+            );
+            throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
+        }
+    }
+
+    private void requireServiceAccountSpreadsheetAccess(String spreadsheetId, Integer requesterId) {
+        try {
+            File file = googleDriveService.files().get(spreadsheetId)
+                .setFields("id")
+                .setSupportsAllDrives(true)
+                .execute();
+            if (file == null || !StringUtils.hasText(file.getId())) {
+                throw GoogleSheetApiExceptionHelper.accessDenied();
+            }
+        } catch (IOException e) {
+            if (GoogleSheetApiExceptionHelper.isAccessDenied(e)
+                || GoogleSheetApiExceptionHelper.isNotFound(e)) {
+                log.warn(
+                    "Service account has no spreadsheet access after auto-share failed. requesterId={}, "
+                        + "spreadsheetId={}, cause={}",
+                    requesterId,
+                    spreadsheetId,
+                    e.getMessage()
+                );
+                throw GoogleSheetApiExceptionHelper.accessDenied();
+            }
+
+            log.error(
+                "Unexpected error while re-checking service account spreadsheet access. requesterId={}, "
+                    + "spreadsheetId={}",
                 requesterId,
                 spreadsheetId,
                 e

--- a/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
@@ -134,6 +134,7 @@ public class GoogleSheetPermissionService {
         try {
             File file = userDriveService.files().get(spreadsheetId)
                 .setFields("id")
+                .setSupportsAllDrives(true)
                 .execute();
             if (file == null || !StringUtils.hasText(file.getId())) {
                 throw GoogleSheetApiExceptionHelper.accessDenied();
@@ -150,8 +151,18 @@ public class GoogleSheetPermissionService {
                 throw GoogleSheetApiExceptionHelper.invalidGoogleDriveAuth(e);
             }
 
+            if (GoogleSheetApiExceptionHelper.isAuthFailure(e)) {
+                log.warn(
+                    "Google Drive OAuth auth failure while validating spreadsheet access. requesterId={}, "
+                        + "spreadsheetId={}, cause={}",
+                    requesterId,
+                    spreadsheetId,
+                    GoogleSheetApiExceptionHelper.extractDetail(e)
+                );
+                throw GoogleSheetApiExceptionHelper.invalidGoogleDriveAuth(e);
+            }
+
             if (GoogleSheetApiExceptionHelper.isAccessDenied(e)
-                || GoogleSheetApiExceptionHelper.isAuthFailure(e)
                 || GoogleSheetApiExceptionHelper.isNotFound(e)) {
                 log.warn(
                     "Requester has no spreadsheet access. requesterId={}, spreadsheetId={}, cause={}",

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
@@ -200,4 +200,28 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
             .isSameAs(expected);
         verifyNoInteractions(sheetHeaderMapper, clubMemberSheetService, sheetImportService);
     }
+
+    @Test
+    @DisplayName("Drive OAuth가 연결되지 않으면 후속 시트 작업을 진행하지 않는다")
+    void analyzeAndImportPreMembersStopsWhenGoogleDriveOAuthIsNotConnected() {
+        // given
+        Integer clubId = 1;
+        Integer requesterId = 2;
+        String spreadsheetUrl =
+            "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit";
+        String spreadsheetId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms";
+        CustomException expected = CustomException.of(ApiResponseCode.NOT_FOUND_GOOGLE_DRIVE_AUTH);
+
+        willThrow(expected).given(googleSheetPermissionService)
+            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+
+        // when & then
+        assertThatThrownBy(() -> clubSheetIntegratedService.analyzeAndImportPreMembers(
+            clubId,
+            requesterId,
+            spreadsheetUrl
+        ))
+            .isSameAs(expected);
+        verifyNoInteractions(sheetHeaderMapper, clubMemberSheetService, sheetImportService);
+    }
 }

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
@@ -3,6 +3,7 @@ package gg.agit.konect.domain.club.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -53,8 +54,6 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
             new SheetHeaderMapper.SheetAnalysisResult(SheetColumnMapping.defaultMapping(), null, null);
         SheetImportResponse expected = SheetImportResponse.of(3, 1, List.of("warn"));
 
-        given(googleSheetPermissionService.tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId))
-            .willReturn(true);
         given(sheetHeaderMapper.analyzeAllSheets(spreadsheetId)).willReturn(analysis);
         given(sheetImportService.importPreMembersFromSheet(
             clubId,
@@ -81,7 +80,7 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
         );
         inOrder.verify(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
         inOrder.verify(googleSheetPermissionService)
-            .tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
         inOrder.verify(sheetHeaderMapper).analyzeAllSheets(spreadsheetId);
         inOrder.verify(clubMemberSheetService).updateSheetId(
             clubId,
@@ -99,8 +98,8 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("자동 권한 부여가 실패해도 기존 공유 권한으로 가져오기를 계속 시도한다")
-    void analyzeAndImportPreMembersContinuesWhenAutoGrantFails() {
+    @DisplayName("Drive OAuth가 미연결된 경우 검증을 건너뛰고 기존 흐름으로 가져오기를 계속 시도한다")
+    void analyzeAndImportPreMembersContinuesWhenDriveOAuthIsNotConnected() {
         // given
         Integer clubId = 1;
         Integer requesterId = 2;
@@ -111,8 +110,6 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
             new SheetHeaderMapper.SheetAnalysisResult(SheetColumnMapping.defaultMapping(), null, null);
         SheetImportResponse expected = SheetImportResponse.of(1, 0, List.of());
 
-        given(googleSheetPermissionService.tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId))
-            .willReturn(false);
         given(sheetHeaderMapper.analyzeAllSheets(spreadsheetId)).willReturn(analysis);
         given(sheetImportService.importPreMembersFromSheet(
             clubId,
@@ -139,7 +136,7 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
         );
         inOrder.verify(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
         inOrder.verify(googleSheetPermissionService)
-            .tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
         inOrder.verify(sheetHeaderMapper).analyzeAllSheets(spreadsheetId);
         inOrder.verify(clubMemberSheetService).updateSheetId(
             clubId,
@@ -167,8 +164,32 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
         String spreadsheetId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms";
         CustomException expected = CustomException.of(ApiResponseCode.FAILED_INIT_GOOGLE_DRIVE);
 
-        given(googleSheetPermissionService.tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId))
-            .willThrow(expected);
+        willThrow(expected).given(googleSheetPermissionService)
+            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+
+        // when & then
+        assertThatThrownBy(() -> clubSheetIntegratedService.analyzeAndImportPreMembers(
+            clubId,
+            requesterId,
+            spreadsheetUrl
+        ))
+            .isSameAs(expected);
+        verifyNoInteractions(sheetHeaderMapper, clubMemberSheetService, sheetImportService);
+    }
+
+    @Test
+    @DisplayName("요청자 계정이 시트 접근 권한이 없으면 후속 시트 작업을 진행하지 않는다")
+    void analyzeAndImportPreMembersStopsWhenRequesterHasNoSpreadsheetAccess() {
+        // given
+        Integer clubId = 1;
+        Integer requesterId = 2;
+        String spreadsheetUrl =
+            "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit";
+        String spreadsheetId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms";
+        CustomException expected = CustomException.of(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS);
+
+        willThrow(expected).given(googleSheetPermissionService)
+            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
 
         // when & then
         assertThatThrownBy(() -> clubSheetIntegratedService.analyzeAndImportPreMembers(

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
@@ -98,62 +98,6 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("구글 시트 권한 검증 후에도 기존 흐름대로 사전 회원 가져오기를 수행한다")
-    void analyzeAndImportPreMembersContinuesAfterPermissionValidation() {
-        // given
-        Integer clubId = 1;
-        Integer requesterId = 2;
-        String spreadsheetUrl =
-            "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit";
-        String spreadsheetId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms";
-        SheetHeaderMapper.SheetAnalysisResult analysis =
-            new SheetHeaderMapper.SheetAnalysisResult(SheetColumnMapping.defaultMapping(), null, null);
-        SheetImportResponse expected = SheetImportResponse.of(1, 0, List.of());
-
-        given(sheetHeaderMapper.analyzeAllSheets(spreadsheetId)).willReturn(analysis);
-        given(sheetImportService.importPreMembersFromSheet(
-            clubId,
-            requesterId,
-            spreadsheetId,
-            analysis.memberListMapping()
-        ))
-            .willReturn(expected);
-
-        // when
-        SheetImportResponse actual = clubSheetIntegratedService.analyzeAndImportPreMembers(
-            clubId,
-            requesterId,
-            spreadsheetUrl
-        );
-
-        // then
-        InOrder inOrder = inOrder(
-            clubPermissionValidator,
-            googleSheetPermissionService,
-            sheetHeaderMapper,
-            clubMemberSheetService,
-            sheetImportService
-        );
-        inOrder.verify(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
-        inOrder.verify(googleSheetPermissionService)
-            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
-        inOrder.verify(sheetHeaderMapper).analyzeAllSheets(spreadsheetId);
-        inOrder.verify(clubMemberSheetService).updateSheetId(
-            clubId,
-            requesterId,
-            spreadsheetId,
-            analysis
-        );
-        inOrder.verify(sheetImportService).importPreMembersFromSheet(
-            clubId,
-            requesterId,
-            spreadsheetId,
-            analysis.memberListMapping()
-        );
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
     @DisplayName("자동 권한 부여 중 예외가 발생하면 후속 시트 작업을 진행하지 않는다")
     void analyzeAndImportPreMembersStopsWhenAutoGrantThrowsException() {
         // given

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
@@ -98,8 +98,8 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("Drive OAuth가 미연결된 경우 검증을 건너뛰고 기존 흐름으로 가져오기를 계속 시도한다")
-    void analyzeAndImportPreMembersContinuesWhenDriveOAuthIsNotConnected() {
+    @DisplayName("구글 시트 권한 검증 후에도 기존 흐름대로 사전 회원 가져오기를 수행한다")
+    void analyzeAndImportPreMembersContinuesAfterPermissionValidation() {
         // given
         Integer clubId = 1;
         Integer requesterId = 2;

--- a/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
@@ -16,9 +16,9 @@ import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import com.google.api.services.drive.Drive;
@@ -58,6 +58,9 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
     private Drive userDriveService;
 
     @Mock
+    private Drive googleDriveService;
+
+    @Mock
     private Drive.Permissions permissions;
 
     @Mock
@@ -78,8 +81,23 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
     @Mock
     private Drive.Files.Get getFileRequest;
 
-    @InjectMocks
+    @Mock
+    private Drive.Files serviceAccountFiles;
+
+    @Mock
+    private Drive.Files.Get serviceAccountGetFileRequest;
+
     private GoogleSheetPermissionService googleSheetPermissionService;
+
+    @BeforeEach
+    void setUpGoogleSheetPermissionService() {
+        googleSheetPermissionService = new GoogleSheetPermissionService(
+            serviceAccountCredentials,
+            googleDriveService,
+            googleSheetsConfig,
+            userOAuthAccountRepository
+        );
+    }
 
     @Test
     @DisplayName("returns false when the requester has no Google Drive OAuth account")
@@ -316,6 +334,67 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
 
         verify(files).get(FILE_ID);
         verify(permissions, never()).create(eq(FILE_ID), any(Permission.class));
+    }
+
+    @Test
+    @DisplayName("서비스 계정 권한 부여가 실패해도 이미 접근 가능하면 가져오기를 계속 허용한다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessContinuesWhenServiceAccountAlreadyHasAccess()
+        throws IOException, GeneralSecurityException {
+        mockConnectedDriveAccount();
+        given(userDriveService.files()).willReturn(files);
+        given(files.get(FILE_ID)).willReturn(getFileRequest);
+        given(getFileRequest.setFields("id")).willReturn(getFileRequest);
+        given(getFileRequest.setSupportsAllDrives(true)).willReturn(getFileRequest);
+        given(getFileRequest.execute()).willReturn(new File().setId(FILE_ID));
+        given(permissions.list(FILE_ID)).willReturn(listRequest);
+        given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
+            .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
+        given(listRequest.execute()).willThrow(googleException(403, "forbidden"));
+        given(googleDriveService.files()).willReturn(serviceAccountFiles);
+        given(serviceAccountFiles.get(FILE_ID)).willReturn(serviceAccountGetFileRequest);
+        given(serviceAccountGetFileRequest.setFields("id")).willReturn(serviceAccountGetFileRequest);
+        given(serviceAccountGetFileRequest.setSupportsAllDrives(true)).willReturn(serviceAccountGetFileRequest);
+        given(serviceAccountGetFileRequest.execute()).willReturn(new File().setId(FILE_ID));
+
+        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+            REQUESTER_ID,
+            FILE_ID
+        );
+
+        verify(serviceAccountFiles).get(FILE_ID);
+    }
+
+    @Test
+    @DisplayName("서비스 계정 권한 부여가 실패하고 실제 접근도 불가하면 forbidden 예외를 던진다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessThrowsWhenServiceAccountStillCannotAccess()
+        throws IOException, GeneralSecurityException {
+        mockConnectedDriveAccount();
+        given(userDriveService.files()).willReturn(files);
+        given(files.get(FILE_ID)).willReturn(getFileRequest);
+        given(getFileRequest.setFields("id")).willReturn(getFileRequest);
+        given(getFileRequest.setSupportsAllDrives(true)).willReturn(getFileRequest);
+        given(getFileRequest.execute()).willReturn(new File().setId(FILE_ID));
+        given(permissions.list(FILE_ID)).willReturn(listRequest);
+        given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
+            .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
+        given(listRequest.execute()).willThrow(googleException(403, "forbidden"));
+        given(googleDriveService.files()).willReturn(serviceAccountFiles);
+        given(serviceAccountFiles.get(FILE_ID)).willReturn(serviceAccountGetFileRequest);
+        given(serviceAccountGetFileRequest.setFields("id")).willReturn(serviceAccountGetFileRequest);
+        given(serviceAccountGetFileRequest.setSupportsAllDrives(true)).willReturn(serviceAccountGetFileRequest);
+        given(serviceAccountGetFileRequest.execute()).willThrow(googleException(404, "notFound"));
+
+        assertThatThrownBy(() ->
+            googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+                REQUESTER_ID,
+                FILE_ID
+            )
+        )
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS);
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
@@ -398,35 +398,43 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("Drive OAuth 계정이 없으면 요청자 접근 검증을 건너뛴다")
-    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessSkipsWhenOAuthAccountIsMissing()
+    @DisplayName("Drive OAuth 계정이 없으면 요청자 접근 검증을 거부한다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessThrowsWhenOAuthAccountIsMissing()
         throws IOException, GeneralSecurityException {
         given(userOAuthAccountRepository.findByUserIdAndProvider(REQUESTER_ID, Provider.GOOGLE))
             .willReturn(Optional.empty());
 
-        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
-            REQUESTER_ID,
-            FILE_ID
-        );
-
+        assertThatThrownBy(() ->
+            googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+                REQUESTER_ID,
+                FILE_ID
+            )
+        )
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ApiResponseCode.NOT_FOUND_GOOGLE_DRIVE_AUTH);
         verify(userDriveService, never()).files();
         verify(userDriveService, never()).permissions();
         verify(googleSheetsConfig, never()).buildUserDriveService(any());
     }
 
     @Test
-    @DisplayName("Drive OAuth refresh token이 비어 있으면 요청자 접근 검증을 건너뛴다")
-    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessSkipsWhenRefreshTokenIsBlank()
+    @DisplayName("Drive OAuth refresh token이 비어 있으면 요청자 접근 검증을 거부한다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessThrowsWhenRefreshTokenIsBlank()
         throws IOException, GeneralSecurityException {
         given(userOAuthAccountRepository.findByUserIdAndProvider(REQUESTER_ID, Provider.GOOGLE))
             .willReturn(Optional.of(userOAuthAccount));
         given(userOAuthAccount.getGoogleDriveRefreshToken()).willReturn("   ");
 
-        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
-            REQUESTER_ID,
-            FILE_ID
-        );
-
+        assertThatThrownBy(() ->
+            googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+                REQUESTER_ID,
+                FILE_ID
+            )
+        )
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ApiResponseCode.NOT_FOUND_GOOGLE_DRIVE_AUTH);
         verify(userDriveService, never()).files();
         verify(userDriveService, never()).permissions();
         verify(googleSheetsConfig, never()).buildUserDriveService(any());

--- a/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
@@ -93,6 +93,8 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         );
 
         assertThat(granted).isFalse();
+        verify(userDriveService, never()).files();
+        verify(userDriveService, never()).permissions();
     }
 
     @Test
@@ -103,6 +105,7 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(permissions.list(FILE_ID)).willReturn(listRequest);
         given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
         given(listRequest.execute()).willReturn(permissionList(permission("perm-1", "writer")));
 
         boolean granted = googleSheetPermissionService.tryGrantServiceAccountWriterAccess(
@@ -123,11 +126,13 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(permissions.list(FILE_ID)).willReturn(listRequest, nextPageListRequest);
         given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
         given(listRequest.execute()).willReturn(
             new PermissionList().setPermissions(List.of()).setNextPageToken("next-page")
         );
         given(nextPageListRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(nextPageListRequest);
+        given(nextPageListRequest.setSupportsAllDrives(true)).willReturn(nextPageListRequest);
         given(nextPageListRequest.setPageToken("next-page")).willReturn(nextPageListRequest);
         given(nextPageListRequest.execute()).willReturn(permissionList(permission("perm-1", "writer")));
 
@@ -152,15 +157,19 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(permissions.list(FILE_ID)).willReturn(initialListRequest, applyListRequest, recheckListRequest);
         given(initialListRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(initialListRequest);
+        given(initialListRequest.setSupportsAllDrives(true)).willReturn(initialListRequest);
         given(applyListRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(applyListRequest);
+        given(applyListRequest.setSupportsAllDrives(true)).willReturn(applyListRequest);
         given(recheckListRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(recheckListRequest);
+        given(recheckListRequest.setSupportsAllDrives(true)).willReturn(recheckListRequest);
         given(initialListRequest.execute()).willReturn(permissionList());
         given(applyListRequest.execute()).willReturn(permissionList());
         given(recheckListRequest.execute()).willReturn(permissionList(permission("perm-1", "writer")));
         given(permissions.create(eq(FILE_ID), any(Permission.class))).willReturn(createRequest);
         given(createRequest.setSendNotificationEmail(false)).willReturn(createRequest);
+        given(createRequest.setSupportsAllDrives(true)).willReturn(createRequest);
         given(createRequest.execute()).willThrow(new IOException("already granted"));
 
         boolean granted = googleSheetPermissionService.tryGrantServiceAccountWriterAccess(
@@ -180,8 +189,10 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(permissions.list(FILE_ID)).willReturn(listRequest);
         given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
         given(listRequest.execute()).willReturn(permissionList(permission("perm-x", "reader")));
         given(permissions.update(eq(FILE_ID), eq("perm-x"), any(Permission.class))).willReturn(updateRequest);
+        given(updateRequest.setSupportsAllDrives(true)).willReturn(updateRequest);
         given(updateRequest.execute()).willReturn(permission("perm-x", "writer"));
 
         boolean granted = googleSheetPermissionService.tryGrantServiceAccountWriterAccess(
@@ -201,6 +212,7 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(permissions.list(FILE_ID)).willReturn(listRequest);
         given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
         given(listRequest.execute()).willThrow(googleException(401, "authError"));
 
         boolean granted = googleSheetPermissionService.tryGrantServiceAccountWriterAccess(
@@ -219,6 +231,7 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(permissions.list(FILE_ID)).willReturn(listRequest);
         given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
         given(listRequest.execute()).willThrow(googleException(403, "forbidden"));
 
         boolean granted = googleSheetPermissionService.tryGrantServiceAccountWriterAccess(
@@ -237,6 +250,7 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(permissions.list(FILE_ID)).willReturn(listRequest);
         given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
         given(listRequest.execute()).willThrow(new IOException(
             "token refresh failed",
             httpResponseException(
@@ -265,6 +279,7 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(userDriveService.files()).willReturn(files);
         given(files.get(FILE_ID)).willReturn(getFileRequest);
         given(getFileRequest.setFields("id")).willReturn(getFileRequest);
+        given(getFileRequest.setSupportsAllDrives(true)).willReturn(getFileRequest);
         given(getFileRequest.execute()).willThrow(googleException(403, "forbidden"));
 
         assertThatThrownBy(() ->
@@ -286,10 +301,12 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
         given(userDriveService.files()).willReturn(files);
         given(files.get(FILE_ID)).willReturn(getFileRequest);
         given(getFileRequest.setFields("id")).willReturn(getFileRequest);
+        given(getFileRequest.setSupportsAllDrives(true)).willReturn(getFileRequest);
         given(getFileRequest.execute()).willReturn(new File().setId(FILE_ID));
         given(permissions.list(FILE_ID)).willReturn(listRequest);
         given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
             .willReturn(listRequest);
+        given(listRequest.setSupportsAllDrives(true)).willReturn(listRequest);
         given(listRequest.execute()).willReturn(permissionList(permission("perm-1", "writer")));
 
         googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
@@ -299,6 +316,66 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
 
         verify(files).get(FILE_ID);
         verify(permissions, never()).create(eq(FILE_ID), any(Permission.class));
+    }
+
+    @Test
+    @DisplayName("Drive OAuth 계정이 없으면 요청자 접근 검증을 건너뛴다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessSkipsWhenOAuthAccountIsMissing()
+        throws IOException, GeneralSecurityException {
+        given(userOAuthAccountRepository.findByUserIdAndProvider(REQUESTER_ID, Provider.GOOGLE))
+            .willReturn(Optional.empty());
+
+        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+            REQUESTER_ID,
+            FILE_ID
+        );
+
+        verify(userDriveService, never()).files();
+        verify(userDriveService, never()).permissions();
+        verify(googleSheetsConfig, never()).buildUserDriveService(any());
+    }
+
+    @Test
+    @DisplayName("Drive OAuth refresh token이 비어 있으면 요청자 접근 검증을 건너뛴다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessSkipsWhenRefreshTokenIsBlank()
+        throws IOException, GeneralSecurityException {
+        given(userOAuthAccountRepository.findByUserIdAndProvider(REQUESTER_ID, Provider.GOOGLE))
+            .willReturn(Optional.of(userOAuthAccount));
+        given(userOAuthAccount.getGoogleDriveRefreshToken()).willReturn("   ");
+
+        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+            REQUESTER_ID,
+            FILE_ID
+        );
+
+        verify(userDriveService, never()).files();
+        verify(userDriveService, never()).permissions();
+        verify(googleSheetsConfig, never()).buildUserDriveService(any());
+    }
+
+    @Test
+    @DisplayName("요청자 Drive 인증이 만료되면 invalid Google Drive auth 예외를 던진다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessThrowsWhenAuthFailureOccurs()
+        throws IOException, GeneralSecurityException {
+        given(userOAuthAccountRepository.findByUserIdAndProvider(REQUESTER_ID, Provider.GOOGLE))
+            .willReturn(Optional.of(userOAuthAccount));
+        given(userOAuthAccount.getGoogleDriveRefreshToken()).willReturn(REFRESH_TOKEN);
+        given(googleSheetsConfig.buildUserDriveService(REFRESH_TOKEN)).willReturn(userDriveService);
+        given(userDriveService.files()).willReturn(files);
+        given(files.get(FILE_ID)).willReturn(getFileRequest);
+        given(getFileRequest.setFields("id")).willReturn(getFileRequest);
+        given(getFileRequest.setSupportsAllDrives(true)).willReturn(getFileRequest);
+        given(getFileRequest.execute()).willThrow(googleException(401, "authError"));
+
+        assertThatThrownBy(() ->
+            googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+                REQUESTER_ID,
+                FILE_ID
+            )
+        )
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ApiResponseCode.INVALID_GOOGLE_DRIVE_AUTH);
     }
 
     private void mockConnectedDriveAccount() throws IOException, GeneralSecurityException {

--- a/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -21,6 +22,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.model.File;
 import com.google.api.services.drive.model.Permission;
 import com.google.api.services.drive.model.PermissionList;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -69,6 +71,12 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
 
     @Mock
     private Drive.Permissions.Update updateRequest;
+
+    @Mock
+    private Drive.Files files;
+
+    @Mock
+    private Drive.Files.Get getFileRequest;
 
     @InjectMocks
     private GoogleSheetPermissionService googleSheetPermissionService;
@@ -137,13 +145,20 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
     void tryGrantServiceAccountWriterAccessReturnsTrueAfterConcurrentGrant()
         throws IOException, GeneralSecurityException {
         mockConnectedDriveAccount();
-        given(permissions.list(FILE_ID)).willReturn(listRequest);
-        given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
-            .willReturn(listRequest);
-        given(listRequest.execute()).willReturn(
-            permissionList(),
-            permissionList(permission("perm-1", "writer"))
-        );
+        Drive.Permissions.List initialListRequest = mock(Drive.Permissions.List.class);
+        Drive.Permissions.List applyListRequest = mock(Drive.Permissions.List.class);
+        Drive.Permissions.List recheckListRequest = mock(Drive.Permissions.List.class);
+
+        given(permissions.list(FILE_ID)).willReturn(initialListRequest, applyListRequest, recheckListRequest);
+        given(initialListRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
+            .willReturn(initialListRequest);
+        given(applyListRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
+            .willReturn(applyListRequest);
+        given(recheckListRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
+            .willReturn(recheckListRequest);
+        given(initialListRequest.execute()).willReturn(permissionList());
+        given(applyListRequest.execute()).willReturn(permissionList());
+        given(recheckListRequest.execute()).willReturn(permissionList(permission("perm-1", "writer")));
         given(permissions.create(eq(FILE_ID), any(Permission.class))).willReturn(createRequest);
         given(createRequest.setSendNotificationEmail(false)).willReturn(createRequest);
         given(createRequest.execute()).willThrow(new IOException("already granted"));
@@ -237,6 +252,53 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
             .isInstanceOf(CustomException.class)
             .extracting("errorCode")
             .isEqualTo(ApiResponseCode.INVALID_GOOGLE_DRIVE_AUTH);
+    }
+
+    @Test
+    @DisplayName("요청자 계정이 시트 접근 권한이 없으면 forbidden 예외를 던진다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessThrowsWhenRequesterCannotAccessSpreadsheet()
+        throws IOException, GeneralSecurityException {
+        given(userOAuthAccountRepository.findByUserIdAndProvider(REQUESTER_ID, Provider.GOOGLE))
+            .willReturn(Optional.of(userOAuthAccount));
+        given(userOAuthAccount.getGoogleDriveRefreshToken()).willReturn(REFRESH_TOKEN);
+        given(googleSheetsConfig.buildUserDriveService(REFRESH_TOKEN)).willReturn(userDriveService);
+        given(userDriveService.files()).willReturn(files);
+        given(files.get(FILE_ID)).willReturn(getFileRequest);
+        given(getFileRequest.setFields("id")).willReturn(getFileRequest);
+        given(getFileRequest.execute()).willThrow(googleException(403, "forbidden"));
+
+        assertThatThrownBy(() ->
+            googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+                REQUESTER_ID,
+                FILE_ID
+            )
+        )
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS);
+    }
+
+    @Test
+    @DisplayName("요청자 계정이 시트에 접근 가능하면 서비스 계정 권한 부여까지 진행한다")
+    void validateRequesterAccessAndTryGrantServiceAccountWriterAccessSucceedsWhenRequesterCanAccessSpreadsheet()
+        throws IOException, GeneralSecurityException {
+        mockConnectedDriveAccount();
+        given(userDriveService.files()).willReturn(files);
+        given(files.get(FILE_ID)).willReturn(getFileRequest);
+        given(getFileRequest.setFields("id")).willReturn(getFileRequest);
+        given(getFileRequest.execute()).willReturn(new File().setId(FILE_ID));
+        given(permissions.list(FILE_ID)).willReturn(listRequest);
+        given(listRequest.setFields("nextPageToken,permissions(id,type,emailAddress,role)"))
+            .willReturn(listRequest);
+        given(listRequest.execute()).willReturn(permissionList(permission("perm-1", "writer")));
+
+        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
+            REQUESTER_ID,
+            FILE_ID
+        );
+
+        verify(files).get(FILE_ID);
+        verify(permissions, never()).create(eq(FILE_ID), any(Permission.class));
     }
 
     private void mockConnectedDriveAccount() throws IOException, GeneralSecurityException {


### PR DESCRIPTION
### 🔍 개요

* integrated 시트 등록 API가 로그인한 사용자의 Google 계정이 실제로 시트 접근 권한을 가지고 있는지 검증하지 않아, 서비스 계정만 접근 가능해도 등록이 성공하던 문제를 수정했습니다.
* 추가로 Drive OAuth가 연결되지 않은 상태에서 integrated 등록이 우회되지 않도록, Drive OAuth 미연결 시 즉시 재연결을 요구하도록 보완했습니다.


---

### 🚀 주요 변경 내용

* `GoogleSheetPermissionService`에 요청자 Drive OAuth 기준 시트 접근 권한을 먼저 검증하는 로직을 추가했습니다.
* integrated 등록 흐름에서 Drive OAuth가 연결되지 않은 경우 `NOT_FOUND_GOOGLE_DRIVE_AUTH`로 즉시 실패하도록 변경했습니다.
* 서비스 계정 권한 부여가 실패한 경우, 서비스 계정의 실제 시트 접근 가능 여부를 재확인한 뒤 계속 진행 여부를 결정하도록 보완했습니다.
* 공유 드라이브 스프레드시트도 처리할 수 있도록 Drive API 호출에 `supportsAllDrives` 설정을 추가했습니다.
* 요청자 접근 불가, Drive OAuth 미연결, 서비스 계정 재검증, 권한 검증 후 후속 작업 중단 시나리오를 테스트로 보강했습니다.


---

### 💬 참고 사항

* 현재 integrated 시트 등록은 요청자 본인의 Google Drive OAuth 연결이 선행되어야 합니다.
* 기존 `tryGrantServiceAccountWriterAccess()` 메서드는 다른 호출 가능성을 고려해 유지하고 있으며, integrated 등록은 더 엄격한 `validateRequesterAccessAndTryGrantServiceAccountWriterAccess()` 흐름을 사용합니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)