### PR TITLE
refactor: 동아리 채팅방 멤버십 Lazy 생성으로 변경

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -4,12 +4,8 @@ import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACC
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
@@ -62,50 +58,6 @@ public class ChatRoomMembershipService {
     public void removeClubMember(Integer clubId, Integer userId) {
         chatRoomRepository.findByClubId(clubId)
             .ifPresent(room -> chatRoomMemberRepository.deleteByChatRoomIdAndUserId(room.getId(), userId));
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void ensureClubRoomMemberships(Integer userId) {
-        List<ClubMember> memberships = clubMemberRepository.findAllByUserId(userId);
-        if (memberships.isEmpty()) {
-            return;
-        }
-
-        Map<Integer, ClubMember> membershipByClubId = memberships.stream()
-            .collect(Collectors.toMap(cm -> cm.getClub().getId(), cm -> cm, (a, b) -> a));
-
-        List<ChatRoom> rooms = resolveOrCreateClubRooms(memberships).stream()
-            .sorted(Comparator.comparing(ChatRoom::getId))
-            .toList();
-        List<Integer> roomIds = rooms.stream().map(ChatRoom::getId).toList();
-        if (roomIds.isEmpty()) {
-            return;
-        }
-
-        Map<Integer, ChatRoomMember> memberByRoomId = chatRoomMemberRepository
-            .findByChatRoomIdsAndUserId(roomIds, userId)
-            .stream()
-            .collect(Collectors.toMap(ChatRoomMember::getChatRoomId, member -> member, (a, b) -> a));
-
-        for (ChatRoom room : rooms) {
-            ClubMember member = membershipByClubId.get(room.getClub().getId());
-            if (member == null) {
-                continue;
-            }
-
-            ChatRoomMember existingMember = memberByRoomId.get(room.getId());
-            if (existingMember != null) {
-                LocalDateTime lastReadAt = existingMember.getLastReadAt();
-                if (lastReadAt == null || lastReadAt.isBefore(member.getCreatedAt())) {
-                    chatRoomMemberRepository.updateLastReadAtIfOlder(
-                        room.getId(), userId, member.getCreatedAt()
-                    );
-                }
-                continue;
-            }
-
-            saveRoomMemberIgnoringDuplicate(room, member.getUser(), member.getCreatedAt());
-        }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -164,39 +116,6 @@ public class ChatRoomMembershipService {
                         .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
                 }
             });
-    }
-
-    private List<ChatRoom> resolveOrCreateClubRooms(List<ClubMember> memberships) {
-        Map<Integer, Club> clubById = memberships.stream()
-            .map(ClubMember::getClub)
-            .collect(Collectors.toMap(Club::getId, club -> club, (a, b) -> a));
-
-        Map<Integer, ChatRoom> roomByClubId = chatRoomRepository.findByClubIds(new ArrayList<>(clubById.keySet()))
-            .stream()
-            .filter(room -> room.getClub() != null)
-            .collect(Collectors.toMap(room -> room.getClub().getId(), room -> room, (a, b) -> a));
-
-        for (Map.Entry<Integer, Club> clubEntry : clubById.entrySet()) {
-            if (roomByClubId.containsKey(clubEntry.getKey())) {
-                continue;
-            }
-            try {
-                ChatRoom createdRoom = chatRoomRepository.save(ChatRoom.clubGroupOf(clubEntry.getValue()));
-                roomByClubId.put(clubEntry.getKey(), createdRoom);
-            } catch (DataIntegrityViolationException e) {
-                if (!isDuplicateKeyException(e)) {
-                    throw e;
-                }
-                log.debug("클럽 채팅방 동시 생성 감지, 재조회: clubId={}", clubEntry.getKey());
-                chatRoomRepository.findByClubId(clubEntry.getKey())
-                    .ifPresent(room -> roomByClubId.put(clubEntry.getKey(), room));
-            }
-        }
-
-        return memberships.stream()
-            .map(membership -> roomByClubId.get(membership.getClub().getId()))
-            .filter(Objects::nonNull)
-            .toList();
     }
 
     private void ensureMember(ChatRoom room, User user, LocalDateTime baseline) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -209,8 +209,6 @@ public class ChatService {
     }
 
     public ChatRoomsSummaryResponse getChatRooms(Integer userId) {
-        chatRoomMembershipService.ensureClubRoomMemberships(userId);
-
         List<ChatRoomSummaryResponse> directRooms = getDirectChatRooms(userId);
         List<ChatRoomSummaryResponse> clubRooms = getClubChatRooms(userId);
         List<ChatRoomSummaryResponse> groupRooms = getGroupChatRooms(userId);
@@ -866,8 +864,6 @@ public class ChatService {
     }
 
     private AccessibleChatRooms getAccessibleChatRooms(Integer userId) {
-        chatRoomMembershipService.ensureClubRoomMemberships(userId);
-
         List<ChatRoomSummaryResponse> directRooms = getDirectChatRooms(userId);
         List<ChatRoomSummaryResponse> clubRooms = getClubChatRooms(userId);
 

--- a/src/main/resources/db/migration/V67__backfill_missing_chat_room_members.sql
+++ b/src/main/resources/db/migration/V67__backfill_missing_chat_room_members.sql
@@ -1,0 +1,23 @@
+-- 누락된 chat_room_member 데이터를 복구합니다.
+-- 과거 버그로 인해 club_member는 있지만 chat_room_member가 없는 경우를 복구합니다.
+-- last_read_at은 동아리 가입 시점(club_member.created_at)으로 설정합니다.
+
+INSERT INTO chat_room_member (
+    chat_room_id,
+    user_id,
+    last_read_at,
+    created_at,
+    updated_at
+)
+SELECT
+    cr.id AS chat_room_id,
+    cm.user_id AS user_id,
+    cm.created_at AS last_read_at,
+    NOW() AS created_at,
+    NOW() AS updated_at
+FROM club_member cm
+JOIN chat_room cr ON cr.club_id = cm.club_id
+LEFT JOIN chat_room_member crm
+    ON crm.chat_room_id = cr.id
+    AND crm.user_id = cm.user_id
+WHERE crm.chat_room_id IS NULL;


### PR DESCRIPTION
### 🔍 개요

* 


---

### 🚀 주요 변경 내용

#### 1. 커넥션 풀 점유 감소
- `ChatService.getChatRooms()`에서 `ensureClubRoomMemberships()` 호출 제거
- `ChatService.getAccessibleChatRooms()`에서 `ensureClubRoomMemberships()` 호출 제거
- 매 API 호출마다 실행되던 `REQUIRES_NEW` 트랜잭션 제거

#### 2. 불필요한 코드 제거
- `ChatRoomMembershipService.ensureClubRoomMemberships()` 메서드 제거
- `ChatRoomMembershipService.resolveOrCreateClubRooms()` private 메서드 제거
- 사용하지 않는 import 정리

#### 3. 데이터 정합성 복구
- `V67__backfill_missing_chat_room_members.sql` 마이그레이션 추가
- 과거 버그로 누락된 `chat_room_member` 데이터 복구


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
