### PR TITLE
refactor: 채팅 서비스 코드 중복 제거 및 단순화

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -20,7 +20,6 @@ import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
 import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.ClubMember;
 import gg.agit.konect.domain.club.repository.ClubMemberRepository;
-import gg.agit.konect.domain.user.enums.UserRole;
 import gg.agit.konect.domain.user.model.User;
 import gg.agit.konect.domain.user.repository.UserRepository;
 import gg.agit.konect.global.exception.CustomException;
@@ -68,7 +67,7 @@ public class ChatRoomMembershipService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateDirectRoomLastReadAt(Integer roomId, User user, LocalDateTime readAt, ChatRoom room) {
         // 어드민이 SYSTEM_ADMIN 방의 메시지를 읽으면 SYSTEM_ADMIN의 lastReadAt을 업데이트
-        if (user.getRole() == UserRole.ADMIN && isSystemAdminRoom(roomId)) {
+        if (user.isAdmin() && isSystemAdminRoom(roomId)) {
             chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, SYSTEM_ADMIN_ID, readAt);
             return;
         }
@@ -134,7 +133,7 @@ public class ChatRoomMembershipService {
 
         // 어드민은 SYSTEM_ADMIN 방의 메시지를 조회할 수 있지만, 멤버로 추가되지는 않는다
         // (멤버가 추가되면 findByTwoUsers에서 해당 방을 찾지 못해 채팅방이 중복 생성됨)
-        if (user.getRole() == UserRole.ADMIN && isSystemAdminRoom(room.getId())) {
+        if (user.isAdmin() && isSystemAdminRoom(room.getId())) {
             return;
         }
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class ChatRoomMembershipService {
 
-    private static final int SYSTEM_ADMIN_ID = 1;
+    public static final int SYSTEM_ADMIN_ID = 1;
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -621,72 +621,28 @@ public class ChatService {
             .toList();
     }
 
-    private ChatMessagePageResponse getDirectChatRoomMessages(
-        Integer userId,
-        Integer roomId,
-        Integer page,
-        Integer limit,
-        LocalDateTime readAt
-    ) {
-        ChatRoom chatRoom = getDirectRoom(roomId);
-        User user = userRepository.getById(userId);
-        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(getOrCreateDirectRoomMember(chatRoom, user),
-            chatRoom);
-
-        PageRequest pageable = PageRequest.of(page - 1, limit);
-        Page<ChatMessage> messages = chatMessageRepository.findByChatRoomId(roomId, visibleMessageFrom, pageable);
-
-        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
-
-        List<ChatMessageDetailResponse> responseMessages = messages.getContent().stream()
-            .map(message -> {
-                boolean isRead = message.isSentBy(userId) || !message.getCreatedAt().isAfter(readAt);
-                int unreadCount = countUnreadSince(message.getCreatedAt(), sortedReadBaselines);
-                return new ChatMessageDetailResponse(
-                    message.getId(),
-                    message.getSender().getId(),
-                    null,
-                    message.getContent(),
-                    message.getCreatedAt(),
-                    isRead,
-                    unreadCount,
-                    message.isSentBy(userId)
-                );
-            })
-            .toList();
-
-        return new ChatMessagePageResponse(
-            messages.getTotalElements(),
-            messages.getNumberOfElements(),
-            messages.getTotalPages(),
-            messages.getNumber() + 1,
-            null,
-            responseMessages
-        );
-    }
-
-    private ChatMessagePageResponse getAdminSystemDirectChatRoomMessages(
+    private ChatMessagePageResponse buildDirectChatRoomMessages(
         User user,
         ChatRoom chatRoom,
         Integer roomId,
         Integer page,
         Integer limit,
-        LocalDateTime readAt
+        LocalDateTime readAt,
+        LocalDateTime visibleMessageFrom,
+        List<LocalDateTime> sortedReadBaselines,
+        Integer maskedAdminId
     ) {
-        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        LocalDateTime visibleMessageFrom = resolveAdminSystemRoomVisibleMessageFrom(members);
-
         PageRequest pageable = PageRequest.of(page - 1, limit);
         Page<ChatMessage> messages = chatMessageRepository.findByChatRoomId(roomId, visibleMessageFrom, pageable);
 
-        List<LocalDateTime> sortedReadBaselines = toAdminChatReadBaselines(members);
-
-        Integer maskedAdminId = getMaskedAdminId(user, chatRoom);
         List<ChatMessageDetailResponse> responseMessages = messages.getContent().stream()
             .map(message -> {
-                Integer senderId = resolveDirectSenderId(message, maskedAdminId);
-                boolean isMine = shouldDisplayAsOwnMessage(user, message, true);
+                Integer senderId = maskedAdminId != null
+                    ? resolveDirectSenderId(message, maskedAdminId)
+                    : message.getSender().getId();
+                boolean isMine = maskedAdminId != null
+                    ? shouldDisplayAsOwnMessage(user, message, true)
+                    : message.isSentBy(user.getId());
                 boolean isRead = isMine || !message.getCreatedAt().isAfter(readAt);
                 int unreadCount = countUnreadSince(message.getCreatedAt(), sortedReadBaselines);
                 return new ChatMessageDetailResponse(
@@ -710,6 +666,43 @@ public class ChatService {
             null,
             responseMessages
         );
+    }
+
+    private ChatMessagePageResponse getDirectChatRoomMessages(
+        Integer userId,
+        Integer roomId,
+        Integer page,
+        Integer limit,
+        LocalDateTime readAt
+    ) {
+        ChatRoom chatRoom = getDirectRoom(roomId);
+        User user = userRepository.getById(userId);
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(getOrCreateDirectRoomMember(chatRoom, user),
+            chatRoom);
+
+        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
+
+        return buildDirectChatRoomMessages(user, chatRoom, roomId, page, limit, readAt,
+            visibleMessageFrom, sortedReadBaselines, null);
+    }
+
+    private ChatMessagePageResponse getAdminSystemDirectChatRoomMessages(
+        User user,
+        ChatRoom chatRoom,
+        Integer roomId,
+        Integer page,
+        Integer limit,
+        LocalDateTime readAt
+    ) {
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        LocalDateTime visibleMessageFrom = resolveAdminSystemRoomVisibleMessageFrom(members);
+
+        List<LocalDateTime> sortedReadBaselines = toAdminChatReadBaselines(members);
+        Integer maskedAdminId = getMaskedAdminId(user, chatRoom);
+
+        return buildDirectChatRoomMessages(user, chatRoom, roomId, page, limit, readAt,
+            visibleMessageFrom, sortedReadBaselines, maskedAdminId);
     }
 
     private ChatMessageDetailResponse sendDirectMessage(

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -35,7 +35,6 @@ import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomMatchesResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
-import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
 import gg.agit.konect.domain.chat.dto.ChatRoomSummaryResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomsSummaryResponse;
 import gg.agit.konect.domain.chat.dto.ChatSearchResponse;

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package gg.agit.konect.domain.chat.service;
 
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
 import static gg.agit.konect.global.code.ApiResponseCode.*;
 
 import java.time.LocalDateTime;
@@ -34,6 +35,7 @@ import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomMatchesResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
 import gg.agit.konect.domain.chat.dto.ChatRoomSummaryResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomsSummaryResponse;
 import gg.agit.konect.domain.chat.dto.ChatSearchResponse;
@@ -69,7 +71,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class ChatService {
 
-    private static final int SYSTEM_ADMIN_ID = 1;
     private static final String ETC_SECTION_NAME = "기타";
     private static final String DEFAULT_GROUP_ROOM_NAME = "그룹 채팅";
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1531,11 +1531,16 @@ public class ChatService {
     }
 
     private User findNonAdminUser(List<ChatRoomMember> members) {
-        return members.stream()
-            .map(ChatRoomMember::getUser)
-            .filter(memberUser -> !memberUser.isAdmin())
-            .findFirst()
-            .orElse(null);
+        Map<Integer, User> userMap = members.stream()
+            .collect(Collectors.toMap(
+                ChatRoomMember::getUserId,
+                ChatRoomMember::getUser,
+                (existing, replacement) -> existing
+            ));
+        List<MemberInfo> memberInfos = members.stream()
+            .map(m -> new MemberInfo(m.getUserId(), m.getCreatedAt()))
+            .toList();
+        return findNonAdminUserFromMemberInfo(memberInfos, userMap);
     }
 
     private User resolveDirectMessageReceiver(List<ChatRoomMember> members, User sender) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1297,11 +1297,10 @@ public class ChatService {
     }
 
     private List<LocalDateTime> toSortedReadBaselines(List<ChatRoomMember> members) {
-        List<LocalDateTime> baselines = members.stream()
+        return members.stream()
             .map(ChatRoomMember::getLastReadAt)
             .sorted()
             .toList();
-        return baselines;
     }
 
     private List<LocalDateTime> toAdminChatReadBaselines(List<ChatRoomMember> members) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -622,7 +622,6 @@ public class ChatService {
 
     private ChatMessagePageResponse buildDirectChatRoomMessages(
         User user,
-        ChatRoom chatRoom,
         Integer roomId,
         Integer page,
         Integer limit,
@@ -682,7 +681,7 @@ public class ChatService {
 
         List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
 
-        return buildDirectChatRoomMessages(user, chatRoom, roomId, page, limit, readAt,
+        return buildDirectChatRoomMessages(user, roomId, page, limit, readAt,
             visibleMessageFrom, sortedReadBaselines, null);
     }
 
@@ -700,7 +699,7 @@ public class ChatService {
         List<LocalDateTime> sortedReadBaselines = toAdminChatReadBaselines(members);
         Integer maskedAdminId = getMaskedAdminId(user, chatRoom);
 
-        return buildDirectChatRoomMessages(user, chatRoom, roomId, page, limit, readAt,
+        return buildDirectChatRoomMessages(user, roomId, page, limit, readAt,
             visibleMessageFrom, sortedReadBaselines, maskedAdminId);
     }
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -94,7 +94,7 @@ public class ChatService {
             throw CustomException.of(CANNOT_CREATE_CHAT_ROOM_WITH_SELF);
         }
 
-        if (currentUser.getRole() == UserRole.ADMIN && targetUser.getRole() != UserRole.ADMIN) {
+        if (currentUser.isAdmin() && !targetUser.isAdmin()) {
             return getOrCreateSystemAdminChatRoomForUser(targetUser, currentUser);
         }
 
@@ -396,7 +396,7 @@ public class ChatService {
         LocalDateTime readAt = LocalDateTime.now();
 
         if (room.isDirectRoom()) {
-            boolean isAdminViewingSystemRoom = user.getRole() == UserRole.ADMIN && isSystemAdminRoom(room);
+            boolean isAdminViewingSystemRoom = user.isAdmin() && isSystemAdminRoom(room);
             if (isAdminViewingSystemRoom) {
                 chatRoomMembershipService.updateLastReadAt(roomId, SYSTEM_ADMIN_ID, readAt);
                 recordPresenceSafely(roomId, userId);
@@ -448,7 +448,7 @@ public class ChatService {
             ensureRoomMember(room, member.getUser(), member.getCreatedAt());
         } else if (room.isDirectRoom()) {
             // 어드민이 SYSTEM_ADMIN 방에 접근하는 경우는 멤버십 체크를 건너뜀
-            boolean isAdminAccessingSystemAdminRoom = user.getRole() == UserRole.ADMIN
+            boolean isAdminAccessingSystemAdminRoom = user.isAdmin()
                 && isSystemAdminRoom(room);
             if (!isAdminAccessingSystemAdminRoom) {
                 getAccessibleDirectRoomMember(room, user);
@@ -491,7 +491,7 @@ public class ChatService {
     private List<ChatRoomSummaryResponse> getDirectChatRooms(Integer userId) {
         User user = userRepository.getById(userId);
 
-        if (user.getRole() == UserRole.ADMIN) {
+        if (user.isAdmin()) {
             return getAdminDirectChatRooms(userId);
         }
 
@@ -720,7 +720,7 @@ public class ChatService {
         User sender = userRepository.getById(userId);
 
         // 어드민이 SYSTEM_ADMIN 방에 메시지를 보내는 경우
-        boolean isAdminSendingToSystemAdminRoom = sender.getRole() == UserRole.ADMIN
+        boolean isAdminSendingToSystemAdminRoom = sender.isAdmin()
             && isSystemAdminRoom(chatRoom);
 
         ChatRoomMember senderMember = null;
@@ -1175,7 +1175,7 @@ public class ChatService {
     }
 
     private Integer getMaskedAdminId(User user, ChatRoom chatRoom) {
-        if (user.getRole() == UserRole.ADMIN) {
+        if (user.isAdmin()) {
             return null;
         }
 
@@ -1197,7 +1197,7 @@ public class ChatService {
     }
 
     private void publishAdminChatEventIfNeeded(boolean isSystemAdminRoom, User sender, String content) {
-        if (isSystemAdminRoom && sender.getRole() != UserRole.ADMIN) {
+        if (isSystemAdminRoom && !sender.isAdmin()) {
             eventPublisher.publishEvent(AdminChatReceivedEvent.of(sender.getId(), sender.getName(), content));
         }
     }
@@ -1260,7 +1260,7 @@ public class ChatService {
     private boolean shouldSkipSystemAdminMembership(ChatRoom room, User user) {
         // 문의방은 SYSTEM_ADMIN + 일반 사용자 2인 구조를 전제로 재사용(findByTwoUsers)되므로,
         // 생성/재오픈 경로에서도 일반 ADMIN을 멤버로 추가하면 안 된다.
-        return user.getRole() == UserRole.ADMIN && isSystemAdminRoom(room);
+        return user.isAdmin() && isSystemAdminRoom(room);
     }
 
     private String normalizeCustomRoomName(String roomName) {
@@ -1308,7 +1308,7 @@ public class ChatService {
         LocalDateTime userLastReadAt = null;
 
         for (ChatRoomMember member : members) {
-            if (member.getUser().getRole() == UserRole.ADMIN) {
+            if (member.getUser().isAdmin()) {
                 if (adminLastReadAt == null || member.getLastReadAt().isAfter(adminLastReadAt)) {
                     adminLastReadAt = member.getLastReadAt();
                 }
@@ -1383,7 +1383,7 @@ public class ChatService {
         return chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoom.getId(), user.getId())
             .orElseGet(() -> {
                 // 어드민은 SYSTEM_ADMIN 방에 멤버로 추가되지 않음
-                if (user.getRole() == UserRole.ADMIN && isSystemAdminRoom(chatRoom)) {
+                if (user.isAdmin() && isSystemAdminRoom(chatRoom)) {
                     throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
                 }
                 throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -1440,13 +1440,13 @@ public class ChatService {
         boolean isAdminViewingSystemRoom
     ) {
         if (isAdminViewingSystemRoom) {
-            return message.getSender().getRole() == UserRole.ADMIN;
+            return message.getSender().isAdmin();
         }
         return message.isSentBy(currentUser.getId());
     }
 
     private Integer resolveDirectSenderId(ChatMessage message, Integer maskedAdminId) {
-        if (maskedAdminId != null && message.getSender().getRole() == UserRole.ADMIN) {
+        if (maskedAdminId != null && message.getSender().isAdmin()) {
             return maskedAdminId;
         }
         return message.getSender().getId();
@@ -1533,13 +1533,13 @@ public class ChatService {
     private User findNonAdminUser(List<ChatRoomMember> members) {
         return members.stream()
             .map(ChatRoomMember::getUser)
-            .filter(memberUser -> memberUser.getRole() != UserRole.ADMIN)
+            .filter(memberUser -> !memberUser.isAdmin())
             .findFirst()
             .orElse(null);
     }
 
     private User resolveDirectMessageReceiver(List<ChatRoomMember> members, User sender) {
-        if (sender.getRole() == UserRole.ADMIN) {
+        if (sender.isAdmin()) {
             User nonAdminUser = findNonAdminUser(members);
             if (nonAdminUser != null) {
                 return nonAdminUser;
@@ -1585,7 +1585,7 @@ public class ChatService {
             .sorted(Comparator.comparing(MemberInfo::createdAt))
             .map(info -> userMap.get(info.userId()))
             .filter(Objects::nonNull)
-            .filter(user -> user.getRole() != UserRole.ADMIN)
+            .filter(user -> !user.isAdmin())
             .findFirst()
             .orElse(null);
     }
@@ -1595,7 +1595,7 @@ public class ChatService {
         List<MemberInfo> memberInfos,
         Map<Integer, User> userMap
     ) {
-        if (sender.getRole() == UserRole.ADMIN) {
+        if (sender.isAdmin()) {
             User nonAdminUser = findNonAdminUserFromMemberInfo(memberInfos, userMap);
             if (nonAdminUser != null) {
                 return nonAdminUser;

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1537,18 +1537,16 @@ public class ChatService {
     }
 
     private User resolveDirectMessageReceiver(List<ChatRoomMember> members, User sender) {
-        if (sender.isAdmin()) {
-            User nonAdminUser = findNonAdminUser(members);
-            if (nonAdminUser != null) {
-                return nonAdminUser;
-            }
-        }
-
-        User partner = resolveDirectChatPartner(members, sender.getId());
-        if (partner == null) {
-            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
-        }
-        return partner;
+        Map<Integer, User> userMap = members.stream()
+            .collect(Collectors.toMap(
+                ChatRoomMember::getUserId,
+                ChatRoomMember::getUser,
+                (existing, replacement) -> existing
+            ));
+        List<MemberInfo> memberInfos = members.stream()
+            .map(m -> new MemberInfo(m.getUserId(), m.getCreatedAt()))
+            .toList();
+        return resolveMessageReceiverFromMemberInfo(sender, memberInfos, userMap);
     }
 
     private User findDirectPartnerFromMemberInfo(


### PR DESCRIPTION
### 🔍 개요

* 


---

### 🚀 주요 변경 내용

### 1. user.isAdmin() 메서드 활용
- `user.getRole() == UserRole.ADMIN` → `user.isAdmin()` 일괄 변경
- `ChatService` 16개 위치, `ChatRoomMembershipService` 2개 위치 수정
- 불필요한 `UserRole` import 제거

### 2. SYSTEM_ADMIN_ID 상수 중복 제거
- `ChatRoomMembershipService.SYSTEM_ADMIN_ID`를 `public`으로 변경
- `ChatService`의 중복 상수 정의 제거
- `ChatService`에서 static import로 참조하도록 변경

### 3. 메서드 단순화 및 통합

#### toSortedReadBaselines
- 불필요한 지역 변수 제거하고 바로 반환하도록 변경

#### findNonAdminUser 통합
- `findNonAdminUser`가 내부적으로 `MemberInfo`로 변환 후 `findNonAdminUserFromMemberInfo` 호출
- 중복된 필터링 로직 제거

#### getDirectChatRoomMessages 메서드 통합
- `buildDirectChatRoomMessages` 공통 메서드 추출
- `getDirectChatRoomMessages`와 `getAdminSystemDirectChatRoomMessages`가 공통 메서드를 호출하도록 변경
- 중복된 메시지 조회 및 매핑 로직 제거

#### resolveDirectMessageReceiver 통합
- `resolveDirectMessageReceiver`가 `MemberInfo`로 변환 후 `resolveMessageReceiverFromMemberInfo` 호출
- 중복된 수신자 결정 로직 제거

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
