### PR TITLE
fix: 동아리 지원 거절 알림을 AFTER_COMMIT 이벤트 기반으로 변경 

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/event/ClubApplicationRejectedEvent.java
+++ b/src/main/java/gg/agit/konect/domain/club/event/ClubApplicationRejectedEvent.java
@@ -1,0 +1,11 @@
+package gg.agit.konect.domain.club.event;
+
+public record ClubApplicationRejectedEvent(
+    Integer receiverId,
+    Integer clubId,
+    String clubName
+) {
+    public static ClubApplicationRejectedEvent of(Integer receiverId, Integer clubId, String clubName) {
+        return new ClubApplicationRejectedEvent(receiverId, clubId, clubName);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
@@ -32,6 +32,7 @@ import gg.agit.konect.domain.club.dto.ClubApplyRequest;
 import gg.agit.konect.domain.club.dto.ClubFeeInfoReplaceRequest;
 import gg.agit.konect.domain.club.dto.ClubFeeInfoResponse;
 import gg.agit.konect.domain.club.event.ClubApplicationApprovedEvent;
+import gg.agit.konect.domain.club.event.ClubApplicationRejectedEvent;
 import gg.agit.konect.domain.club.event.ClubApplicationSubmittedEvent;
 import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.ClubApply;
@@ -69,7 +70,6 @@ public class ClubApplicationService {
     private final BankRepository bankRepository;
     private final ClubPermissionValidator clubPermissionValidator;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final NotificationService notificationService;
     private final ChatRoomMembershipService chatRoomMembershipService;
 
     public ClubAppliedClubsResponse getAppliedClubs(Integer userId) {
@@ -265,11 +265,11 @@ public class ClubApplicationService {
         User applicant = clubApply.getUser();
         clubApply.reject();
 
-        notificationService.sendClubApplicationRejectedNotification(
+        applicationEventPublisher.publishEvent(ClubApplicationRejectedEvent.of(
             applicant.getId(),
             clubId,
             club.getName()
-        );
+        ));
     }
 
     @Transactional

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
@@ -3,6 +3,7 @@ package gg.agit.konect.domain.club.service;
 import static gg.agit.konect.domain.club.enums.ClubPosition.MEMBER;
 
 import gg.agit.konect.domain.club.enums.ClubPosition;
+
 import static gg.agit.konect.global.code.ApiResponseCode.*;
 
 import java.time.LocalDateTime;
@@ -48,7 +49,6 @@ import gg.agit.konect.domain.club.repository.ClubApplyRepository;
 import gg.agit.konect.domain.club.repository.ClubMemberRepository;
 import gg.agit.konect.domain.club.repository.ClubRecruitmentRepository;
 import gg.agit.konect.domain.club.repository.ClubRepository;
-import gg.agit.konect.domain.notification.service.NotificationService;
 import gg.agit.konect.domain.user.model.User;
 import gg.agit.konect.domain.user.repository.UserRepository;
 import gg.agit.konect.global.exception.CustomException;

--- a/src/main/java/gg/agit/konect/domain/notification/listener/ClubApplicationNotificationListener.java
+++ b/src/main/java/gg/agit/konect/domain/notification/listener/ClubApplicationNotificationListener.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import gg.agit.konect.domain.club.event.ClubApplicationApprovedEvent;
+import gg.agit.konect.domain.club.event.ClubApplicationRejectedEvent;
 import gg.agit.konect.domain.club.event.ClubApplicationSubmittedEvent;
 import gg.agit.konect.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,15 @@ public class ClubApplicationNotificationListener {
                 event.clubName(),
                 event.applicantName()
             )
+        );
+    }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleClubApplicationRejected(ClubApplicationRejectedEvent event) {
+        notificationService.sendClubApplicationRejectedNotification(
+            event.receiverId(),
+            event.clubId(),
+            event.clubName()
         );
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 동아리 지원 거절 시 알림이 트랜잭션 커밋 전에 발송되어, 트랜잭션 롤백 시에도 사용자에게 잘못된 상태(거절됨)가 전달될 수 있는 문제를 해결합니다.


---

### 🚀 주요 변경 내용

  ## 문제 상황 (AS-IS)
  - `rejectClubApplication()`에서 `notificationService.sendClubApplicationRejectedNotification()`를 직접 호출
  - 해당 메서드는 `@Async @Transactional`로 외부 트랜잭션과 분리되어 실행
  - 원 트랜잭션이 커밋 실패해도 알림은 이미 발송되어 사용자에게 잘못된 최종 상태가 노출됨

  ## 해결 방안 (TO-BE)
  - 승인(approve)/제출(submit)과 동일하게 `@TransactionalEventListener(AFTER_COMMIT)` 패턴 적용
  - `ClubApplicationRejectedEvent` 신규 도메인 이벤트 생성
  - 트랜잭션 커밋 성공 후에만 알림 발송 보장


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
