### PR TITLE
refactor: 시트 등록 시 권한 조건 제거

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedService.java
@@ -23,12 +23,7 @@ public class ClubSheetIntegratedService {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
-        // integrated 등록은 요청자 Google Drive OAuth 연결을 전제로 한다.
-        // 연결된 계정이 실제 시트 접근 권한을 가지는지 검증한 뒤 서비스 계정 권한을 맞춘다.
-        googleSheetPermissionService.validateRequesterAccessAndTryGrantServiceAccountWriterAccess(
-            requesterId,
-            spreadsheetId
-        );
+        googleSheetPermissionService.tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
 
         SheetHeaderMapper.SheetAnalysisResult analysis =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);

--- a/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionService.java
@@ -45,7 +45,7 @@ public class GoogleSheetPermissionService {
         String refreshToken = resolveRefreshToken(requesterId);
 
         if (refreshToken == null) {
-            log.warn(
+            log.info(
                 "Skipping service account auto-share because Google Drive OAuth is not connected. requesterId={}",
                 requesterId
             );
@@ -91,14 +91,14 @@ public class GoogleSheetPermissionService {
             return true;
         } catch (IOException e) {
             if (GoogleSheetApiExceptionHelper.isInvalidGrant(e)) {
-                log.warn(
-                    "Google Drive OAuth token is invalid while auto-sharing spreadsheet. requesterId={}, "
+                log.info(
+                    "Skipping service account auto-share because Google Drive OAuth token is invalid. requesterId={}, "
                         + "spreadsheetId={}, cause={}",
                     requesterId,
                     spreadsheetId,
                     GoogleSheetApiExceptionHelper.extractDetail(e)
                 );
-                throw GoogleSheetApiExceptionHelper.invalidGoogleDriveAuth(e);
+                return false;
             }
 
             if (GoogleSheetApiExceptionHelper.isAccessDenied(e)

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
@@ -44,7 +44,6 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
     @Test
     @DisplayName("시트 분석 등록 후 사전 회원 가져오기를 순서대로 실행한다")
     void analyzeAndImportPreMembersSuccess() {
-        // given
         Integer clubId = 1;
         Integer requesterId = 2;
         String spreadsheetUrl =
@@ -60,17 +59,14 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
             requesterId,
             spreadsheetId,
             analysis.memberListMapping()
-        ))
-            .willReturn(expected);
+        )).willReturn(expected);
 
-        // when
         SheetImportResponse actual = clubSheetIntegratedService.analyzeAndImportPreMembers(
             clubId,
             requesterId,
             spreadsheetUrl
         );
 
-        // then
         InOrder inOrder = inOrder(
             clubPermissionValidator,
             googleSheetPermissionService,
@@ -80,7 +76,7 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
         );
         inOrder.verify(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
         inOrder.verify(googleSheetPermissionService)
-            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+            .tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
         inOrder.verify(sheetHeaderMapper).analyzeAllSheets(spreadsheetId);
         inOrder.verify(clubMemberSheetService).updateSheetId(
             clubId,
@@ -100,7 +96,6 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
     @Test
     @DisplayName("자동 권한 부여 중 예외가 발생하면 후속 시트 작업을 진행하지 않는다")
     void analyzeAndImportPreMembersStopsWhenAutoGrantThrowsException() {
-        // given
         Integer clubId = 1;
         Integer requesterId = 2;
         String spreadsheetUrl =
@@ -109,63 +104,44 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
         CustomException expected = CustomException.of(ApiResponseCode.FAILED_INIT_GOOGLE_DRIVE);
 
         willThrow(expected).given(googleSheetPermissionService)
-            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+            .tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
 
-        // when & then
         assertThatThrownBy(() -> clubSheetIntegratedService.analyzeAndImportPreMembers(
             clubId,
             requesterId,
             spreadsheetUrl
-        ))
-            .isSameAs(expected);
+        )).isSameAs(expected);
         verifyNoInteractions(sheetHeaderMapper, clubMemberSheetService, sheetImportService);
     }
 
     @Test
-    @DisplayName("요청자 계정이 시트 접근 권한이 없으면 후속 시트 작업을 진행하지 않는다")
-    void analyzeAndImportPreMembersStopsWhenRequesterHasNoSpreadsheetAccess() {
-        // given
+    @DisplayName("요청자 Drive OAuth가 없어도 시트 분석과 가져오기를 계속 진행한다")
+    void analyzeAndImportPreMembersContinuesWhenGoogleDriveOAuthIsNotConnected() {
         Integer clubId = 1;
         Integer requesterId = 2;
         String spreadsheetUrl =
             "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit";
         String spreadsheetId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms";
-        CustomException expected = CustomException.of(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS);
+        SheetHeaderMapper.SheetAnalysisResult analysis =
+            new SheetHeaderMapper.SheetAnalysisResult(SheetColumnMapping.defaultMapping(), null, null);
+        SheetImportResponse expected = SheetImportResponse.of(2, 0, List.of());
 
-        willThrow(expected).given(googleSheetPermissionService)
-            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+        given(googleSheetPermissionService.tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId))
+            .willReturn(false);
+        given(sheetHeaderMapper.analyzeAllSheets(spreadsheetId)).willReturn(analysis);
+        given(sheetImportService.importPreMembersFromSheet(
+            clubId,
+            requesterId,
+            spreadsheetId,
+            analysis.memberListMapping()
+        )).willReturn(expected);
 
-        // when & then
-        assertThatThrownBy(() -> clubSheetIntegratedService.analyzeAndImportPreMembers(
+        SheetImportResponse actual = clubSheetIntegratedService.analyzeAndImportPreMembers(
             clubId,
             requesterId,
             spreadsheetUrl
-        ))
-            .isSameAs(expected);
-        verifyNoInteractions(sheetHeaderMapper, clubMemberSheetService, sheetImportService);
-    }
+        );
 
-    @Test
-    @DisplayName("Drive OAuth가 연결되지 않으면 후속 시트 작업을 진행하지 않는다")
-    void analyzeAndImportPreMembersStopsWhenGoogleDriveOAuthIsNotConnected() {
-        // given
-        Integer clubId = 1;
-        Integer requesterId = 2;
-        String spreadsheetUrl =
-            "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit";
-        String spreadsheetId = "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms";
-        CustomException expected = CustomException.of(ApiResponseCode.NOT_FOUND_GOOGLE_DRIVE_AUTH);
-
-        willThrow(expected).given(googleSheetPermissionService)
-            .validateRequesterAccessAndTryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
-
-        // when & then
-        assertThatThrownBy(() -> clubSheetIntegratedService.analyzeAndImportPreMembers(
-            clubId,
-            requesterId,
-            spreadsheetUrl
-        ))
-            .isSameAs(expected);
-        verifyNoInteractions(sheetHeaderMapper, clubMemberSheetService, sheetImportService);
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubSheetIntegratedServiceTest.java
@@ -142,6 +142,29 @@ class ClubSheetIntegratedServiceTest extends ServiceTestSupport {
             spreadsheetUrl
         );
 
+        InOrder inOrder = inOrder(
+            clubPermissionValidator,
+            googleSheetPermissionService,
+            sheetHeaderMapper,
+            clubMemberSheetService,
+            sheetImportService
+        );
+        inOrder.verify(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
+        inOrder.verify(googleSheetPermissionService)
+            .tryGrantServiceAccountWriterAccess(requesterId, spreadsheetId);
+        inOrder.verify(sheetHeaderMapper).analyzeAllSheets(spreadsheetId);
+        inOrder.verify(clubMemberSheetService).updateSheetId(
+            clubId,
+            requesterId,
+            spreadsheetId,
+            analysis
+        );
+        inOrder.verify(sheetImportService).importPreMembersFromSheet(
+            clubId,
+            requesterId,
+            spreadsheetId,
+            analysis.memberListMapping()
+        );
         assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/GoogleSheetPermissionServiceTest.java
@@ -261,8 +261,8 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("throws a bad request custom exception when Google returns invalid_grant")
-    void tryGrantServiceAccountWriterAccessThrowsWhenInvalidGrantOccurs()
+    @DisplayName("returns false when Google returns invalid_grant")
+    void tryGrantServiceAccountWriterAccessReturnsFalseWhenInvalidGrantOccurs()
         throws IOException, GeneralSecurityException {
         mockConnectedDriveAccount();
         given(permissions.list(FILE_ID)).willReturn(listRequest);
@@ -277,13 +277,12 @@ class GoogleSheetPermissionServiceTest extends ServiceTestSupport {
             )
         ));
 
-        assertThatThrownBy(() -> googleSheetPermissionService.tryGrantServiceAccountWriterAccess(
+        boolean granted = googleSheetPermissionService.tryGrantServiceAccountWriterAccess(
             REQUESTER_ID,
             FILE_ID
-        ))
-            .isInstanceOf(CustomException.class)
-            .extracting("errorCode")
-            .isEqualTo(ApiResponseCode.INVALID_GOOGLE_DRIVE_AUTH);
+        );
+
+        assertThat(granted).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### 📌 개요

* 시트 통합 등록(`sheet/import/integrated`) 시 요청자 개인이 해당 스프레드시트에 직접 접근 가능한지 확인하던 조건을 제거했습니다.
* 이제 동아리 운영진 권한만 충족하면, 요청자 개인의 편집자/소유자 권한 여부로 등록이 막히지 않습니다.

---

### ✅ 주요 변경 내용

* `ClubSheetIntegratedService`에서 `validateRequesterAccessAndTryGrantServiceAccountWriterAccess(...)` 대신 `tryGrantServiceAccountWriterAccess(...)`를 호출하도록 변경했습니다.
* 요청자 Google Drive OAuth 또는 개인 시트 접근 권한이 없어도, 서비스 계정 권한 부여는 가능한 경우에만 시도하고 등록 흐름은 계속 진행하도록 수정했습니다.
* 변경된 동작에 맞게 `ClubSheetIntegratedServiceTest`를 정리했습니다.
  * 정상 플로우 검증
  * 자동 권한 부여 중 예외 발생 시 중단 검증
  * 요청자 Drive OAuth가 없어도 통합 등록이 계속 진행되는 케이스 검증

---

### 🙇 참고 사항

* 이번 변경은 `sheet/import/integrated` 플로우의 요청자 개인 접근 권한 조건만 제거한 것입니다.
* 서비스 계정 자동 공유 시도 로직은 그대로 유지됩니다.
* 확인한 테스트
  * `./gradlew.bat test --tests "gg.agit.konect.domain.club.service.ClubSheetIntegratedServiceTest"`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함 및 검증 완료
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)