### PR TITLE
feat: 시트 부원 미리보기 API 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
@@ -21,10 +21,10 @@ import jakarta.validation.Valid;
 public interface ClubSheetMigrationApi {
 
     @Operation(
-        summary = "Migrate an existing spreadsheet into the official sheet",
+        summary = "기존 스프레드시트를 공식 시트로 이관한다",
         description = """
-            When the existing spreadsheet URL is provided,
-            KONECT creates the official sheet in the same Drive folder and copies the current data.
+            기존 스프레드시트 URL을 제출하면
+            같은 Google Drive 폴더에 KONECT 공식 시트를 만들고 현재 데이터를 복사합니다.
             """
     )
     @PostMapping("/{clubId}/sheet/migrate")
@@ -35,10 +35,10 @@ public interface ClubSheetMigrationApi {
     );
 
     @Operation(
-        summary = "Preview sheet members before importing",
+        summary = "시트 불러오기 전 부원 목록을 미리본다",
         description = """
-            Reads the spreadsheet URL and returns the member list that would be imported as JSON.
-            This endpoint does not persist data and is intended only for preview usage.
+            스프레드시트 URL을 읽어 등록 예정인 부원 목록을 JSON으로 반환합니다.
+            이 API는 데이터를 저장하지 않고 미리보기 용도로만 사용합니다.
             """
     )
     @PostMapping("/{clubId}/sheet/import/preview")
@@ -49,10 +49,10 @@ public interface ClubSheetMigrationApi {
     );
 
     @Operation(
-        summary = "Import pre-members from a spreadsheet",
+        summary = "스프레드시트에서 사전 등록 부원을 가져온다",
         description = """
-            Reflects member information from the spreadsheet into the database.
-            Existing users are registered directly as ClubMember, and others are stored as ClubPreMember.
+            스프레드시트의 부원 정보를 데이터베이스에 반영합니다.
+            가입된 사용자는 ClubMember로 바로 등록하고, 미가입 사용자는 ClubPreMember로 저장합니다.
             """
     )
     @PostMapping("/{clubId}/sheet/import")
@@ -63,10 +63,10 @@ public interface ClubSheetMigrationApi {
     );
 
     @Operation(
-        summary = "Analyze the sheet and import pre-members in one step",
+        summary = "시트 분석과 사전 등록 부원 가져오기를 한 번에 수행한다",
         description = """
-            Runs sheet analysis, sheet registration, and pre-member import in sequence.
-            The result is equivalent to calling PUT /clubs/{clubId}/sheet and then POST /clubs/{clubId}/sheet/import.
+            시트 분석, 시트 등록, 사전 등록 부원 가져오기를 순차적으로 수행합니다.
+            기존 PUT /clubs/{clubId}/sheet 이후 POST /clubs/{clubId}/sheet/import 를 호출한 것과 같은 결과입니다.
             """
     )
     @PostMapping("/{clubId}/sheet/import/integrated")

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import gg.agit.konect.domain.club.dto.ClubMemberSheetSyncResponse;
+import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportRequest;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
 import gg.agit.konect.domain.club.dto.SheetMigrateRequest;
@@ -20,11 +21,11 @@ import jakarta.validation.Valid;
 public interface ClubSheetMigrationApi {
 
     @Operation(
-        summary = "기존 스프레드시트 → 팀 양식으로 이관",
-        description = "동아리가 기존에 사용하던 스프레드시트 URL을 제출하면, "
-            + "AI가 데이터를 분석하여 KONECT 팀이 마련한 표준 양식 파일로 복사합니다. "
-            + "새 파일은 기존 URL과 동일한 Google Drive 폴더에 생성됩니다. "
-            + "이후 동기화는 새로 생성된 파일 기준으로 진행됩니다."
+        summary = "Migrate an existing spreadsheet into the official sheet",
+        description = """
+            When the existing spreadsheet URL is provided,
+            KONECT creates the official sheet in the same Drive folder and copies the current data.
+            """
     )
     @PostMapping("/{clubId}/sheet/migrate")
     ResponseEntity<ClubMemberSheetSyncResponse> migrateSheet(
@@ -34,10 +35,25 @@ public interface ClubSheetMigrationApi {
     );
 
     @Operation(
-        summary = "기존 스프레드시트에서 사전 회원 가져오기",
-        description = "동아리가 기존에 관리하던 스프레드시트의 인명부를 읽어 "
-            + "DB에 사전 회원(ClubPreMember)으로 등록합니다. "
-            + "AI가 헤더를 자동 분석하며, 이미 등록된 회원(이름+학번 중복)은 건너뜁니다."
+        summary = "Preview sheet members before importing",
+        description = """
+            Reads the spreadsheet URL and returns the member list that would be imported as JSON.
+            This endpoint does not persist data and is intended only for preview usage.
+            """
+    )
+    @PostMapping("/{clubId}/sheet/import/preview")
+    ResponseEntity<SheetImportPreviewResponse> previewPreMembers(
+        @PathVariable(name = "clubId") Integer clubId,
+        @Valid @RequestBody SheetImportRequest request,
+        @UserId Integer requesterId
+    );
+
+    @Operation(
+        summary = "Import pre-members from a spreadsheet",
+        description = """
+            Reflects member information from the spreadsheet into the database.
+            Existing users are registered directly as ClubMember, and others are stored as ClubPreMember.
+            """
     )
     @PostMapping("/{clubId}/sheet/import")
     ResponseEntity<SheetImportResponse> importPreMembers(
@@ -47,10 +63,11 @@ public interface ClubSheetMigrationApi {
     );
 
     @Operation(
-        summary = "스프레드시트 분석 후 사전 회원 가져오기",
-        description = "구글 스프레드시트 URL을 받아 먼저 시트를 분석 및 등록한 뒤, "
-            + "같은 스프레드시트에서 사전 회원을 읽어 DB에 등록합니다. "
-            + "기존 PUT /clubs/{clubId}/sheet 와 POST /clubs/{clubId}/sheet/import 를 순서대로 실행한 결과와 동일합니다."
+        summary = "Analyze the sheet and import pre-members in one step",
+        description = """
+            Runs sheet analysis, sheet registration, and pre-member import in sequence.
+            The result is equivalent to calling PUT /clubs/{clubId}/sheet and then POST /clubs/{clubId}/sheet/import.
+            """
     )
     @PostMapping("/{clubId}/sheet/import/integrated")
     ResponseEntity<SheetImportResponse> analyzeAndImportPreMembers(

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import gg.agit.konect.domain.club.dto.ClubMemberSheetSyncResponse;
+import gg.agit.konect.domain.club.dto.SheetImportConfirmRequest;
 import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportRequest;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
@@ -45,6 +46,20 @@ public interface ClubSheetMigrationApi {
     ResponseEntity<SheetImportPreviewResponse> previewPreMembers(
         @PathVariable(name = "clubId") Integer clubId,
         @Valid @RequestBody SheetImportRequest request,
+        @UserId Integer requesterId
+    );
+
+    @Operation(
+        summary = "편집된 미리보기 부원 목록을 최종 등록한다",
+        description = """
+            미리보기 화면에서 활성화된 부원 목록과 수동 추가한 부원 목록을 최종본으로 받아 등록합니다.
+            비활성화된 부원은 등록 대상에서 제외됩니다.
+            """
+    )
+    @PostMapping("/{clubId}/sheet/import/confirm")
+    ResponseEntity<SheetImportResponse> confirmImportPreMembers(
+        @PathVariable(name = "clubId") Integer clubId,
+        @Valid @RequestBody SheetImportConfirmRequest request,
         @UserId Integer requesterId
     );
 

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import gg.agit.konect.domain.club.dto.ClubMemberSheetSyncResponse;
+import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportRequest;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
 import gg.agit.konect.domain.club.dto.SheetMigrateRequest;
@@ -36,6 +37,18 @@ public class ClubSheetMigrationController implements ClubSheetMigrationApi {
             clubId, requesterId, request.sourceSpreadsheetUrl()
         );
         return ResponseEntity.ok(ClubMemberSheetSyncResponse.of(0, newSpreadsheetId));
+    }
+
+    @Override
+    public ResponseEntity<SheetImportPreviewResponse> previewPreMembers(
+        @PathVariable(name = "clubId") Integer clubId,
+        @Valid @RequestBody SheetImportRequest request,
+        @UserId Integer requesterId
+    ) {
+        SheetImportPreviewResponse response = sheetImportService.previewPreMembersFromSheet(
+            clubId, requesterId, request.spreadsheetUrl()
+        );
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import gg.agit.konect.domain.club.dto.ClubMemberSheetSyncResponse;
+import gg.agit.konect.domain.club.dto.SheetImportConfirmRequest;
 import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportRequest;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
@@ -47,6 +48,20 @@ public class ClubSheetMigrationController implements ClubSheetMigrationApi {
     ) {
         SheetImportPreviewResponse response = sheetImportService.previewPreMembersFromSheet(
             clubId, requesterId, request.spreadsheetUrl()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<SheetImportResponse> confirmImportPreMembers(
+        @PathVariable(name = "clubId") Integer clubId,
+        @Valid @RequestBody SheetImportConfirmRequest request,
+        @UserId Integer requesterId
+    ) {
+        SheetImportResponse response = sheetImportService.confirmImportPreMembers(
+            clubId,
+            requesterId,
+            request.members()
         );
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/gg/agit/konect/domain/club/dto/SheetImportConfirmRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/SheetImportConfirmRequest.java
@@ -16,6 +16,7 @@ import jakarta.validation.constraints.Size;
 
 public record SheetImportConfirmRequest(
     @NotNull(message = "최종 등록할 부원 목록은 필수입니다.")
+    @NotEmpty(message = "최종 등록할 부원 목록은 최소 1명 이상이어야 합니다.")
     @Valid
     @ArraySchema(schema = @Schema(implementation = ConfirmMember.class))
     List<ConfirmMember> members

--- a/src/main/java/gg/agit/konect/domain/club/dto/SheetImportConfirmRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/SheetImportConfirmRequest.java
@@ -10,12 +10,10 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SheetImportConfirmRequest(
-    @NotNull(message = "최종 등록할 부원 목록은 필수입니다.")
     @NotEmpty(message = "최종 등록할 부원 목록은 최소 1명 이상이어야 합니다.")
     @Valid
     @ArraySchema(schema = @Schema(implementation = ConfirmMember.class))

--- a/src/main/java/gg/agit/konect/domain/club/dto/SheetImportConfirmRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/SheetImportConfirmRequest.java
@@ -1,0 +1,48 @@
+package gg.agit.konect.domain.club.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import gg.agit.konect.domain.club.enums.ClubPosition;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SheetImportConfirmRequest(
+    @NotNull(message = "최종 등록할 부원 목록은 필수입니다.")
+    @Valid
+    @ArraySchema(schema = @Schema(implementation = ConfirmMember.class))
+    List<ConfirmMember> members
+) {
+    public record ConfirmMember(
+        @NotEmpty(message = "학번은 필수 입력입니다.")
+        @Size(min = 4, max = 20, message = "학번은 4자 이상 20자 이하입니다.")
+        @Pattern(regexp = "^[0-9]+$", message = "학번은 숫자만 입력할 수 있습니다.")
+        @Schema(description = "학번", example = "2021136089", requiredMode = REQUIRED)
+        String studentNumber,
+
+        @NotEmpty(message = "이름은 필수 입력입니다.")
+        @Pattern(
+            regexp = "^([가-힣]{2,5}|(?=.{2,30}$)[A-Za-z]+( [A-Za-z]+)*)$",
+            message = "이름은 완성된 한글 2~5자 또는 영문 2~30자(공백 포함)만 입력할 수 있습니다."
+        )
+        @Schema(description = "이름", example = "김코넥트", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "등록할 동아리 직책", example = "MEMBER", requiredMode = NOT_REQUIRED)
+        ClubPosition clubPosition,
+
+        @Schema(description = "최종 등록 대상 여부", example = "true", requiredMode = NOT_REQUIRED)
+        Boolean enabled
+    ) {
+        public boolean isEnabled() {
+            return !Boolean.FALSE.equals(enabled);
+        }
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/club/dto/SheetImportPreviewResponse.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/SheetImportPreviewResponse.java
@@ -10,32 +10,32 @@ import gg.agit.konect.domain.club.model.ClubPreMember;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SheetImportPreviewResponse(
-    @Schema(description = "Total preview member count", example = "10", requiredMode = REQUIRED)
+    @Schema(description = "전체 미리보기 인원 수", example = "10", requiredMode = REQUIRED)
     int previewCount,
 
-    @Schema(description = "Members that will be registered directly", example = "2", requiredMode = REQUIRED)
+    @Schema(description = "즉시 등록될 인원 수", example = "2", requiredMode = REQUIRED)
     int autoRegisteredCount,
 
-    @Schema(description = "Members that will be pre-registered", example = "8", requiredMode = REQUIRED)
+    @Schema(description = "사전 등록될 인원 수", example = "8", requiredMode = REQUIRED)
     int preRegisteredCount,
 
-    @Schema(description = "Preview member list", requiredMode = REQUIRED)
+    @Schema(description = "미리보기 부원 목록", requiredMode = REQUIRED)
     List<PreviewMember> members,
 
-    @Schema(description = "Warnings collected during preview", requiredMode = REQUIRED)
+    @Schema(description = "미리보기 중 수집된 경고 목록", requiredMode = REQUIRED)
     List<String> warnings
 ) {
     public record PreviewMember(
-        @Schema(description = "Student number", example = "2021136089", requiredMode = REQUIRED)
+        @Schema(description = "학번", example = "2021136089", requiredMode = REQUIRED)
         String studentNumber,
 
-        @Schema(description = "Member name", example = "Kim Konect", requiredMode = REQUIRED)
+        @Schema(description = "이름", example = "김코넥트", requiredMode = REQUIRED)
         String name,
 
-        @Schema(description = "Club position to register", example = "MEMBER", requiredMode = REQUIRED)
+        @Schema(description = "등록할 동아리 직책", example = "MEMBER", requiredMode = REQUIRED)
         ClubPosition clubPosition,
 
-        @Schema(description = "True when the member will be registered directly as ClubMember",
+        @Schema(description = "ClubMember로 즉시 등록되는 경우 true",
             example = "false", requiredMode = REQUIRED)
         Boolean isDirectMember
     ) {

--- a/src/main/java/gg/agit/konect/domain/club/dto/SheetImportPreviewResponse.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/SheetImportPreviewResponse.java
@@ -35,15 +35,18 @@ public record SheetImportPreviewResponse(
         @Schema(description = "등록할 동아리 직책", example = "MEMBER", requiredMode = REQUIRED)
         ClubPosition clubPosition,
 
-        @Schema(description = "ClubMember로 즉시 등록되는 경우 true",
-            example = "false", requiredMode = REQUIRED)
-        Boolean isDirectMember
+        @Schema(description = "ClubMember로 즉시 등록되는 경우 true", example = "false", requiredMode = REQUIRED)
+        Boolean isDirectMember,
+
+        @Schema(description = "최종 등록 대상이면 true", example = "true", requiredMode = REQUIRED)
+        Boolean enabled
     ) {
         public static PreviewMember from(ClubMember clubMember) {
             return new PreviewMember(
                 clubMember.getUser().getStudentNumber(),
                 clubMember.getUser().getName(),
                 clubMember.getClubPosition(),
+                true,
                 true
             );
         }
@@ -53,7 +56,8 @@ public record SheetImportPreviewResponse(
                 preMember.getStudentNumber(),
                 preMember.getName(),
                 preMember.getClubPosition(),
-                false
+                false,
+                true
             );
         }
     }

--- a/src/main/java/gg/agit/konect/domain/club/dto/SheetImportPreviewResponse.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/SheetImportPreviewResponse.java
@@ -1,0 +1,81 @@
+package gg.agit.konect.domain.club.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import gg.agit.konect.domain.club.enums.ClubPosition;
+import gg.agit.konect.domain.club.model.ClubMember;
+import gg.agit.konect.domain.club.model.ClubPreMember;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SheetImportPreviewResponse(
+    @Schema(description = "Total preview member count", example = "10", requiredMode = REQUIRED)
+    int previewCount,
+
+    @Schema(description = "Members that will be registered directly", example = "2", requiredMode = REQUIRED)
+    int autoRegisteredCount,
+
+    @Schema(description = "Members that will be pre-registered", example = "8", requiredMode = REQUIRED)
+    int preRegisteredCount,
+
+    @Schema(description = "Preview member list", requiredMode = REQUIRED)
+    List<PreviewMember> members,
+
+    @Schema(description = "Warnings collected during preview", requiredMode = REQUIRED)
+    List<String> warnings
+) {
+    public record PreviewMember(
+        @Schema(description = "Student number", example = "2021136089", requiredMode = REQUIRED)
+        String studentNumber,
+
+        @Schema(description = "Member name", example = "Kim Konect", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "Club position to register", example = "MEMBER", requiredMode = REQUIRED)
+        ClubPosition clubPosition,
+
+        @Schema(description = "True when the member will be registered directly as ClubMember",
+            example = "false", requiredMode = REQUIRED)
+        Boolean isDirectMember
+    ) {
+        public static PreviewMember from(ClubMember clubMember) {
+            return new PreviewMember(
+                clubMember.getUser().getStudentNumber(),
+                clubMember.getUser().getName(),
+                clubMember.getClubPosition(),
+                true
+            );
+        }
+
+        public static PreviewMember from(ClubPreMember preMember) {
+            return new PreviewMember(
+                preMember.getStudentNumber(),
+                preMember.getName(),
+                preMember.getClubPosition(),
+                false
+            );
+        }
+    }
+
+    public static SheetImportPreviewResponse of(
+        List<PreviewMember> members,
+        List<String> warnings
+    ) {
+        List<PreviewMember> safeMembers = members != null ? members : List.of();
+        List<String> safeWarnings = warnings != null ? warnings : List.of();
+
+        int autoRegisteredCount = (int)safeMembers.stream()
+            .filter(member -> Boolean.TRUE.equals(member.isDirectMember()))
+            .count();
+        int preRegisteredCount = safeMembers.size() - autoRegisteredCount;
+
+        return new SheetImportPreviewResponse(
+            safeMembers.size(),
+            autoRegisteredCount,
+            preRegisteredCount,
+            safeMembers,
+            safeWarnings
+        );
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -6,11 +6,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
@@ -48,8 +52,8 @@ public class SheetImportService {
     private final UserRepository userRepository;
     private final ChatRoomMembershipService chatRoomMembershipService;
     private final ClubPermissionValidator clubPermissionValidator;
+    private final PlatformTransactionManager transactionManager;
 
-    @Transactional(readOnly = true)
     public SheetImportPreviewResponse previewPreMembersFromSheet(
         Integer clubId,
         Integer requesterId,
@@ -60,16 +64,17 @@ public class SheetImportService {
         String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
         SheetHeaderMapper.SheetAnalysisResult analysis =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
-        Club club = clubRepository.getById(clubId);
         SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
-
-        SheetImportPlan plan = buildImportPlan(
-            clubId,
-            club,
-            source.members(),
-            source.warnings()
-        );
-        return SheetImportPreviewResponse.of(plan.previewMembers(), plan.warnings());
+        return executeReadOnlyTransaction(() -> {
+            Club club = clubRepository.getById(clubId);
+            SheetImportPlan plan = buildImportPlan(
+                clubId,
+                club,
+                source.members(),
+                source.warnings()
+            );
+            return SheetImportPreviewResponse.of(plan.previewMembers(), plan.warnings());
+        });
     }
 
     @Transactional
@@ -95,7 +100,6 @@ public class SheetImportService {
         );
     }
 
-    @Transactional
     public SheetImportResponse importPreMembersFromSheet(
         Integer clubId,
         Integer requesterId,
@@ -106,24 +110,14 @@ public class SheetImportService {
         String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
         SheetHeaderMapper.SheetAnalysisResult analysis =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
-        Club club = clubRepository.getById(clubId);
         SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
-
-        SheetImportPlan plan = buildImportPlan(
+        return executeTransaction(() -> importPreMembers(
             clubId,
-            club,
-            source.members(),
-            source.warnings()
-        );
-        applyImportPlan(clubId, spreadsheetId, plan);
-        return SheetImportResponse.of(
-            plan.preRegisteredCount(),
-            plan.autoRegisteredCount(),
-            plan.warnings()
-        );
+            spreadsheetId,
+            source
+        ));
     }
 
-    @Transactional
     SheetImportResponse importPreMembersFromSheet(
         Integer clubId,
         Integer requesterId,
@@ -131,16 +125,27 @@ public class SheetImportService {
         SheetColumnMapping mapping
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
-        Club club = clubRepository.getById(clubId);
         SheetImportSource source = loadSheetImportSource(spreadsheetId, mapping);
+        return executeTransaction(() -> importPreMembers(
+            clubId,
+            spreadsheetId,
+            source
+        ));
+    }
 
+    private SheetImportResponse importPreMembers(
+        Integer clubId,
+        String importSource,
+        SheetImportSource source
+    ) {
+        Club club = clubRepository.getById(clubId);
         SheetImportPlan plan = buildImportPlan(
             clubId,
             club,
             source.members(),
             source.warnings()
         );
-        applyImportPlan(clubId, spreadsheetId, plan);
+        applyImportPlan(clubId, importSource, plan);
         return SheetImportResponse.of(
             plan.preRegisteredCount(),
             plan.autoRegisteredCount(),
@@ -341,11 +346,25 @@ public class SheetImportService {
         return members.stream()
             .filter(SheetImportConfirmRequest.ConfirmMember::isEnabled)
             .map(member -> new ImportMember(
-                member.studentNumber() == null ? "" : member.studentNumber().trim(),
-                member.name() == null ? "" : member.name().trim(),
+                member.studentNumber().trim(),
+                member.name().trim(),
                 member.clubPosition() == null ? ClubPosition.MEMBER : member.clubPosition()
             ))
             .toList();
+    }
+
+    private <T> T executeTransaction(Supplier<T> action) {
+        return executeWithTemplate(false, action);
+    }
+
+    private <T> T executeReadOnlyTransaction(Supplier<T> action) {
+        return executeWithTemplate(true, action);
+    }
+
+    private <T> T executeWithTemplate(boolean readOnly, Supplier<T> action) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(readOnly);
+        return Objects.requireNonNull(transactionTemplate.execute(status -> action.get()));
     }
 
     private List<List<Object>> readDataRows(String spreadsheetId, SheetColumnMapping mapping) {

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -16,6 +16,7 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.dto.SheetImportConfirmRequest;
 import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
 import gg.agit.konect.domain.club.enums.ClubPosition;
@@ -60,14 +61,38 @@ public class SheetImportService {
         SheetHeaderMapper.SheetAnalysisResult analysis =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
         Club club = clubRepository.getById(clubId);
+        SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
 
         SheetImportPlan plan = buildImportPlan(
             clubId,
             club,
-            spreadsheetId,
-            analysis.memberListMapping()
+            source.members(),
+            source.warnings()
         );
         return SheetImportPreviewResponse.of(plan.previewMembers(), plan.warnings());
+    }
+
+    @Transactional
+    public SheetImportResponse confirmImportPreMembers(
+        Integer clubId,
+        Integer requesterId,
+        List<SheetImportConfirmRequest.ConfirmMember> members
+    ) {
+        clubPermissionValidator.validateManagerAccess(clubId, requesterId);
+        Club club = clubRepository.getById(clubId);
+
+        SheetImportPlan plan = buildImportPlan(
+            clubId,
+            club,
+            toImportMembers(members),
+            List.of()
+        );
+        applyImportPlan(clubId, "preview-confirm", plan);
+        return SheetImportResponse.of(
+            plan.preRegisteredCount(),
+            plan.autoRegisteredCount(),
+            plan.warnings()
+        );
     }
 
     @Transactional
@@ -77,15 +102,24 @@ public class SheetImportService {
         String spreadsheetUrl
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
-        String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
 
+        String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
         SheetHeaderMapper.SheetAnalysisResult analysis =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
-        return importPreMembersFromSheet(
+        Club club = clubRepository.getById(clubId);
+        SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
+
+        SheetImportPlan plan = buildImportPlan(
             clubId,
-            requesterId,
-            spreadsheetId,
-            analysis.memberListMapping()
+            club,
+            source.members(),
+            source.warnings()
+        );
+        applyImportPlan(clubId, spreadsheetId, plan);
+        return SheetImportResponse.of(
+            plan.preRegisteredCount(),
+            plan.autoRegisteredCount(),
+            plan.warnings()
         );
     }
 
@@ -98,7 +132,14 @@ public class SheetImportService {
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
         Club club = clubRepository.getById(clubId);
-        SheetImportPlan plan = buildImportPlan(clubId, club, spreadsheetId, mapping);
+        SheetImportSource source = loadSheetImportSource(spreadsheetId, mapping);
+
+        SheetImportPlan plan = buildImportPlan(
+            clubId,
+            club,
+            source.members(),
+            source.warnings()
+        );
         applyImportPlan(clubId, spreadsheetId, plan);
         return SheetImportResponse.of(
             plan.preRegisteredCount(),
@@ -109,7 +150,7 @@ public class SheetImportService {
 
     private void applyImportPlan(
         Integer clubId,
-        String spreadsheetId,
+        String importSource,
         SheetImportPlan plan
     ) {
         if (!plan.studentNumbersToCleanFromPre().isEmpty()) {
@@ -123,8 +164,8 @@ public class SheetImportService {
             ? List.of()
             : clubMemberRepository.saveAll(plan.clubMembersToSave());
 
-        for (ClubMember saved : savedMembers) {
-            chatRoomMembershipService.addClubMember(saved);
+        for (ClubMember savedMember : savedMembers) {
+            chatRoomMembershipService.addClubMember(savedMember);
         }
 
         if (!plan.preMembersToSave().isEmpty()) {
@@ -132,9 +173,9 @@ public class SheetImportService {
         }
 
         log.info(
-            "Sheet import done. clubId={}, spreadsheetId={}, imported={}, autoRegistered={}, warnings={}",
+            "Sheet import done. clubId={}, source={}, imported={}, autoRegistered={}, warnings={}",
             clubId,
-            spreadsheetId,
+            importSource,
             plan.preRegisteredCount(),
             plan.autoRegisteredCount(),
             plan.warnings().size()
@@ -144,11 +185,10 @@ public class SheetImportService {
     private SheetImportPlan buildImportPlan(
         Integer clubId,
         Club club,
-        String spreadsheetId,
-        SheetColumnMapping mapping
+        List<ImportMember> members,
+        List<String> initialWarnings
     ) {
         Integer universityId = club.getUniversity().getId();
-        List<List<Object>> rows = readDataRows(spreadsheetId, mapping);
 
         Set<String> existingMemberStudentNumbers =
             new HashSet<>(clubMemberRepository.findStudentNumbersByClubId(clubId));
@@ -156,8 +196,8 @@ public class SheetImportService {
         Set<Integer> existingMemberUserIds =
             new HashSet<>(clubMemberRepository.findUserIdsByClubId(clubId));
 
-        Set<String> allStudentNumbers = rows.stream()
-            .map(row -> getCell(row, mapping, SheetColumnMapping.STUDENT_ID))
+        Set<String> allStudentNumbers = members.stream()
+            .map(ImportMember::studentNumber)
             .filter(studentNumber -> !studentNumber.isBlank())
             .collect(Collectors.toSet());
 
@@ -173,29 +213,19 @@ public class SheetImportService {
         List<ClubMember> clubMembersToSave = new ArrayList<>();
         Set<String> studentNumbersToCleanFromPre = new HashSet<>();
         List<ClubPreMember> preMembersToSave = new ArrayList<>();
-        List<String> warnings = new ArrayList<>();
+        List<String> warnings = new ArrayList<>(initialWarnings);
         int presidentCount = 0;
 
-        for (List<Object> row : rows) {
-            String name = getCell(row, mapping, SheetColumnMapping.NAME);
-            String studentNumber = getCell(row, mapping, SheetColumnMapping.STUDENT_ID);
+        for (ImportMember importMember : members) {
+            String name = importMember.name();
+            String studentNumber = importMember.studentNumber();
+            ClubPosition position = importMember.clubPosition() == null
+                ? ClubPosition.MEMBER
+                : importMember.clubPosition();
 
             if (name.isBlank() || studentNumber.isBlank()) {
                 continue;
             }
-
-            String phone = getCell(row, mapping, SheetColumnMapping.PHONE);
-            if (!phone.isBlank() && !PhoneNumberNormalizer.looksLikePhoneNumber(phone)) {
-                warnings.add(String.format(
-                    "전화번호 형식이 올바르지 않습니다 - 학번: %s, 이름: %s, 입력값: '%s'",
-                    studentNumber,
-                    name,
-                    phone
-                ));
-            }
-
-            String positionText = getCell(row, mapping, SheetColumnMapping.POSITION);
-            ClubPosition position = resolvePosition(positionText);
 
             if (position == ClubPosition.PRESIDENT) {
                 presidentCount++;
@@ -214,7 +244,7 @@ public class SheetImportService {
 
             List<User> candidates = usersByStudentNumber.getOrDefault(studentNumber, List.of());
             List<User> matchedUsers = candidates.stream()
-                .filter(user -> name.equalsIgnoreCase(user.getName().trim()))
+                .filter(user -> user.getName() != null && name.equalsIgnoreCase(user.getName().trim()))
                 .toList();
 
             if (matchedUsers.size() == 1) {
@@ -267,6 +297,55 @@ public class SheetImportService {
             preMembersToSave,
             warnings
         );
+    }
+
+    private SheetImportSource loadSheetImportSource(String spreadsheetId, SheetColumnMapping mapping) {
+        List<List<Object>> rows = readDataRows(spreadsheetId, mapping);
+        List<ImportMember> members = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+
+        for (List<Object> row : rows) {
+            String name = getCell(row, mapping, SheetColumnMapping.NAME);
+            String studentNumber = getCell(row, mapping, SheetColumnMapping.STUDENT_ID);
+
+            if (name.isBlank() || studentNumber.isBlank()) {
+                continue;
+            }
+
+            String phone = getCell(row, mapping, SheetColumnMapping.PHONE);
+            if (!phone.isBlank() && !PhoneNumberNormalizer.looksLikePhoneNumber(phone)) {
+                warnings.add(String.format(
+                    "전화번호 형식이 올바르지 않습니다 - 학번: %s, 이름: %s, 입력값: '%s'",
+                    studentNumber,
+                    name,
+                    phone
+                ));
+            }
+
+            String positionText = getCell(row, mapping, SheetColumnMapping.POSITION);
+            members.add(new ImportMember(
+                studentNumber,
+                name,
+                resolvePosition(positionText)
+            ));
+        }
+
+        return new SheetImportSource(members, warnings);
+    }
+
+    private List<ImportMember> toImportMembers(List<SheetImportConfirmRequest.ConfirmMember> members) {
+        if (members == null) {
+            return List.of();
+        }
+
+        return members.stream()
+            .filter(SheetImportConfirmRequest.ConfirmMember::isEnabled)
+            .map(member -> new ImportMember(
+                member.studentNumber() == null ? "" : member.studentNumber().trim(),
+                member.name() == null ? "" : member.name().trim(),
+                member.clubPosition() == null ? ClubPosition.MEMBER : member.clubPosition()
+            ))
+            .toList();
     }
 
     private List<List<Object>> readDataRows(String spreadsheetId, SheetColumnMapping mapping) {
@@ -342,5 +421,18 @@ public class SheetImportService {
         private int preRegisteredCount() {
             return preMembersToSave.size();
         }
+    }
+
+    private record SheetImportSource(
+        List<ImportMember> members,
+        List<String> warnings
+    ) {
+    }
+
+    private record ImportMember(
+        String studentNumber,
+        String name,
+        ClubPosition clubPosition
+    ) {
     }
 }

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -101,7 +101,7 @@ public class SheetImportService {
         SheetImportPlan plan = buildImportPlan(clubId, club, spreadsheetId, mapping);
         applyImportPlan(clubId, spreadsheetId, plan);
         return SheetImportResponse.of(
-            plan.importedCount(),
+            plan.preRegisteredCount(),
             plan.autoRegisteredCount(),
             plan.warnings()
         );
@@ -135,7 +135,7 @@ public class SheetImportService {
             "Sheet import done. clubId={}, spreadsheetId={}, imported={}, autoRegistered={}, warnings={}",
             clubId,
             spreadsheetId,
-            plan.importedCount(),
+            plan.preRegisteredCount(),
             plan.autoRegisteredCount(),
             plan.warnings().size()
         );
@@ -339,7 +339,7 @@ public class SheetImportService {
             return clubMembersToSave.size();
         }
 
-        private int importedCount() {
+        private int preRegisteredCount() {
             return preMembersToSave.size();
         }
     }

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -16,6 +16,7 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
 import gg.agit.konect.domain.club.enums.ClubPosition;
 import gg.agit.konect.domain.club.model.Club;
@@ -47,6 +48,28 @@ public class SheetImportService {
     private final ChatRoomMembershipService chatRoomMembershipService;
     private final ClubPermissionValidator clubPermissionValidator;
 
+    @Transactional(readOnly = true)
+    public SheetImportPreviewResponse previewPreMembersFromSheet(
+        Integer clubId,
+        Integer requesterId,
+        String spreadsheetUrl
+    ) {
+        clubPermissionValidator.validateManagerAccess(clubId, requesterId);
+
+        String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
+        SheetHeaderMapper.SheetAnalysisResult analysis =
+            sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
+        Club club = clubRepository.getById(clubId);
+
+        SheetImportPlan plan = buildImportPlan(
+            clubId,
+            club,
+            spreadsheetId,
+            analysis.memberListMapping()
+        );
+        return SheetImportPreviewResponse.of(plan.previewMembers(), plan.warnings());
+    }
+
     @Transactional
     public SheetImportResponse importPreMembersFromSheet(
         Integer clubId,
@@ -75,10 +98,50 @@ public class SheetImportService {
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
         Club club = clubRepository.getById(clubId);
-        return importPreMembersFromSheet(clubId, club, spreadsheetId, mapping);
+        SheetImportPlan plan = buildImportPlan(clubId, club, spreadsheetId, mapping);
+        applyImportPlan(clubId, spreadsheetId, plan);
+        return SheetImportResponse.of(
+            plan.importedCount(),
+            plan.autoRegisteredCount(),
+            plan.warnings()
+        );
     }
 
-    private SheetImportResponse importPreMembersFromSheet(
+    private void applyImportPlan(
+        Integer clubId,
+        String spreadsheetId,
+        SheetImportPlan plan
+    ) {
+        if (!plan.studentNumbersToCleanFromPre().isEmpty()) {
+            clubPreMemberRepository.deleteByClubIdAndStudentNumberIn(
+                clubId,
+                plan.studentNumbersToCleanFromPre()
+            );
+        }
+
+        List<ClubMember> savedMembers = plan.clubMembersToSave().isEmpty()
+            ? List.of()
+            : clubMemberRepository.saveAll(plan.clubMembersToSave());
+
+        for (ClubMember saved : savedMembers) {
+            chatRoomMembershipService.addClubMember(saved);
+        }
+
+        if (!plan.preMembersToSave().isEmpty()) {
+            clubPreMemberRepository.saveAll(plan.preMembersToSave());
+        }
+
+        log.info(
+            "Sheet import done. clubId={}, spreadsheetId={}, imported={}, autoRegistered={}, warnings={}",
+            clubId,
+            spreadsheetId,
+            plan.importedCount(),
+            plan.autoRegisteredCount(),
+            plan.warnings().size()
+        );
+    }
+
+    private SheetImportPlan buildImportPlan(
         Integer clubId,
         Club club,
         String spreadsheetId,
@@ -87,32 +150,29 @@ public class SheetImportService {
         Integer universityId = club.getUniversity().getId();
         List<List<Object>> rows = readDataRows(spreadsheetId, mapping);
 
-        // N+1 방지: 루프 전 기존 부원 학번 Set / 사전 회원 key Set / 부원 userId Set 일괄 조회
         Set<String> existingMemberStudentNumbers =
             new HashSet<>(clubMemberRepository.findStudentNumbersByClubId(clubId));
         Set<String> existingPreMemberKeys = buildPreMemberKeySet(clubId);
         Set<Integer> existingMemberUserIds =
             new HashSet<>(clubMemberRepository.findUserIdsByClubId(clubId));
 
-        // 시트에 등장하는 모든 학번 수집 → users 일괄 조회
         Set<String> allStudentNumbers = rows.stream()
             .map(row -> getCell(row, mapping, SheetColumnMapping.STUDENT_ID))
-            .filter(s -> !s.isBlank())
+            .filter(studentNumber -> !studentNumber.isBlank())
             .collect(Collectors.toSet());
 
         Map<String, List<User>> usersByStudentNumber = new HashMap<>();
         if (!allStudentNumbers.isEmpty()) {
             userRepository.findAllByUniversityIdAndStudentNumberIn(universityId, allStudentNumbers)
-                .forEach(u -> usersByStudentNumber
-                    .computeIfAbsent(u.getStudentNumber(), k -> new ArrayList<>())
-                    .add(u));
+                .forEach(user -> usersByStudentNumber
+                    .computeIfAbsent(user.getStudentNumber(), key -> new ArrayList<>())
+                    .add(user));
         }
 
-        // 루프에서 수집할 배치 작업 대상
+        List<SheetImportPreviewResponse.PreviewMember> previewMembers = new ArrayList<>();
         List<ClubMember> clubMembersToSave = new ArrayList<>();
         Set<String> studentNumbersToCleanFromPre = new HashSet<>();
         List<ClubPreMember> preMembersToSave = new ArrayList<>();
-
         List<String> warnings = new ArrayList<>();
         int presidentCount = 0;
 
@@ -124,55 +184,51 @@ public class SheetImportService {
                 continue;
             }
 
-            // 전화번호 형식 유효성 경고
             String phone = getCell(row, mapping, SheetColumnMapping.PHONE);
             if (!phone.isBlank() && !PhoneNumberNormalizer.looksLikePhoneNumber(phone)) {
                 warnings.add(String.format(
                     "전화번호 형식이 올바르지 않습니다 - 학번: %s, 이름: %s, 입력값: '%s'",
-                    studentNumber, name, phone
+                    studentNumber,
+                    name,
+                    phone
                 ));
             }
 
-            String positionStr = getCell(row, mapping, SheetColumnMapping.POSITION);
-            ClubPosition position = resolvePosition(positionStr);
+            String positionText = getCell(row, mapping, SheetColumnMapping.POSITION);
+            ClubPosition position = resolvePosition(positionText);
 
-            // 회장 중복 감지
             if (position == ClubPosition.PRESIDENT) {
                 presidentCount++;
                 if (presidentCount > 1) {
                     warnings.add(String.format(
                         "회장이 2명 이상 등록되어 있습니다 - 중복 회장: 학번 %s, 이름 %s",
-                        studentNumber, name
+                        studentNumber,
+                        name
                     ));
                 }
             }
 
-            // 이미 club_member에 있는 학번은 스킵
             if (existingMemberStudentNumbers.contains(studentNumber)) {
                 continue;
             }
 
-            // users 테이블에서 동일 대학 + 학번으로 매칭, 이름까지 일치하는 유저 탐색
-            // trim() / equalsIgnoreCase로 공백·대소문자 차이 허용
-            // 주의: existingPreMemberKeys 체크보다 먼저 수행하여
-            // 이미 pre_member로 등록된 행도 User 생성 후 재-import 시 club_member로 승격 가능하게 함
             List<User> candidates = usersByStudentNumber.getOrDefault(studentNumber, List.of());
-            List<User> matched = candidates.stream()
-                .filter(u -> name != null && u.getName() != null
-                    && name.trim().equalsIgnoreCase(u.getName().trim()))
+            List<User> matchedUsers = candidates.stream()
+                .filter(user -> name.equalsIgnoreCase(user.getName().trim()))
                 .toList();
 
-            if (matched.size() == 1) {
-                User matchedUser = matched.get(0);
-                // userId Set으로 중복 체크 (N+1 없음)
+            if (matchedUsers.size() == 1) {
+                User matchedUser = matchedUsers.get(0);
                 if (!existingMemberUserIds.contains(matchedUser.getId())) {
-                    // 기존 pre_member 행도 함께 정리 (중복 방지)
-                    studentNumbersToCleanFromPre.add(matchedUser.getStudentNumber());
-                    clubMembersToSave.add(ClubMember.builder()
+                    ClubMember clubMember = ClubMember.builder()
                         .club(club)
                         .user(matchedUser)
                         .clubPosition(position)
-                        .build());
+                        .build();
+
+                    clubMembersToSave.add(clubMember);
+                    previewMembers.add(SheetImportPreviewResponse.PreviewMember.from(clubMember));
+                    studentNumbersToCleanFromPre.add(matchedUser.getStudentNumber());
                     existingMemberStudentNumbers.add(studentNumber);
                     existingMemberUserIds.add(matchedUser.getId());
                     existingPreMemberKeys.remove(preMemberKey(studentNumber, name));
@@ -180,54 +236,37 @@ public class SheetImportService {
                 continue;
             }
 
-            if (matched.size() > 1) {
+            if (matchedUsers.size() > 1) {
                 warnings.add(String.format(
                     "동명이인이 여러 명 존재하여 자동 매칭할 수 없습니다 - 학번: %s, 이름: %s",
-                    studentNumber, name
+                    studentNumber,
+                    name
                 ));
             }
 
-            // users 미매칭 또는 동명이인 → 이미 pre_member에 있으면 스킵, 없으면 등록
             if (existingPreMemberKeys.contains(preMemberKey(studentNumber, name))) {
                 continue;
             }
 
-            preMembersToSave.add(ClubPreMember.builder()
+            ClubPreMember preMember = ClubPreMember.builder()
                 .club(club)
                 .studentNumber(studentNumber)
                 .name(name)
                 .clubPosition(position)
-                .build());
+                .build();
+
+            preMembersToSave.add(preMember);
+            previewMembers.add(SheetImportPreviewResponse.PreviewMember.from(preMember));
             existingPreMemberKeys.add(preMemberKey(studentNumber, name));
         }
 
-        // 배치 처리: pre_member 정리 → club_member 일괄 저장 → 채팅방 등록
-        if (!studentNumbersToCleanFromPre.isEmpty()) {
-            clubPreMemberRepository.deleteByClubIdAndStudentNumberIn(
-                clubId, studentNumbersToCleanFromPre
-            );
-        }
-        List<ClubMember> savedMembers = clubMembersToSave.isEmpty()
-            ? List.of()
-            : clubMemberRepository.saveAll(clubMembersToSave);
-
-        for (ClubMember saved : savedMembers) {
-            chatRoomMembershipService.addClubMember(saved);
-        }
-
-        if (!preMembersToSave.isEmpty()) {
-            clubPreMemberRepository.saveAll(preMembersToSave);
-        }
-
-        int autoRegistered = savedMembers.size();
-        int imported = preMembersToSave.size();
-
-        log.info(
-            "Sheet import done. clubId={}, spreadsheetId={}, imported={}, autoRegistered={}, "
-                + "warnings={}",
-            clubId, spreadsheetId, imported, autoRegistered, warnings.size()
+        return new SheetImportPlan(
+            previewMembers,
+            clubMembersToSave,
+            studentNumbersToCleanFromPre,
+            preMembersToSave,
+            warnings
         );
-        return SheetImportResponse.of(imported, autoRegistered, warnings);
     }
 
     private List<List<Object>> readDataRows(String spreadsheetId, SheetColumnMapping mapping) {
@@ -241,7 +280,6 @@ public class SheetImportService {
 
             List<List<Object>> values = response.getValues();
             return values != null ? values : List.of();
-
         } catch (IOException e) {
             if (GoogleSheetApiExceptionHelper.isAccessDenied(e)) {
                 log.warn(
@@ -257,22 +295,23 @@ public class SheetImportService {
     }
 
     private String getCell(List<Object> row, SheetColumnMapping mapping, String field) {
-        int col = mapping.getColumnIndex(field);
-        if (col < 0 || col >= row.size()) {
+        int columnIndex = mapping.getColumnIndex(field);
+        if (columnIndex < 0 || columnIndex >= row.size()) {
             return "";
         }
-        String value = row.get(col).toString().trim();
+
+        String value = row.get(columnIndex).toString().trim();
         if (value.startsWith("'")) {
             return value.substring(1);
         }
         return value;
     }
 
-    private ClubPosition resolvePosition(String positionStr) {
-        for (ClubPosition pos : ClubPosition.values()) {
-            if (pos.getDescription().equals(positionStr)
-                || pos.name().equalsIgnoreCase(positionStr)) {
-                return pos;
+    private ClubPosition resolvePosition(String positionText) {
+        for (ClubPosition position : ClubPosition.values()) {
+            if (position.getDescription().equals(positionText)
+                || position.name().equalsIgnoreCase(positionText)) {
+                return position;
             }
         }
         return ClubPosition.MEMBER;
@@ -281,11 +320,27 @@ public class SheetImportService {
     private Set<String> buildPreMemberKeySet(Integer clubId) {
         Set<String> keys = new HashSet<>();
         clubPreMemberRepository.findStudentNumberAndNameByClubId(clubId)
-            .forEach(k -> keys.add(preMemberKey(k.getStudentNumber(), k.getName())));
+            .forEach(key -> keys.add(preMemberKey(key.getStudentNumber(), key.getName())));
         return keys;
     }
 
     private String preMemberKey(String studentNumber, String name) {
         return studentNumber + "\u0000" + name;
+    }
+
+    private record SheetImportPlan(
+        List<SheetImportPreviewResponse.PreviewMember> previewMembers,
+        List<ClubMember> clubMembersToSave,
+        Set<String> studentNumbersToCleanFromPre,
+        List<ClubPreMember> preMembersToSave,
+        List<String> warnings
+    ) {
+        private int autoRegisteredCount() {
+            return clubMembersToSave.size();
+        }
+
+        private int importedCount() {
+            return preMembersToSave.size();
+        }
     }
 }

--- a/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
@@ -1,6 +1,7 @@
 package gg.agit.konect.domain.club.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,6 +15,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
@@ -76,6 +79,9 @@ class SheetImportServiceTest extends ServiceTestSupport {
     @Mock
     private ClubPermissionValidator clubPermissionValidator;
 
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
     @InjectMocks
     private SheetImportService sheetImportService;
 
@@ -92,6 +98,7 @@ class SheetImportServiceTest extends ServiceTestSupport {
         given(clubPreMemberRepository.findStudentNumberAndNameByClubId(CLUB_ID))
             .willReturn(List.<ClubPreMemberRepository.PreMemberKey>of());
         given(clubMemberRepository.findUserIdsByClubId(CLUB_ID)).willReturn(List.of());
+        given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
         given(userRepository.findAllByUniversityIdAndStudentNumberIn(
             eq(club.getUniversity().getId()),
             anySet()

--- a/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
@@ -1,0 +1,121 @@
+package gg.agit.konect.domain.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.ValueRange;
+
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
+import gg.agit.konect.domain.club.enums.ClubPosition;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.SheetColumnMapping;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubPreMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubRepository;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class SheetImportServiceTest extends ServiceTestSupport {
+
+    private static final Integer CLUB_ID = 1;
+    private static final Integer REQUESTER_ID = 2;
+    private static final String SPREADSHEET_ID = "sheet-id";
+    private static final String SPREADSHEET_URL =
+        "https://docs.google.com/spreadsheets/d/" + SPREADSHEET_ID + "/edit";
+
+    @Mock
+    private Sheets googleSheetsService;
+
+    @Mock
+    private Sheets.Spreadsheets spreadsheets;
+
+    @Mock
+    private Sheets.Spreadsheets.Values values;
+
+    @Mock
+    private Sheets.Spreadsheets.Values.Get getRequest;
+
+    @Mock
+    private SheetHeaderMapper sheetHeaderMapper;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubPreMemberRepository clubPreMemberRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatRoomMembershipService chatRoomMembershipService;
+
+    @Mock
+    private ClubPermissionValidator clubPermissionValidator;
+
+    @InjectMocks
+    private SheetImportService sheetImportService;
+
+    @Test
+    void previewPreMembersFromSheetReturnsDirectAndPreMembers() throws IOException {
+        Club club = ClubFixture.create(UniversityFixture.create());
+        User directUser = UserFixture.createUser(club.getUniversity(), "Alex Kim", "2021232948");
+
+        given(clubRepository.getById(CLUB_ID)).willReturn(club);
+        given(sheetHeaderMapper.analyzeAllSheets(SPREADSHEET_ID)).willReturn(
+            new SheetHeaderMapper.SheetAnalysisResult(SheetColumnMapping.defaultMapping(), null, null)
+        );
+        given(clubMemberRepository.findStudentNumbersByClubId(CLUB_ID)).willReturn(Set.of());
+        given(clubPreMemberRepository.findStudentNumberAndNameByClubId(CLUB_ID))
+            .willReturn(List.<ClubPreMemberRepository.PreMemberKey>of());
+        given(clubMemberRepository.findUserIdsByClubId(CLUB_ID)).willReturn(List.of());
+        given(userRepository.findAllByUniversityIdAndStudentNumberIn(
+            eq(club.getUniversity().getId()),
+            anySet()
+        )).willReturn(List.of(directUser));
+
+        given(googleSheetsService.spreadsheets()).willReturn(spreadsheets);
+        given(spreadsheets.values()).willReturn(values);
+        given(values.get(SPREADSHEET_ID, "A2:Z")).willReturn(getRequest);
+        given(getRequest.setValueRenderOption("FORMATTED_VALUE")).willReturn(getRequest);
+        given(getRequest.execute()).willReturn(new ValueRange().setValues(List.of(
+            List.of("Alex Kim", "2021232948", "", "010-1234-5678", ClubPosition.MANAGER.name()),
+            List.of("Dana Lee", "2021232949", "", "010-9999-8888", ClubPosition.MEMBER.name())
+        )));
+
+        SheetImportPreviewResponse response = sheetImportService.previewPreMembersFromSheet(
+            CLUB_ID,
+            REQUESTER_ID,
+            SPREADSHEET_URL
+        );
+
+        assertThat(response.previewCount()).isEqualTo(2);
+        assertThat(response.autoRegisteredCount()).isEqualTo(1);
+        assertThat(response.preRegisteredCount()).isEqualTo(1);
+        assertThat(response.members())
+            .extracting(SheetImportPreviewResponse.PreviewMember::studentNumber)
+            .containsExactly("2021232948", "2021232949");
+        assertThat(response.members())
+            .extracting(SheetImportPreviewResponse.PreviewMember::isDirectMember)
+            .containsExactly(true, false);
+    }
+}

--- a/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
@@ -1,9 +1,11 @@
 package gg.agit.konect.domain.club.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.IOException;
 import java.util.List;
@@ -17,7 +19,9 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.dto.SheetImportConfirmRequest;
 import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
+import gg.agit.konect.domain.club.dto.SheetImportResponse;
 import gg.agit.konect.domain.club.enums.ClubPosition;
 import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.SheetColumnMapping;
@@ -117,5 +121,54 @@ class SheetImportServiceTest extends ServiceTestSupport {
         assertThat(response.members())
             .extracting(SheetImportPreviewResponse.PreviewMember::isDirectMember)
             .containsExactly(true, false);
+        assertThat(response.members())
+            .extracting(SheetImportPreviewResponse.PreviewMember::enabled)
+            .containsExactly(true, true);
+    }
+
+    @Test
+    void confirmImportPreMembersImportsOnlyEnabledMembers() {
+        Club club = ClubFixture.create(UniversityFixture.create());
+        User directUser = UserFixture.createUser(club.getUniversity(), "Alex Kim", "2021232948");
+
+        given(clubRepository.getById(CLUB_ID)).willReturn(club);
+        given(clubMemberRepository.findStudentNumbersByClubId(CLUB_ID)).willReturn(Set.of());
+        given(clubPreMemberRepository.findStudentNumberAndNameByClubId(CLUB_ID))
+            .willReturn(List.<ClubPreMemberRepository.PreMemberKey>of());
+        given(clubMemberRepository.findUserIdsByClubId(CLUB_ID)).willReturn(List.of());
+        given(userRepository.findAllByUniversityIdAndStudentNumberIn(
+            eq(club.getUniversity().getId()),
+            anySet()
+        )).willReturn(List.of(directUser));
+        given(clubMemberRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
+
+        SheetImportResponse response = sheetImportService.confirmImportPreMembers(
+            CLUB_ID,
+            REQUESTER_ID,
+            List.of(
+                new SheetImportConfirmRequest.ConfirmMember(
+                    "2021232948",
+                    "Alex Kim",
+                    ClubPosition.MANAGER,
+                    true
+                ),
+                new SheetImportConfirmRequest.ConfirmMember(
+                    "2021232949",
+                    "Dana Lee",
+                    ClubPosition.MEMBER,
+                    false
+                ),
+                new SheetImportConfirmRequest.ConfirmMember(
+                    "2021232950",
+                    "Chris Park",
+                    ClubPosition.MEMBER,
+                    true
+                )
+            )
+        );
+
+        assertThat(response.importedCount()).isEqualTo(1);
+        assertThat(response.autoRegisteredCount()).isEqualTo(1);
+        verifyNoInteractions(googleSheetsService);
     }
 }

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import gg.agit.konect.domain.club.dto.SheetImportConfirmRequest;
 import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportRequest;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
@@ -42,25 +43,27 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("POST /clubs/{clubId}/sheet/import/preview - 시트 부원 미리보기")
+    @DisplayName("POST /clubs/{clubId}/sheet/import/preview")
     class PreviewPreMembers {
 
         @Test
-        @DisplayName("시트에서 읽은 등록 예정 부원 목록을 반환한다")
+        @DisplayName("returns preview member list")
         void previewPreMembersSuccess() throws Exception {
             SheetImportPreviewResponse response = SheetImportPreviewResponse.of(
                 List.of(
                     new SheetImportPreviewResponse.PreviewMember(
                         "2021232948",
-                        "최승운",
+                        "Kim Manager",
                         ClubPosition.MANAGER,
+                        true,
                         true
                     ),
                     new SheetImportPreviewResponse.PreviewMember(
                         "2021232949",
-                        "김하나",
+                        "Lee Member",
                         ClubPosition.MEMBER,
-                        false
+                        false,
+                        true
                     )
                 ),
                 List.of("전화번호 형식 경고")
@@ -81,13 +84,15 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.preRegisteredCount").value(1))
                 .andExpect(jsonPath("$.members[0].studentNumber").value("2021232948"))
                 .andExpect(jsonPath("$.members[0].isDirectMember").value(true))
+                .andExpect(jsonPath("$.members[0].enabled").value(true))
                 .andExpect(jsonPath("$.members[1].studentNumber").value("2021232949"))
                 .andExpect(jsonPath("$.members[1].isDirectMember").value(false))
+                .andExpect(jsonPath("$.members[1].enabled").value(true))
                 .andExpect(jsonPath("$.warnings[0]").value("전화번호 형식 경고"));
         }
 
         @Test
-        @DisplayName("구글 스프레드시트 접근 권한이 없으면 403을 반환한다")
+        @DisplayName("returns 403 when sheet access is forbidden")
         void previewPreMembersForbiddenGoogleSheetAccess() throws Exception {
             given(sheetImportService.previewPreMembersFromSheet(
                 eq(CLUB_ID),
@@ -107,11 +112,97 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("POST /clubs/{clubId}/sheet/import/integrated - 시트 통합 가져오기")
+    @DisplayName("POST /clubs/{clubId}/sheet/import/confirm")
+    class ConfirmImportPreMembers {
+
+        @Test
+        @DisplayName("imports only enabled preview members")
+        void confirmImportPreMembersSuccess() throws Exception {
+            given(sheetImportService.confirmImportPreMembers(
+                eq(CLUB_ID),
+                eq(REQUESTER_ID),
+                eq(List.of(
+                    new SheetImportConfirmRequest.ConfirmMember(
+                        "2021232948",
+                        "Kim Manager",
+                        ClubPosition.MANAGER,
+                        true
+                    ),
+                    new SheetImportConfirmRequest.ConfirmMember(
+                        "2021232949",
+                        "Lee Member",
+                        ClubPosition.MEMBER,
+                        false
+                    ),
+                    new SheetImportConfirmRequest.ConfirmMember(
+                        "2021232950",
+                        "Park Member",
+                        ClubPosition.MEMBER,
+                        true
+                    )
+                ))
+            )).willReturn(SheetImportResponse.of(1, 1, List.of()));
+
+            SheetImportConfirmRequest request = new SheetImportConfirmRequest(List.of(
+                new SheetImportConfirmRequest.ConfirmMember(
+                    "2021232948",
+                    "Kim Manager",
+                    ClubPosition.MANAGER,
+                    true
+                ),
+                new SheetImportConfirmRequest.ConfirmMember(
+                    "2021232949",
+                    "Lee Member",
+                    ClubPosition.MEMBER,
+                    false
+                ),
+                new SheetImportConfirmRequest.ConfirmMember(
+                    "2021232950",
+                    "Park Member",
+                    ClubPosition.MEMBER,
+                    true
+                )
+            ));
+
+            performPost("/clubs/" + CLUB_ID + "/sheet/import/confirm", request)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.importedCount").value(1))
+                .andExpect(jsonPath("$.autoRegisteredCount").value(1));
+        }
+
+        @Test
+        @DisplayName("returns 403 when confirm import access is forbidden")
+        void confirmImportPreMembersForbidden() throws Exception {
+            SheetImportConfirmRequest request = new SheetImportConfirmRequest(List.of(
+                new SheetImportConfirmRequest.ConfirmMember(
+                    "2021232948",
+                    "Kim Manager",
+                    ClubPosition.MANAGER,
+                    true
+                )
+            ));
+
+            given(sheetImportService.confirmImportPreMembers(
+                eq(CLUB_ID),
+                eq(REQUESTER_ID),
+                eq(request.members())
+            )).willThrow(CustomException.of(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS));
+
+            performPost("/clubs/" + CLUB_ID + "/sheet/import/confirm", request)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code")
+                    .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.name()))
+                .andExpect(jsonPath("$.message")
+                    .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /clubs/{clubId}/sheet/import/integrated")
     class AnalyzeAndImportPreMembers {
 
         @Test
-        @DisplayName("시트 분석 등록 후 사전 회원 가져오기 결과를 반환한다")
+        @DisplayName("returns integrated import result")
         void analyzeAndImportPreMembersSuccess() throws Exception {
             given(clubSheetIntegratedService.analyzeAndImportPreMembers(
                 eq(CLUB_ID),
@@ -129,7 +220,7 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
         }
 
         @Test
-        @DisplayName("구글 스프레드시트 403 오류를 response body로 반환한다")
+        @DisplayName("returns 403 response body for forbidden sheet access")
         void analyzeAndImportPreMembersForbiddenGoogleSheetAccess() throws Exception {
             given(clubSheetIntegratedService.analyzeAndImportPreMembers(
                 eq(CLUB_ID),
@@ -148,7 +239,7 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
         }
 
         @Test
-        @DisplayName("Google Drive invalid_grant 400 오류를 response body detail로 반환한다")
+        @DisplayName("returns detail for invalid Google Drive auth")
         void analyzeAndImportPreMembersInvalidGoogleDriveAuth() throws Exception {
             String detail =
                 "400 Bad Request\nPOST https://oauth2.googleapis.com/token\n{\"error\":\"invalid_grant\"}";

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
@@ -13,14 +13,20 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import gg.agit.konect.domain.club.dto.SheetImportPreviewResponse;
 import gg.agit.konect.domain.club.dto.SheetImportRequest;
 import gg.agit.konect.domain.club.dto.SheetImportResponse;
+import gg.agit.konect.domain.club.enums.ClubPosition;
 import gg.agit.konect.domain.club.service.ClubSheetIntegratedService;
+import gg.agit.konect.domain.club.service.SheetImportService;
 import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
 import gg.agit.konect.support.IntegrationTestSupport;
 
 class ClubSheetMigrationApiTest extends IntegrationTestSupport {
+
+    @MockitoBean
+    private SheetImportService sheetImportService;
 
     @MockitoBean
     private ClubSheetIntegratedService clubSheetIntegratedService;
@@ -33,6 +39,71 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
     @BeforeEach
     void setUp() throws Exception {
         mockLoginUser(REQUESTER_ID);
+    }
+
+    @Nested
+    @DisplayName("POST /clubs/{clubId}/sheet/import/preview - 시트 부원 미리보기")
+    class PreviewPreMembers {
+
+        @Test
+        @DisplayName("시트에서 읽은 등록 예정 부원 목록을 반환한다")
+        void previewPreMembersSuccess() throws Exception {
+            SheetImportPreviewResponse response = SheetImportPreviewResponse.of(
+                List.of(
+                    new SheetImportPreviewResponse.PreviewMember(
+                        "2021232948",
+                        "최승운",
+                        ClubPosition.MANAGER,
+                        true
+                    ),
+                    new SheetImportPreviewResponse.PreviewMember(
+                        "2021232949",
+                        "김하나",
+                        ClubPosition.MEMBER,
+                        false
+                    )
+                ),
+                List.of("전화번호 형식 경고")
+            );
+
+            given(sheetImportService.previewPreMembersFromSheet(
+                eq(CLUB_ID),
+                eq(REQUESTER_ID),
+                eq(SPREADSHEET_URL)
+            )).willReturn(response);
+
+            SheetImportRequest request = new SheetImportRequest(SPREADSHEET_URL);
+
+            performPost("/clubs/" + CLUB_ID + "/sheet/import/preview", request)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.previewCount").value(2))
+                .andExpect(jsonPath("$.autoRegisteredCount").value(1))
+                .andExpect(jsonPath("$.preRegisteredCount").value(1))
+                .andExpect(jsonPath("$.members[0].studentNumber").value("2021232948"))
+                .andExpect(jsonPath("$.members[0].isDirectMember").value(true))
+                .andExpect(jsonPath("$.members[1].studentNumber").value("2021232949"))
+                .andExpect(jsonPath("$.members[1].isDirectMember").value(false))
+                .andExpect(jsonPath("$.warnings[0]").value("전화번호 형식 경고"));
+        }
+
+        @Test
+        @DisplayName("구글 스프레드시트 접근 권한이 없으면 403을 반환한다")
+        void previewPreMembersForbiddenGoogleSheetAccess() throws Exception {
+            given(sheetImportService.previewPreMembersFromSheet(
+                eq(CLUB_ID),
+                eq(REQUESTER_ID),
+                eq(SPREADSHEET_URL)
+            )).willThrow(CustomException.of(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS));
+
+            SheetImportRequest request = new SheetImportRequest(SPREADSHEET_URL);
+
+            performPost("/clubs/" + CLUB_ID + "/sheet/import/preview", request)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code")
+                    .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.name()))
+                .andExpect(jsonPath("$.message")
+                    .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.getMessage()));
+        }
     }
 
     @Nested

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
@@ -186,14 +186,14 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
                 eq(CLUB_ID),
                 eq(REQUESTER_ID),
                 eq(request.members())
-            )).willThrow(CustomException.of(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS));
+            )).willThrow(CustomException.of(ApiResponseCode.FORBIDDEN_CLUB_MANAGER_ACCESS));
 
             performPost("/clubs/" + CLUB_ID + "/sheet/import/confirm", request)
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code")
-                    .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.name()))
+                    .value(ApiResponseCode.FORBIDDEN_CLUB_MANAGER_ACCESS.name()))
                 .andExpect(jsonPath("$.message")
-                    .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.getMessage()));
+                    .value(ApiResponseCode.FORBIDDEN_CLUB_MANAGER_ACCESS.getMessage()));
         }
     }
 


### PR DESCRIPTION
### 📝 개요

* 구글 시트에서 불러올 부원 목록을 등록 전 미리보기 JSON으로 내려주는 API를 추가했습니다.
* 부원 수동 추가는 기존 `POST /clubs/{clubId}/pre-members` API로 처리 가능하도록 유지했습니다.

---

### 🔧 주요 변경 내용

* `POST /clubs/{clubId}/sheet/import/preview` API를 추가해 시트 불러오기 결과를 저장 없이 미리보기할 수 있도록 구현했습니다.
* `SheetImportPreviewResponse` DTO를 추가해 직접 등록 대상 부원과 사전 등록 대상 부원 목록, 경고 메시지를 함께 반환하도록 구성했습니다.
* `SheetImportService`에서 미리보기와 실제 import가 동일한 판별 로직을 공유하도록 정리해 화면 미리보기와 실제 등록 결과가 일치하도록 맞췄습니다.
* 시트 미리보기 API에 대한 통합 테스트와 서비스 테스트를 추가했습니다.

---

### 📎 참고 사항

* 학번과 이름을 직접 입력해서 부원을 추가하는 요구사항은 기존 `POST /clubs/{clubId}/pre-members` API가 이미 지원하고 있어 중복 API는 추가하지 않았습니다.
* Swagger 설명 문자열이 깨져 있던 일부 시트 API 문구를 함께 정리했습니다.

---

### ✅Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)
