### PR TITLE
fix: 어드민 계정으로도 부원 직책 변경할 수 있도록 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -54,9 +54,10 @@ public class ClubMemberManagementService {
 
         validateNotSelf(requesterId, targetUserId, CANNOT_CHANGE_OWN_POSITION);
 
-        clubPermissionValidator.validateLeaderAccess(clubId, requesterId);
+        User requesterUser = userRepository.getById(requesterId);
+        clubPermissionValidator.validateLeaderAccess(clubId, requesterUser);
 
-        boolean isAdminRequester = userRepository.getById(requesterId).isAdmin();
+        boolean isAdminRequester = requesterUser.isAdmin();
         ClubMember target = clubMemberRepository.getByClubIdAndUserId(clubId, targetUserId);
 
         ClubPosition newPosition = request.position();

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -56,17 +56,21 @@ public class ClubMemberManagementService {
 
         clubPermissionValidator.validateLeaderAccess(clubId, requesterId);
 
-        ClubMember requester = clubMemberRepository.getByClubIdAndUserId(clubId, requesterId);
+        boolean isAdminRequester = userRepository.getById(requesterId).isAdmin();
         ClubMember target = clubMemberRepository.getByClubIdAndUserId(clubId, targetUserId);
-
-        if (!requester.canManage(target)) {
-            throw CustomException.of(CANNOT_MANAGE_HIGHER_POSITION);
-        }
 
         ClubPosition newPosition = request.position();
 
-        if (!requester.getClubPosition().canManage(newPosition)) {
-            throw CustomException.of(FORBIDDEN_MEMBER_POSITION_CHANGE);
+        if (!isAdminRequester) {
+            ClubMember requester = clubMemberRepository.getByClubIdAndUserId(clubId, requesterId);
+
+            if (!requester.canManage(target)) {
+                throw CustomException.of(CANNOT_MANAGE_HIGHER_POSITION);
+            }
+
+            if (!requester.getClubPosition().canManage(newPosition)) {
+                throw CustomException.of(FORBIDDEN_MEMBER_POSITION_CHANGE);
+            }
         }
 
         validatePositionLimit(clubId, newPosition, target);

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubPermissionValidator.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubPermissionValidator.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import gg.agit.konect.domain.club.enums.ClubPosition;
 import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.user.model.User;
 import gg.agit.konect.domain.user.repository.UserRepository;
 import gg.agit.konect.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,13 @@ public class ClubPermissionValidator {
     }
 
     public void validateLeaderAccess(Integer clubId, Integer userId) {
-        if (isAdmin(userId)) {
+        validateLeaderAccess(clubId, userRepository.getById(userId));
+    }
+
+    public void validateLeaderAccess(Integer clubId, User user) {
+        Integer userId = user.getId();
+
+        if (user.isAdmin()) {
             return ;
         }
 

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
@@ -38,6 +38,7 @@ class ClubMemberApiTest extends IntegrationTestSupport {
     private User vicePresident;
     private User manager;
     private User member;
+    private User admin;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -47,6 +48,7 @@ class ClubMemberApiTest extends IntegrationTestSupport {
         vicePresident = persist(UserFixture.createUser(university, "부회장", "2020000002"));
         manager = persist(UserFixture.createUser(university, "매니저", "2020000003"));
         member = persist(UserFixture.createUser(university, "일반멤버", "2021136001"));
+        admin = persist(UserFixture.createAdmin(university));
 
         persist(ClubMemberFixture.createPresident(club, president));
         persist(ClubMemberFixture.createVicePresident(club, vicePresident));
@@ -64,6 +66,21 @@ class ClubMemberApiTest extends IntegrationTestSupport {
             // given
             clearPersistenceContext();
             mockLoginUser(president.getId());
+
+            MemberPositionChangeRequest request = new MemberPositionChangeRequest(ClubPosition.MANAGER);
+
+            // when & then
+            performPatch("/clubs/" + club.getId() + "/members/" + member.getId() + "/position", request)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.position").value("MANAGER"));
+        }
+
+        @Test
+        @DisplayName("관리자는 동아리 회원이 아니어도 멤버 직책을 변경할 수 있다")
+        void adminCanChangeMemberPositionWithoutClubMembership() throws Exception {
+            // given
+            clearPersistenceContext();
+            mockLoginUser(admin.getId());
 
             MemberPositionChangeRequest request = new MemberPositionChangeRequest(ClubPosition.MANAGER);
 


### PR DESCRIPTION
### 🔍 개요

* 관리자 계정이 동아리 소속 `club_member`가 아니어도 부원 직책 변경 API를 정상 호출할 수 있도록 수정했습니다.

---

### 🚀 주요 변경 내용

* `ClubMemberManagementService`에서 관리자 요청자는 `club_member` requester 조회와 리더 전용 직급 비교를 건너뛰도록 분기했습니다.
* 기존의 대상 부원 조회와 직책 수 제한 검증은 그대로 유지했습니다.

---

### 💬 참고 사항


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)
