### PR TITLE
fix: getChatRooms에서 GROUP 채팅방 누락 버그 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -268,7 +268,7 @@ public class ChatService {
             )
         );
 
-        return new ChatRoomsSummaryResponse(getAccessibleChatRooms(userId).rooms());
+        return new ChatRoomsSummaryResponse(rooms);
     }
 
     public ChatSearchResponse searchChats(Integer userId, String keyword, Integer page, Integer limit) {


### PR DESCRIPTION
### 🔍 개요

* 


---

### 🚀 주요 변경 내용

* `getAccessibleChatRooms()`는 `GROUP` 타입을 처리하지 않아 `GROUP` 채팅방이 조회되지 않았음

* 직접 구성한 `rooms` 리스트를 반환하도록 변경

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
