### PR TITLE
fix: 문의하기에서 기존 문의 채팅방이 아닌 새 채팅방이 생성되는 문제를 해결

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -65,27 +65,16 @@ public class ChatRoomMembershipService {
         chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, readAt);
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateDirectRoomLastReadAt(Integer roomId, Integer userId, LocalDateTime readAt) {
+    @Transactional
+    public void updateDirectRoomLastReadAt(Integer roomId, Integer userId, LocalDateTime readAt, ChatRoom room) {
         User user = userRepository.getById(userId);
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
 
         ensureDirectRoomMemberExists(room, user, readAt);
 
-        if (user.getRole() == UserRole.ADMIN) {
-            List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-            boolean isSystemAdmin = members.stream()
-                .anyMatch(member -> Objects.equals(member.getUserId(), SYSTEM_ADMIN_ID));
-
-            if (isSystemAdmin) {
-                for (ChatRoomMember member : members) {
-                    if (member.getUser().getRole() == UserRole.ADMIN) {
-                        chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, member.getUserId(), readAt);
-                    }
-                }
-                return;
-            }
+        // 어드민이 SYSTEM_ADMIN 방의 메시지를 읽으면 SYSTEM_ADMIN의 lastReadAt을 업데이트
+        if (user.getRole() == UserRole.ADMIN && isSystemAdminRoom(roomId)) {
+            chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, SYSTEM_ADMIN_ID, readAt);
+            return;
         }
 
         chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, readAt);
@@ -145,8 +134,9 @@ public class ChatRoomMembershipService {
             return;
         }
 
+        // 어드민은 SYSTEM_ADMIN 방의 메시지를 조회할 수 있지만, 멤버로 추가되지는 않는다
+        // (멤버가 추가되면 findByTwoUsers에서 해당 방을 찾지 못해 채팅방이 중복 생성됨)
         if (user.getRole() == UserRole.ADMIN && isSystemAdminRoom(room.getId())) {
-            saveRoomMemberIgnoringDuplicate(room, user, readAt);
             return;
         }
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -65,19 +65,17 @@ public class ChatRoomMembershipService {
         chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, readAt);
     }
 
-    @Transactional
-    public void updateDirectRoomLastReadAt(Integer roomId, Integer userId, LocalDateTime readAt, ChatRoom room) {
-        User user = userRepository.getById(userId);
-
-        ensureDirectRoomMemberExists(room, user, readAt);
-
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateDirectRoomLastReadAt(Integer roomId, User user, LocalDateTime readAt, ChatRoom room) {
         // 어드민이 SYSTEM_ADMIN 방의 메시지를 읽으면 SYSTEM_ADMIN의 lastReadAt을 업데이트
         if (user.getRole() == UserRole.ADMIN && isSystemAdminRoom(roomId)) {
             chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, SYSTEM_ADMIN_ID, readAt);
             return;
         }
 
-        chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, readAt);
+        ensureDirectRoomMemberExists(room, user, readAt);
+
+        chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, user.getId(), readAt);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -388,7 +388,7 @@ public class ChatService {
         return ChatInvitableUsersResponse.forClubSort(pagedInvitableUsers, sections);
     }
 
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Transactional(readOnly = true)
     public ChatMessagePageResponse getMessages(Integer userId, Integer roomId, Integer page, Integer limit) {
         ChatRoom room = chatRoomRepository.findById(roomId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
@@ -396,7 +396,7 @@ public class ChatService {
         LocalDateTime readAt = LocalDateTime.now();
 
         if (room.isDirectRoom()) {
-            chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, userId, readAt);
+            chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, userId, readAt, room);
             recordPresenceSafely(roomId, userId);
             return getDirectChatRoomMessages(userId, roomId, page, limit, readAt);
         }
@@ -440,7 +440,12 @@ public class ChatService {
             ClubMember member = clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), userId);
             ensureRoomMember(room, member.getUser(), member.getCreatedAt());
         } else if (room.isDirectRoom()) {
-            getAccessibleDirectRoomMember(room, user);
+            // 어드민이 SYSTEM_ADMIN 방에 접근하는 경우는 멤버십 체크를 건너뜀
+            boolean isAdminAccessingSystemAdminRoom = user.getRole() == UserRole.ADMIN
+                && isSystemAdminRoom(room);
+            if (!isAdminAccessingSystemAdminRoom) {
+                getAccessibleDirectRoomMember(room, user);
+            }
         } else {
             getAccessibleRoomMember(room, userId);
         }
