### PR TITLE
fix: 어드민 유저가 채팅방을 나가도 목록에 조회되는 문제 해결

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
@@ -172,6 +172,7 @@ public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
         JOIN User u ON u.id = crm.id.userId
         JOIN ChatRoomMember adminCrm ON adminCrm.id.chatRoomId = cr.id
             AND adminCrm.id.userId = :systemAdminId
+            AND adminCrm.leftAt IS NULL
         LEFT JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
             AND cm.sender.id <> :systemAdminId
             AND cm.createdAt > adminCrm.lastReadAt

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
@@ -170,14 +170,16 @@ public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
         FROM ChatRoom cr
         JOIN ChatRoomMember crm ON crm.id.chatRoomId = cr.id
         JOIN User u ON u.id = crm.id.userId
-        JOIN ChatRoomMember adminCrm ON adminCrm.id.chatRoomId = cr.id
-            AND adminCrm.id.userId = :systemAdminId
-            AND adminCrm.leftAt IS NULL
+        JOIN ChatRoomMember systemAdminCrm ON systemAdminCrm.id.chatRoomId = cr.id
+            AND systemAdminCrm.id.userId = :systemAdminId
+        LEFT JOIN ChatRoomMember viewerAdminCrm ON viewerAdminCrm.id.chatRoomId = cr.id
+            AND viewerAdminCrm.id.userId = :viewerAdminId
         LEFT JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
             AND cm.sender.id <> :systemAdminId
-            AND cm.createdAt > adminCrm.lastReadAt
+            AND cm.createdAt > systemAdminCrm.lastReadAt
         WHERE cr.roomType = :roomType
           AND u.role != :adminRole
+          AND (viewerAdminCrm.leftAt IS NULL OR viewerAdminCrm.id.userId IS NULL)
           AND EXISTS (
               SELECT 1 FROM ChatMessage userReply
               JOIN userReply.sender userSender
@@ -189,6 +191,7 @@ public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
         """)
     List<AdminChatRoomProjection> findAdminChatRoomsOptimized(
         @Param("systemAdminId") Integer systemAdminId,
+        @Param("viewerAdminId") Integer viewerAdminId,
         @Param("adminRole") UserRole adminRole,
         @Param("roomType") ChatType roomType
     );

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -482,7 +482,7 @@ public class ChatService {
         User user = userRepository.getById(userId);
 
         if (user.getRole() == UserRole.ADMIN) {
-            return getAdminDirectChatRooms();
+            return getAdminDirectChatRooms(userId);
         }
 
         List<ChatRoomSummaryResponse> roomSummaries = new ArrayList<>();
@@ -525,9 +525,9 @@ public class ChatService {
         return roomSummaries;
     }
 
-    private List<ChatRoomSummaryResponse> getAdminDirectChatRooms() {
+    private List<ChatRoomSummaryResponse> getAdminDirectChatRooms(Integer adminUserId) {
         List<AdminChatRoomProjection> projections = chatRoomRepository.findAdminChatRoomsOptimized(
-            SYSTEM_ADMIN_ID, UserRole.ADMIN, ChatType.DIRECT
+            SYSTEM_ADMIN_ID, adminUserId, UserRole.ADMIN, ChatType.DIRECT
         );
 
         return projections.stream()


### PR DESCRIPTION
### 🔍 개요

* ADMIN 권한을 가진 유저가 DIRECT 채팅방을 나가도, 해당 채팅방이 목록에서 계속 보이는 버그를 수정합니다.


---

### 🚀 주요 변경 내용

* **ChatService.java**
  - `getAdminDirectChatRooms()` 메서드에 `adminUserId` 파라미터 추가
  - 현재 조회하는 관리자의 ID를 Repository에 전달하도록 변경

* **ChatRoomRepository.java**
  - `findAdminChatRoomsOptimized` 쿼리 수정
  - `viewerAdminCrm`을 LEFT JOIN으로 추가하여 현재 조회하는 관리자의 멤버십 상태 확인
  - WHERE 절에 `(viewerAdminCrm.leftAt IS NULL OR viewerAdminCrm.id.userId IS NULL)` 조건 추가
  - 각 운영자가 독립적으로 채팅방을 나갈 수 있도록 지원

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