@@ -667,19 +672,37 @@ public class ChatService {
     ) {
         ChatRoom chatRoom = getDirectRoom(roomId);
         User sender = userRepository.getById(userId);
-        ChatRoomMember senderMember = getAccessibleDirectRoomMember(chatRoom, sender);
-        boolean senderHadLeft = senderMember.hasLeft();
+
+        // 어드민이 SYSTEM_ADMIN 방에 메시지를 보내는 경우
+        boolean isAdminSendingToSystemAdminRoom = sender.getRole() == UserRole.ADMIN
+            && isSystemAdminRoom(chatRoom);
+
+        ChatRoomMember senderMember = null;
+        boolean senderHadLeft = false;
+
+        if (!isAdminSendingToSystemAdminRoom) {
+            senderMember = getAccessibleDirectRoomMember(chatRoom, sender);
+            senderHadLeft = senderMember.hasLeft();
+        }
+
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
         User receiver = resolveDirectChatPartner(members, userId);
 
         ChatMessage chatMessage = chatMessageRepository.save(
             ChatMessage.of(chatRoom, sender, request.content())
         );
-        if (senderHadLeft) {
+
+        if (senderHadLeft && senderMember != null) {
             senderMember.restoreDirectRoom();
         }
+
         chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
-        updateMemberLastReadAt(roomId, userId, chatMessage.getCreatedAt());
+
+        // 어드민이 보낸 경우는 lastReadAt 업데이트하지 않음 (멤버가 아니므로)
+        if (!isAdminSendingToSystemAdminRoom) {
+            updateMemberLastReadAt(roomId, userId, chatMessage.getCreatedAt());
+        }
+
         List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
 
         notificationService.sendChatNotification(receiver.getId(), roomId, sender.getName(), request.content());
@@ -1303,9 +1326,9 @@ public class ChatService {
     private ChatRoomMember getOrCreateDirectRoomMember(ChatRoom chatRoom, User user) {
         return chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoom.getId(), user.getId())
             .orElseGet(() -> {
+                // 어드민은 SYSTEM_ADMIN 방에 멤버로 추가되지 않음
                 if (user.getRole() == UserRole.ADMIN && isSystemAdminRoom(chatRoom)) {
-                    LocalDateTime joinedAt = LocalDateTime.now();
-                    return chatRoomMemberRepository.save(ChatRoomMember.of(chatRoom, user, joinedAt));
+                    throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
                 }
                 throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
             });

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -685,7 +685,7 @@ public class ChatService {
         }
 
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        User receiver = resolveDirectChatPartner(members, userId);
+        User receiver = resolveDirectMessageReceiver(members, sender);
 
         ChatMessage chatMessage = chatMessageRepository.save(
             ChatMessage.of(chatRoom, sender, request.content())
@@ -1476,6 +1476,29 @@ public class ChatService {
         }
 
         return findDirectPartner(members, userId);
+    }
+
+    private User findNonAdminUser(List<ChatRoomMember> members) {
+        return members.stream()
+            .map(ChatRoomMember::getUser)
+            .filter(memberUser -> memberUser.getRole() != UserRole.ADMIN)
+            .findFirst()
+            .orElse(null);
+    }
+
+    private User resolveDirectMessageReceiver(List<ChatRoomMember> members, User sender) {
+        if (sender.getRole() == UserRole.ADMIN) {
+            User nonAdminUser = findNonAdminUser(members);
+            if (nonAdminUser != null) {
+                return nonAdminUser;
+            }
+        }
+
+        User partner = resolveDirectChatPartner(members, sender.getId());
+        if (partner == null) {
+            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
+        }
+        return partner;
     }
 
     private User findDirectPartnerFromMemberInfo(

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -621,10 +621,11 @@ public class ChatService {
     ) {
         ChatRoom chatRoom = getDirectRoom(roomId);
         User user = userRepository.getById(userId);
-        ChatRoomMember member = getOrCreateDirectRoomMember(chatRoom, user);
-        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(member, chatRoom);
-
         boolean isAdminViewingSystemRoom = user.getRole() == UserRole.ADMIN && isSystemAdminRoom(chatRoom);
+        ChatRoomMember member = isAdminViewingSystemRoom
+            ? getRoomMember(roomId, SYSTEM_ADMIN_ID)
+            : getOrCreateDirectRoomMember(chatRoom, user);
+        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(member, chatRoom);
 
         PageRequest pageable = PageRequest.of(page - 1, limit);
         Page<ChatMessage> messages = chatMessageRepository.findByChatRoomId(roomId, visibleMessageFrom, pageable);

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -630,7 +630,8 @@ public class ChatService {
         ChatRoom chatRoom = getDirectRoom(roomId);
         User user = userRepository.getById(userId);
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(getOrCreateDirectRoomMember(chatRoom, user), chatRoom);
+        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(getOrCreateDirectRoomMember(chatRoom, user),
+            chatRoom);
 
         PageRequest pageable = PageRequest.of(page - 1, limit);
         Page<ChatMessage> messages = chatMessageRepository.findByChatRoomId(roomId, visibleMessageFrom, pageable);

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1192,6 +1192,10 @@ public class ChatService {
     }
 
     private void ensureDirectRoomRequester(ChatRoom room, User user, LocalDateTime joinedAt) {
+        if (shouldSkipSystemAdminMembership(room, user)) {
+            return;
+        }
+
         chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
             .ifPresentOrElse(member -> {
                 if (member.hasLeft()) {
@@ -1204,6 +1208,12 @@ public class ChatService {
                     member.updateLastReadAt(joinedAt);
                 }
             }, () -> chatRoomMemberRepository.save(ChatRoomMember.of(room, user, joinedAt)));
+    }
+
+    private boolean shouldSkipSystemAdminMembership(ChatRoom room, User user) {
+        // 문의방은 SYSTEM_ADMIN + 일반 사용자 2인 구조를 전제로 재사용(findByTwoUsers)되므로,
+        // 생성/재오픈 경로에서도 일반 ADMIN을 멤버로 추가하면 안 된다.
+        return user.getRole() == UserRole.ADMIN && isSystemAdminRoom(room);
     }
 
     private String normalizeCustomRoomName(String roomName) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -391,11 +391,19 @@ public class ChatService {
     public ChatMessagePageResponse getMessages(Integer userId, Integer roomId, Integer page, Integer limit) {
         ChatRoom room = chatRoomRepository.findById(roomId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+        User user = userRepository.getById(userId);
 
         LocalDateTime readAt = LocalDateTime.now();
 
         if (room.isDirectRoom()) {
-            chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, userId, readAt, room);
+            boolean isAdminViewingSystemRoom = user.getRole() == UserRole.ADMIN && isSystemAdminRoom(room);
+            if (isAdminViewingSystemRoom) {
+                chatRoomMembershipService.updateLastReadAt(roomId, SYSTEM_ADMIN_ID, readAt);
+                recordPresenceSafely(roomId, userId);
+                return getAdminSystemDirectChatRoomMessages(user, room, roomId, page, limit, readAt);
+            }
+
+            chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, user, readAt, room);
             recordPresenceSafely(roomId, userId);
             return getDirectChatRoomMessages(userId, roomId, page, limit, readAt);
         }
@@ -621,25 +629,62 @@ public class ChatService {
     ) {
         ChatRoom chatRoom = getDirectRoom(roomId);
         User user = userRepository.getById(userId);
-        boolean isAdminViewingSystemRoom = user.getRole() == UserRole.ADMIN && isSystemAdminRoom(chatRoom);
-        ChatRoomMember member = isAdminViewingSystemRoom
-            ? getRoomMember(roomId, SYSTEM_ADMIN_ID)
-            : getOrCreateDirectRoomMember(chatRoom, user);
-        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(member, chatRoom);
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(getOrCreateDirectRoomMember(chatRoom, user), chatRoom);
 
         PageRequest pageable = PageRequest.of(page - 1, limit);
         Page<ChatMessage> messages = chatMessageRepository.findByChatRoomId(roomId, visibleMessageFrom, pageable);
-        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
 
-        List<LocalDateTime> sortedReadBaselines = isAdminViewingSystemRoom
-            ? toAdminChatReadBaselines(members)
-            : toSortedReadBaselines(members);
+        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
+
+        List<ChatMessageDetailResponse> responseMessages = messages.getContent().stream()
+            .map(message -> {
+                boolean isRead = message.isSentBy(userId) || !message.getCreatedAt().isAfter(readAt);
+                int unreadCount = countUnreadSince(message.getCreatedAt(), sortedReadBaselines);
+                return new ChatMessageDetailResponse(
+                    message.getId(),
+                    message.getSender().getId(),
+                    null,
+                    message.getContent(),
+                    message.getCreatedAt(),
+                    isRead,
+                    unreadCount,
+                    message.isSentBy(userId)
+                );
+            })
+            .toList();
+
+        return new ChatMessagePageResponse(
+            messages.getTotalElements(),
+            messages.getNumberOfElements(),
+            messages.getTotalPages(),
+            messages.getNumber() + 1,
+            null,
+            responseMessages
+        );
+    }
+
+    private ChatMessagePageResponse getAdminSystemDirectChatRoomMessages(
+        User user,
+        ChatRoom chatRoom,
+        Integer roomId,
+        Integer page,
+        Integer limit,
+        LocalDateTime readAt
+    ) {
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        LocalDateTime visibleMessageFrom = resolveAdminSystemRoomVisibleMessageFrom(members);
+
+        PageRequest pageable = PageRequest.of(page - 1, limit);
+        Page<ChatMessage> messages = chatMessageRepository.findByChatRoomId(roomId, visibleMessageFrom, pageable);
+
+        List<LocalDateTime> sortedReadBaselines = toAdminChatReadBaselines(members);
 
         Integer maskedAdminId = getMaskedAdminId(user, chatRoom);
         List<ChatMessageDetailResponse> responseMessages = messages.getContent().stream()
             .map(message -> {
                 Integer senderId = resolveDirectSenderId(message, maskedAdminId);
-                boolean isMine = shouldDisplayAsOwnMessage(user, message, isAdminViewingSystemRoom);
+                boolean isMine = shouldDisplayAsOwnMessage(user, message, true);
                 boolean isRead = isMine || !message.getCreatedAt().isAfter(readAt);
                 int unreadCount = countUnreadSince(message.getCreatedAt(), sortedReadBaselines);
                 return new ChatMessageDetailResponse(
@@ -1354,6 +1399,11 @@ public class ChatService {
         LocalDateTime visibleMessageFrom = member.getVisibleMessageFrom();
         restoreDirectRoomIfVisible(member, chatRoom);
         return visibleMessageFrom;
+    }
+
+    private LocalDateTime resolveAdminSystemRoomVisibleMessageFrom(List<ChatRoomMember> members) {
+        ChatRoomMember systemAdminMember = findRoomMember(members, SYSTEM_ADMIN_ID);
+        return systemAdminMember != null ? systemAdminMember.getVisibleMessageFrom() : null;
     }
 
     /**

--- a/src/main/resources/db/migration/V68__remove_admin_members_from_system_admin_rooms.sql
+++ b/src/main/resources/db/migration/V68__remove_admin_members_from_system_admin_rooms.sql
@@ -1,0 +1,18 @@
+-- SYSTEM_ADMIN(1번)이 있는 DIRECT 채팅방에서 다른 어드민 멤버십 제거
+-- 이유: 어드민이 멤버로 추가되면 findByTwoUsers에서 해당 방을 찾지 못해 중복 생성됨
+-- 참고: https://github.com/BCSDLab/KONECT_BACK_END/issues/503
+
+DELETE FROM chat_room_member
+WHERE user_id IN (
+    SELECT u.id
+    FROM users u
+    WHERE u.role = 'ADMIN'
+    AND u.id != 1  -- SYSTEM_ADMIN(1번)은 제외
+)
+AND chat_room_id IN (
+    SELECT DISTINCT crm.chat_room_id
+    FROM chat_room_member crm
+    JOIN chat_room cr ON crm.chat_room_id = cr.id
+    WHERE crm.user_id = 1  -- SYSTEM_ADMIN(1번)이 있는 방
+    AND cr.room_type = 'DIRECT'  -- DIRECT 타입 방만
+);

--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -304,6 +304,36 @@ class ChatApiTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("관리자가 문의방을 다시 열어도 관리자 멤버는 추가되지 않는다")
+        void adminCreateOrGetInquiryRoomDoesNotAddAdminMember() throws Exception {
+            User anotherAdmin = persist(UserFixture.createAdmin(university));
+            clearPersistenceContext();
+
+            mockLoginUser(normalUser.getId());
+            var createResult = performPost("/chats/rooms/admin")
+                .andExpect(status().isOk())
+                .andReturn();
+
+            int chatRoomId = parseChatRoomId(createResult);
+
+            mockLoginUser(anotherAdmin.getId());
+            performPost("/chats/rooms", new ChatRoomCreateRequest(normalUser.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chatRoomId").value(chatRoomId));
+
+            clearPersistenceContext();
+
+            assertThat(chatRoomRepository.findByTwoUsers(SYSTEM_ADMIN_ID, normalUser.getId(), ChatType.DIRECT))
+                .isPresent()
+                .get()
+                .extracting(ChatRoom::getId)
+                .isEqualTo(chatRoomId);
+            assertThat(chatRoomMemberRepository.findByChatRoomId(chatRoomId))
+                .extracting(ChatRoomMember::getUserId)
+                .containsExactlyInAnyOrder(SYSTEM_ADMIN_ID, normalUser.getId());
+        }
+
+        @Test
         @DisplayName("어드민이 나간 문의 채팅방에 사용자가 새 메시지를 보내 어드민 목록에 다시 노출된다")
         @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
         @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -1,6 +1,8 @@
 package gg.agit.konect.integration.domain.chat;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -659,6 +661,31 @@ class ChatApiTest extends IntegrationTestSupport {
                 .hasSize(1)
                 .extracting(ChatMessage::getContent)
                 .containsExactly("안녕하세요");
+        }
+
+        @Test
+        @DisplayName("관리자가 문의방에 답변하면 실제 문의 사용자에게 알림을 보낸다")
+        void adminReplySendsNotificationToInquiryUser() throws Exception {
+            User anotherAdmin = persist(UserFixture.createAdmin(university));
+            clearPersistenceContext();
+
+            mockLoginUser(normalUser.getId());
+            int roomId = objectMapper.readTree(
+                performPost("/chats/rooms/admin")
+                    .andExpect(status().isOk())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString()
+            ).get("chatRoomId").asInt();
+
+            clearInvocations(notificationService);
+
+            mockLoginUser(anotherAdmin.getId());
+            performPost("/chats/rooms/" + roomId + "/messages", new ChatMessageSendRequest("관리자 답변입니다"))
+                .andExpect(status().isOk());
+
+            verify(notificationService)
+                .sendChatNotification(normalUser.getId(), roomId, anotherAdmin.getName(), "관리자 답변입니다");
         }
 
         @Test

--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -336,6 +336,37 @@ class ChatApiTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("관리자는 멤버가 아니어도 문의방 메시지를 조회할 수 있다")
+        void adminCanReadInquiryRoomMessagesWithoutMembership() throws Exception {
+            User anotherAdmin = persist(UserFixture.createAdmin(university));
+            clearPersistenceContext();
+
+            mockLoginUser(normalUser.getId());
+            int chatRoomId = parseChatRoomId(
+                performPost("/chats/rooms/admin")
+                    .andExpect(status().isOk())
+                    .andReturn()
+            );
+
+            performPost("/chats/rooms/" + chatRoomId + "/messages",
+                new ChatMessageSendRequest("문의 내용입니다"))
+                .andExpect(status().isOk());
+
+            clearPersistenceContext();
+
+            mockLoginUser(anotherAdmin.getId());
+            performGet("/chats/rooms/" + chatRoomId + "?page=1&limit=20")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(1))
+                .andExpect(jsonPath("$.messages[0].content").value("문의 내용입니다"))
+                .andExpect(jsonPath("$.messages[0].isMine").value(false));
+
+            assertThat(chatRoomMemberRepository.findByChatRoomId(chatRoomId))
+                .extracting(ChatRoomMember::getUserId)
+                .containsExactlyInAnyOrder(SYSTEM_ADMIN_ID, normalUser.getId());
+        }
+
+        @Test
         @DisplayName("어드민이 나간 문의 채팅방에 사용자가 새 메시지를 보내 어드민 목록에 다시 노출된다")
         @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
         @Transactional(propagation = Propagation.REQUIRES_NEW)


### PR DESCRIPTION
### 🔍 개요

* 문의하기 버튼 클릭 시 기존 개발팀 채팅방이 아닌 새 채팅방이 중복 생성되는 문제를 해결합니다.

- 문제 원인: 어드민이 문의 채팅방 메시지를 읽을 때 멤버로 추가되어 채팅방 멤버가 3명이 되면, `findByTwoUsers` 쿼리(멤버 정확히 2명 조건)가 해당 방을 찾지 못해 새로운 방이 생성됨


* close #503


---

### 🚀 주요 변경 내용

#### 1. 어드민 멤버 추가 방지 (`ChatRoomMembershipService.java`)
- `ensureDirectRoomMemberExists`: 어드민이 SYSTEM_ADMIN 방에 **멤버로 추가되지 않도록** 수정
- `updateDirectRoomLastReadAt`: 어드민이 읽으면 SYSTEM_ADMIN(1번)의 `lastReadAt`을 업데이트하도록 변경

#### 2. 메시지 전송 로직 수정 (`ChatService.java`)
- `sendDirectMessage`: 어드민이 SYSTEM_ADMIN 방에 메시지를 보내는 경우 별도 처리
  - 멤버십 체크 없이 메시지 전송 가능
  - `lastReadAt` 업데이트는 멤버인 경우만 수행

#### 3. 뮤트 설정 로직 수정 (`ChatService.java`)
- `toggleMute`: 어드민이 SYSTEM_ADMIN 방의 뮤트 설정을 할 수 있도록 수정

#### 4. 기존 데이터 정리 마이그레이션 (`V68__remove_admin_members_from_system_admin_rooms.sql`)
- SYSTEM_ADMIN(1번)이 있는 DIRECT 채팅방에서 다른 어드민 멤버십 제거

---
### 추가 수정
- 문의방 조회는 어드민 개인 멤버십 없이도 가능하도록 조회 경로를 분리했고
- direct 메시지 조회 시 lastReadAt 갱신이 read-only 트랜잭션에 합류하지 않도록 별도 쓰기 트랜잭션으로 분리했으며
- 어드민이 문의방에 답장할 때 알림 수신자가 SYSTEM_ADMIN이 아니라 실제 문의 사용자로 계산되도록 수신자 resolver도 보정했습니다

---

### 💬 참고 사항

#### 변경 후 동작
| 기능 | 동작 |
|------|------|
| 채팅방 목록 보기 | SYSTEM_ADMIN이 멤버인 방 조회 |
| 메시지 읽기 | SYSTEM_ADMIN의 `lastReadAt` 업데이트 |
| 메시지 보내기 | 멤버십 없이 전송 가능 |
| 뮤트 설정 | 멤버십 없이 설정 가능 |
| 채팅방 멤버 수 | 항상 2명 (SYSTEM_ADMIN + 사용자) |

- 어드민들이 개별적으로 읽음 표시를 관리하는 기능은 사라짐 (모두 SYSTEM_ADMIN의 `lastReadAt` 공유)


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
