### PR TITLE
feat: 동아리 사전 등록 회원 배치 등록 API 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberApi.java
@@ -31,7 +31,7 @@ public interface ClubMemberApi {
     @Operation(summary = "동아리 회원의 직책을 변경한다.", description = """
         동아리 회장 또는 부회장만 회원의 직책을 변경할 수 있습니다.
         자기 자신의 직책은 변경할 수 없으며, 상위 직급만 하위 직급의 회원을 관리할 수 있습니다.
-
+        
         ## 에러
         - CANNOT_CHANGE_OWN_POSITION (400): 자기 자신의 직책은 변경할 수 없습니다.
         - CANNOT_MANAGE_HIGHER_POSITION (400): 자신보다 높은 직급의 회원은 관리할 수 없습니다.
@@ -52,7 +52,7 @@ public interface ClubMemberApi {
     @Operation(summary = "동아리 회장 권한을 위임한다.", description = """
         현재 회장만 회장 권한을 다른 회원에게 위임할 수 있습니다.
         회장 위임 시 현재 회장은 일반회원으로 강등됩니다.
-
+        
         ## 에러
         - ILLEGAL_ARGUMENT (400): 자기 자신에게는 위임할 수 없습니다.
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 회장 권한이 없습니다.
@@ -69,7 +69,7 @@ public interface ClubMemberApi {
     @Operation(summary = "동아리 부회장을 변경한다.", description = """
         동아리 회장만 부회장을 임명하거나 해제할 수 있습니다.
         vicePresidentUserId가 null이면 부회장을 해제하고, 값이 있으면 해당 회원을 부회장으로 임명합니다.
-
+        
         ## 에러
         - CANNOT_CHANGE_OWN_POSITION (400): 자기 자신을 부회장으로 임명할 수 없습니다.
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 회장 권한이 없습니다.
@@ -95,7 +95,7 @@ public interface ClubMemberApi {
           - 사전 등록된 회원이 서비스에 가입하면 지정한 직책(clubPosition)으로 자동 전환됩니다.
           - clubPosition이 PRESIDENT인 경우, 기존 회장 회원 정보는 제거되고 새 가입자가 회장으로 등록됩니다.
           - 응답의 `isDirectMember`가 `false`로 반환됩니다.
-
+        
         ## 에러
         - ALREADY_CLUB_MEMBER (409): 이미 동아리 회원입니다. (서비스 가입자인 경우)
         - ALREADY_CLUB_PRE_MEMBER (409): 이미 동아리에 사전 등록된 회원입니다. (서비스 미가입자인 경우)
@@ -111,13 +111,13 @@ public interface ClubMemberApi {
 
     @Operation(summary = "학번으로 여러 회원을 동아리에 일괄 등록한다.", description = """
         운영진 이상만 사전 등록 회원을 일괄 등록할 수 있습니다.
-
+        
         ## 로직
         - 각 회원은 개별적으로 처리되어, 일부 실패 시에도 나머지는 등록됩니다.
         - 해당 학번의 사용자가 이미 서비스에 가입한 경우: 동아리 회원(ClubMember)에 직접 추가됩니다.
         - 해당 학번의 사용자가 서비스에 가입하지 않은 경우: 사전 회원(ClubPreMember)으로 등록됩니다.
         - 응답의 `success` 필드로 개별 회원의 등록 성공 여부를 확인할 수 있습니다.
-
+        
         ## 에러
         - INVALID_INPUT (400): 회원 목록은 1~50명까지 가능합니다.
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
@@ -133,7 +133,7 @@ public interface ClubMemberApi {
 
     @Operation(summary = "동아리 사전 등록 회원 리스트를 조회한다.", description = """
         동아리 운영진 권한부터 사전 등록 회원 리스트를 조회할 수 있습니다.
-
+        
         ## 에러
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
@@ -146,7 +146,7 @@ public interface ClubMemberApi {
 
     @Operation(summary = "동아리 사전 등록 회원을 삭제한다.", description = """
         동아리 운영진 권한부터 사전 등록 회원을 삭제할 수 있습니다.
-
+        
         ## 에러
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
@@ -162,7 +162,7 @@ public interface ClubMemberApi {
     @Operation(summary = "동아리 회원을 강제 탈퇴시킨다.", description = """
         동아리 회장 또는 부회장만 회원을 강제 탈퇴시킬 수 있습니다.
         일반회원만 강제 탈퇴 가능하며, 부회장이나 운영진은 먼저 직책을 변경한 후 탈퇴시켜야 합니다.
-
+        
         ## 에러
         - CANNOT_REMOVE_SELF (400): 자기 자신을 강제 탈퇴시킬 수 없습니다.
         - CANNOT_REMOVE_NON_MEMBER (400): 일반회원만 강제 탈퇴할 수 있습니다.

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberApi.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddRequest;
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddResponse;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddRequest;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddResponse;
 import gg.agit.konect.domain.club.dto.ClubMemberChangesResponse;
 import gg.agit.konect.domain.club.dto.ClubMemberResponse;
 import gg.agit.konect.domain.club.dto.ClubPreMembersResponse;
@@ -104,6 +106,28 @@ public interface ClubMemberApi {
     ResponseEntity<ClubPreMemberAddResponse> addPreMember(
         @PathVariable(name = "clubId") Integer clubId,
         @Valid @RequestBody ClubPreMemberAddRequest request,
+        @UserId Integer userId
+    );
+
+    @Operation(summary = "학번으로 여러 회원을 동아리에 일괄 등록한다.", description = """
+        운영진 이상만 사전 등록 회원을 일괄 등록할 수 있습니다.
+
+        ## 로직
+        - 각 회원은 개별적으로 처리되어, 일부 실패 시에도 나머지는 등록됩니다.
+        - 해당 학번의 사용자가 이미 서비스에 가입한 경우: 동아리 회원(ClubMember)에 직접 추가됩니다.
+        - 해당 학번의 사용자가 서비스에 가입하지 않은 경우: 사전 회원(ClubPreMember)으로 등록됩니다.
+        - 응답의 `success` 필드로 개별 회원의 등록 성공 여부를 확인할 수 있습니다.
+
+        ## 에러
+        - INVALID_INPUT (400): 회원 목록은 1~50명까지 가능합니다.
+        - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
+        - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
+        """
+    )
+    @PostMapping("/{clubId}/pre-members/batch")
+    ResponseEntity<ClubPreMemberBatchAddResponse> addPreMembersBatch(
+        @PathVariable(name = "clubId") Integer clubId,
+        @Valid @RequestBody ClubPreMemberBatchAddRequest request,
         @UserId Integer userId
     );
 

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberController.java
@@ -84,7 +84,8 @@ public class ClubMemberController implements ClubMemberApi {
         @Valid @RequestBody ClubPreMemberBatchAddRequest request,
         @UserId Integer userId
     ) {
-        ClubPreMemberBatchAddResponse response = clubMemberManagementService.addPreMembersBatch(clubId, userId, request);
+        ClubPreMemberBatchAddResponse response = clubMemberManagementService.addPreMembersBatch(clubId, userId,
+            request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubMemberController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddRequest;
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddResponse;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddRequest;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddResponse;
 import gg.agit.konect.domain.club.dto.ClubMemberChangesResponse;
 import gg.agit.konect.domain.club.dto.ClubMemberResponse;
 import gg.agit.konect.domain.club.dto.ClubPreMembersResponse;
@@ -73,6 +75,16 @@ public class ClubMemberController implements ClubMemberApi {
         @UserId Integer userId
     ) {
         ClubPreMemberAddResponse response = clubMemberManagementService.addPreMember(clubId, userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<ClubPreMemberBatchAddResponse> addPreMembersBatch(
+        @PathVariable(name = "clubId") Integer clubId,
+        @Valid @RequestBody ClubPreMemberBatchAddRequest request,
+        @UserId Integer userId
+    ) {
+        ClubPreMemberBatchAddResponse response = clubMemberManagementService.addPreMembersBatch(clubId, userId, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
@@ -5,6 +5,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -12,6 +13,6 @@ public record ClubPreMemberBatchAddRequest(
     @NotNull(message = "회원 목록은 필수입니다.")
     @Size(min = 1, max = 300, message = "회원은 최소 1명에서 최대 300명까지 등록할 수 있습니다.")
     @Schema(description = "사전 등록할 회원 목록", requiredMode = REQUIRED)
-    List<@NotNull ClubPreMemberAddRequest> members
+    @Valid List<@NotNull ClubPreMemberAddRequest> members
 ) {
 }

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
@@ -11,8 +11,9 @@ import jakarta.validation.constraints.Size;
 
 public record ClubPreMemberBatchAddRequest(
     @NotNull(message = "회원 목록은 필수입니다.")
+    @Valid
     @Size(min = 1, max = 50, message = "회원은 최소 1명에서 최대 50명까지 등록할 수 있습니다.")
     @Schema(description = "사전 등록할 회원 목록", requiredMode = REQUIRED)
-    List<ClubPreMemberAddRequest> members
+    List<@NotNull ClubPreMemberAddRequest> members
 ) {
 }

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
@@ -6,9 +6,11 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ClubPreMemberBatchAddRequest(
+    @NotNull(message = "회원 목록은 필수입니다.")
     @Size(min = 1, max = 50, message = "회원은 최소 1명에서 최대 50명까지 등록할 수 있습니다.")
     @Schema(description = "사전 등록할 회원 목록", requiredMode = REQUIRED)
     List<ClubPreMemberAddRequest> members

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
@@ -1,0 +1,16 @@
+package gg.agit.konect.domain.club.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+public record ClubPreMemberBatchAddRequest(
+    @Size(min = 1, max = 50, message = "회원은 최소 1명에서 최대 50명까지 등록할 수 있습니다.")
+    @Schema(description = "사전 등록할 회원 목록", requiredMode = REQUIRED)
+    List<ClubPreMemberAddRequest> members
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Size;
 
 public record ClubPreMemberBatchAddRequest(
     @NotNull(message = "회원 목록은 필수입니다.")
-    @Size(min = 1, max = 50, message = "회원은 최소 1명에서 최대 50명까지 등록할 수 있습니다.")
+    @Size(min = 1, max = 300, message = "회원은 최소 1명에서 최대 300명까지 등록할 수 있습니다.")
     @Schema(description = "사전 등록할 회원 목록", requiredMode = REQUIRED)
     List<@NotNull ClubPreMemberAddRequest> members
 ) {

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddRequest.java
@@ -5,13 +5,11 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ClubPreMemberBatchAddRequest(
     @NotNull(message = "회원 목록은 필수입니다.")
-    @Valid
     @Size(min = 1, max = 50, message = "회원은 최소 1명에서 최대 50명까지 등록할 수 있습니다.")
     @Schema(description = "사전 등록할 회원 목록", requiredMode = REQUIRED)
     List<@NotNull ClubPreMemberAddRequest> members

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddResponse.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddResponse.java
@@ -22,7 +22,7 @@ public record ClubPreMemberBatchAddResponse(
 
     public static ClubPreMemberBatchAddResponse from(List<ClubPreMemberBatchResultItem> results) {
         int totalCount = results.size();
-        int successCount = (int) results.stream()
+        int successCount = (int)results.stream()
             .filter(ClubPreMemberBatchResultItem::success)
             .count();
         int failedCount = totalCount - successCount;

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddResponse.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchAddResponse.java
@@ -1,0 +1,32 @@
+package gg.agit.konect.domain.club.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ClubPreMemberBatchAddResponse(
+    @Schema(description = "전체 요청 수", example = "10", requiredMode = REQUIRED)
+    Integer totalCount,
+
+    @Schema(description = "성공한 회원 수", example = "8", requiredMode = REQUIRED)
+    Integer successCount,
+
+    @Schema(description = "실패한 회원 수", example = "2", requiredMode = REQUIRED)
+    Integer failedCount,
+
+    @Schema(description = "개별 처리 결과 목록", requiredMode = REQUIRED)
+    List<ClubPreMemberBatchResultItem> results
+) {
+
+    public static ClubPreMemberBatchAddResponse from(List<ClubPreMemberBatchResultItem> results) {
+        int totalCount = results.size();
+        int successCount = (int) results.stream()
+            .filter(ClubPreMemberBatchResultItem::success)
+            .count();
+        int failedCount = totalCount - successCount;
+
+        return new ClubPreMemberBatchAddResponse(totalCount, successCount, failedCount, results);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchResultItem.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubPreMemberBatchResultItem.java
@@ -1,0 +1,65 @@
+package gg.agit.konect.domain.club.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import gg.agit.konect.domain.club.enums.ClubPosition;
+import gg.agit.konect.global.code.ApiResponseCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ClubPreMemberBatchResultItem(
+    @Schema(description = "학번", example = "2021136089", requiredMode = REQUIRED)
+    String studentNumber,
+
+    @Schema(description = "이름", example = "홍길동", requiredMode = REQUIRED)
+    String name,
+
+    @Schema(description = "성공 여부", example = "true", requiredMode = REQUIRED)
+    Boolean success,
+
+    // 성공 시 반환되는 필드
+    @Schema(description = "동아리 고유 ID (성공 시)", example = "1")
+    Integer clubId,
+
+    @Schema(description = "가입 직책 (성공 시)", example = "MEMBER")
+    ClubPosition clubPosition,
+
+    @Schema(description = "직접 회원 가입 여부 (성공 시: true면 ClubMember 직접 추가, false면 ClubPreMember 사전등록)",
+        example = "false")
+    Boolean isDirectMember,
+
+    // 실패 시 반환되는 필드
+    @Schema(description = "오류 코드 (실패 시)", example = "ALREADY_CLUB_MEMBER")
+    String errorCode,
+
+    @Schema(description = "오류 메시지 (실패 시)", example = "이미 동아리 회원입니다.")
+    String errorMessage
+) {
+
+    public static ClubPreMemberBatchResultItem success(ClubPreMemberAddRequest request,
+        ClubPreMemberAddResponse response) {
+        return new ClubPreMemberBatchResultItem(
+            request.studentNumber(),
+            request.name(),
+            true,
+            response.clubId(),
+            response.clubPosition(),
+            response.isDirectMember(),
+            null,
+            null
+        );
+    }
+
+    public static ClubPreMemberBatchResultItem fail(ClubPreMemberAddRequest request,
+        ApiResponseCode errorCode) {
+        return new ClubPreMemberBatchResultItem(
+            request.studentNumber(),
+            request.name(),
+            false,
+            null,
+            null,
+            null,
+            errorCode.name(),
+            errorCode.getMessage()
+        );
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -5,14 +5,20 @@ import static gg.agit.konect.global.code.ApiResponseCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddRequest;
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddResponse;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddRequest;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddResponse;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchResultItem;
 import gg.agit.konect.domain.club.dto.ClubPreMembersResponse;
 import gg.agit.konect.domain.club.dto.MemberPositionChangeRequest;
 import gg.agit.konect.domain.club.dto.PresidentTransferRequest;
@@ -42,6 +48,7 @@ public class ClubMemberManagementService {
     private final ClubPermissionValidator clubPermissionValidator;
     private final UserRepository userRepository;
     private final ChatRoomMembershipService chatRoomMembershipService;
+    private final PlatformTransactionManager transactionManager;
 
     @Transactional
     public ClubMember changeMemberPosition(
@@ -159,6 +166,59 @@ public class ClubMemberManagementService {
 
         ClubPreMember savedPreMember = clubPreMemberRepository.save(preMember);
         return ClubPreMemberAddResponse.from(savedPreMember);
+    }
+
+    public ClubPreMemberBatchAddResponse addPreMembersBatch(
+        Integer clubId,
+        Integer requesterId,
+        ClubPreMemberBatchAddRequest request
+    ) {
+        Club club = clubRepository.getById(clubId);
+
+        clubPermissionValidator.validateManagerAccess(clubId, requesterId);
+
+        List<ClubPreMemberBatchResultItem> results = new ArrayList<>();
+
+        for (ClubPreMemberAddRequest memberRequest : request.members()) {
+            try {
+                TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+                ClubPreMemberAddResponse response = Objects.requireNonNull(
+                    transactionTemplate.execute(status -> processSinglePreMember(club, memberRequest))
+                );
+                results.add(ClubPreMemberBatchResultItem.success(memberRequest, response));
+            } catch (CustomException e) {
+                results.add(ClubPreMemberBatchResultItem.fail(memberRequest, e.getErrorCode()));
+            } catch (Exception e) {
+                results.add(ClubPreMemberBatchResultItem.fail(memberRequest, UNEXPECTED_SERVER_ERROR));
+            }
+        }
+
+        return ClubPreMemberBatchAddResponse.from(results);
+    }
+
+    private ClubPreMemberAddResponse processSinglePreMember(Club club, ClubPreMemberAddRequest request) {
+        String studentNumber = request.studentNumber();
+        String name = request.name();
+        ClubPosition clubPosition = request.clubPosition() == null ? MEMBER : request.clubPosition();
+        Integer universityId = club.getUniversity().getId();
+
+        List<User> candidates = userRepository.findAllByUniversityIdAndStudentNumber(
+            universityId, studentNumber
+        );
+
+        List<User> matchedUsers = candidates.stream()
+            .filter(user -> name.equals(user.getName()))
+            .toList();
+
+        if (matchedUsers.isEmpty()) {
+            return addPreMemberInternal(club, studentNumber, name, clubPosition);
+        }
+
+        if (matchedUsers.size() == 1) {
+            return addDirectMember(club, matchedUsers.get(0), clubPosition);
+        }
+
+        throw CustomException.of(AMBIGUOUS_USER_MATCH);
     }
 
     public ClubPreMembersResponse getPreMembers(Integer clubId, Integer requesterId) {

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -178,12 +178,12 @@ public class ClubMemberManagementService {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         List<ClubPreMemberBatchResultItem> results = new ArrayList<>();
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
 
         for (ClubPreMemberAddRequest memberRequest : request.members()) {
             try {
-                TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
                 ClubPreMemberAddResponse response = Objects.requireNonNull(
-                    transactionTemplate.execute(status -> processSinglePreMember(club, memberRequest))
+                    transactionTemplate.execute(status -> addPreMember(clubId, requesterId, memberRequest))
                 );
                 results.add(ClubPreMemberBatchResultItem.success(memberRequest, response));
             } catch (CustomException e) {
@@ -194,31 +194,6 @@ public class ClubMemberManagementService {
         }
 
         return ClubPreMemberBatchAddResponse.from(results);
-    }
-
-    private ClubPreMemberAddResponse processSinglePreMember(Club club, ClubPreMemberAddRequest request) {
-        String studentNumber = request.studentNumber();
-        String name = request.name();
-        ClubPosition clubPosition = request.clubPosition() == null ? MEMBER : request.clubPosition();
-        Integer universityId = club.getUniversity().getId();
-
-        List<User> candidates = userRepository.findAllByUniversityIdAndStudentNumber(
-            universityId, studentNumber
-        );
-
-        List<User> matchedUsers = candidates.stream()
-            .filter(user -> name.equals(user.getName()))
-            .toList();
-
-        if (matchedUsers.isEmpty()) {
-            return addPreMemberInternal(club, studentNumber, name, clubPosition);
-        }
-
-        if (matchedUsers.size() == 1) {
-            return addDirectMember(club, matchedUsers.get(0), clubPosition);
-        }
-
-        throw CustomException.of(AMBIGUOUS_USER_MATCH);
     }
 
     public ClubPreMembersResponse getPreMembers(Integer clubId, Integer requesterId) {

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -98,6 +98,13 @@ public class ClubMemberManagementService {
 
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
+        return processPreMemberWithoutValidation(club, request);
+    }
+
+    private ClubPreMemberAddResponse processPreMemberWithoutValidation(
+        Club club,
+        ClubPreMemberAddRequest request
+    ) {
         String studentNumber = request.studentNumber();
         String name = request.name();
         ClubPosition clubPosition = request.clubPosition() == null ? MEMBER : request.clubPosition();
@@ -173,7 +180,7 @@ public class ClubMemberManagementService {
         Integer requesterId,
         ClubPreMemberBatchAddRequest request
     ) {
-        clubRepository.getById(clubId);
+        Club club = clubRepository.getById(clubId);
 
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
@@ -183,7 +190,7 @@ public class ClubMemberManagementService {
         for (ClubPreMemberAddRequest memberRequest : request.members()) {
             try {
                 ClubPreMemberAddResponse response = Objects.requireNonNull(
-                    transactionTemplate.execute(status -> addPreMember(clubId, requesterId, memberRequest))
+                    transactionTemplate.execute(status -> processPreMemberWithoutValidation(club, memberRequest))
                 );
                 results.add(ClubPreMemberBatchResultItem.success(memberRequest, response));
             } catch (CustomException e) {

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberManagementService.java
@@ -173,7 +173,7 @@ public class ClubMemberManagementService {
         Integer requesterId,
         ClubPreMemberBatchAddRequest request
     ) {
-        Club club = clubRepository.getById(clubId);
+        clubRepository.getById(clubId);
 
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubMemberManagementServiceBatchTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubMemberManagementServiceBatchTest.java
@@ -1,0 +1,114 @@
+package gg.agit.konect.domain.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.dto.ClubPreMemberAddRequest;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddRequest;
+import gg.agit.konect.domain.club.enums.ClubPosition;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubPreMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubRepository;
+import gg.agit.konect.domain.university.enums.Campus;
+import gg.agit.konect.domain.university.model.University;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class ClubMemberManagementServiceBatchTest {
+
+    @InjectMocks
+    private ClubMemberManagementService clubMemberManagementService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private ClubPreMemberRepository clubPreMemberRepository;
+
+    @Mock
+    private ClubPermissionValidator clubPermissionValidator;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatRoomMembershipService chatRoomMembershipService;
+
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
+    private Club club;
+    private University university;
+    private Integer clubId = 1;
+    private Integer requesterId = 100;
+
+    @BeforeEach
+    void setUp() {
+        university = University.builder()
+            .id(1)
+            .koreanName("Test University")
+            .campus(Campus.MAIN)
+            .build();
+
+        club = Club.builder()
+            .id(clubId)
+            .name("Test Club")
+            .university(university)
+            .build();
+    }
+
+    @Test
+    @DisplayName("배치 등록 요청 시 권한 검증이 먼저 수행된다")
+    void addPreMembersBatch_validatesPermissionFirst() {
+        // given
+        when(clubRepository.getById(clubId)).thenReturn(club);
+        doThrow(CustomException.of(ApiResponseCode.FORBIDDEN_CLUB_MANAGER_ACCESS))
+            .when(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
+
+        ClubPreMemberAddRequest request = new ClubPreMemberAddRequest("2022000001", "학생1", ClubPosition.MEMBER);
+        ClubPreMemberBatchAddRequest batchRequest = new ClubPreMemberBatchAddRequest(List.of(request));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            clubMemberManagementService.addPreMembersBatch(clubId, requesterId, batchRequest);
+        });
+        assertThat(exception.getErrorCode()).isEqualTo(ApiResponseCode.FORBIDDEN_CLUB_MANAGER_ACCESS);
+    }
+
+    @Test
+    @DisplayName("배치 등록 요청은 최소 1명 이상의 회원이 필요하다")
+    void addPreMembersBatch_requiresAtLeastOneMember() {
+        // given
+        ClubPreMemberBatchAddRequest batchRequest = new ClubPreMemberBatchAddRequest(List.of());
+
+        // when & then - Bean Validation은 컨트롤러 계층에서 처리되므로 서비스에서는 정상 동작
+        // 실제로는 컨트롤러에서 @Valid로 인해 400 에러가 반환됨
+        when(clubRepository.getById(clubId)).thenReturn(club);
+
+        // 빈 리스트로 호출해도 서비스는 동작하되 결과는 빈 리스트
+        var response = clubMemberManagementService.addPreMembersBatch(clubId, requesterId, batchRequest);
+        assertThat(response.totalCount()).isEqualTo(0);
+        assertThat(response.successCount()).isEqualTo(0);
+        assertThat(response.failedCount()).isEqualTo(0);
+    }
+}

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
@@ -442,14 +442,14 @@ class ClubMemberApiTest extends IntegrationTestSupport {
         }
 
         @Test
-        @DisplayName("50명 초과 요청 시 400을 반환한다")
+        @DisplayName("300명 초과 요청 시 400을 반환한다")
         void addPreMembersBatchExceedsLimit() throws Exception {
             // given
             clearPersistenceContext();
             mockLoginUser(president.getId());
 
             List<ClubPreMemberAddRequest> members = new ArrayList<>();
-            for (int i = 0; i < 51; i++) {
+            for (int i = 0; i < 301; i++) {
                 members.add(
                     new ClubPreMemberAddRequest("2022" + String.format("%06d", i), "학생" + i, ClubPosition.MEMBER));
             }

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
@@ -416,8 +416,8 @@ class ClubMemberApiTest extends IntegrationTestSupport {
                 {"members": [{"studentNumber": "%s", "name": "%s", "clubPosition": "MEMBER"}]}
                 """.formatted(existingUser.getStudentNumber(), existingUser.getName());
             mockMvc.perform(post("/clubs/" + club.getId() + "/pre-members/batch")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(firstRequest));
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(firstRequest));
             clearPersistenceContext();
             mockLoginUser(president.getId());
 
@@ -450,7 +450,8 @@ class ClubMemberApiTest extends IntegrationTestSupport {
 
             List<ClubPreMemberAddRequest> members = new ArrayList<>();
             for (int i = 0; i < 51; i++) {
-                members.add(new ClubPreMemberAddRequest("2022" + String.format("%06d", i), "학생" + i, ClubPosition.MEMBER));
+                members.add(
+                    new ClubPreMemberAddRequest("2022" + String.format("%06d", i), "학생" + i, ClubPosition.MEMBER));
             }
             ClubPreMemberBatchAddRequest request = new ClubPreMemberBatchAddRequest(members);
 

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
@@ -2,8 +2,12 @@ package gg.agit.konect.integration.domain.club;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddRequest;
+import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddRequest;
 import gg.agit.konect.domain.club.dto.MemberPositionChangeRequest;
 import gg.agit.konect.domain.club.dto.PresidentTransferRequest;
 import gg.agit.konect.domain.club.dto.VicePresidentChangeRequest;
@@ -361,6 +366,116 @@ class ClubMemberApiTest extends IntegrationTestSupport {
             // when & then
             performPost("/clubs/" + club.getId() + "/pre-members", request)
                 .andExpect(status().isForbidden());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /clubs/{clubId}/pre-members/batch - 사전 멤버 일괄 등록")
+    class AddPreMembersBatch {
+
+        @Test
+        @DisplayName("여러 명의 사전 멤버를 일괄 등록한다")
+        void addPreMembersBatchSuccess() throws Exception {
+            // given
+            clearPersistenceContext();
+            mockLoginUser(president.getId());
+
+            List<ClubPreMemberAddRequest> members = List.of(
+                new ClubPreMemberAddRequest("2022000001", "신입생1", ClubPosition.MEMBER),
+                new ClubPreMemberAddRequest("2022000002", "신입생2", ClubPosition.MEMBER),
+                new ClubPreMemberAddRequest("2022000003", "신입생3", ClubPosition.MANAGER)
+            );
+            ClubPreMemberBatchAddRequest request = new ClubPreMemberBatchAddRequest(members);
+
+            // when & then
+            performPost("/clubs/" + club.getId() + "/pre-members/batch", request)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(3))
+                .andExpect(jsonPath("$.successCount").value(3))
+                .andExpect(jsonPath("$.failedCount").value(0))
+                .andExpect(jsonPath("$.results", hasSize(3)))
+                .andExpect(jsonPath("$.results[0].success").value(true))
+                .andExpect(jsonPath("$.results[1].success").value(true))
+                .andExpect(jsonPath("$.results[2].success").value(true));
+        }
+
+        @Test
+        @DisplayName("일부 실패 시에도 나머지는 등록된다 (부분 성공)")
+        void addPreMembersBatchPartialSuccess() throws Exception {
+            // given - 이미 존재하는 사용자를 먼저 사전 등록
+            User existingUser = persist(UserFixture.createUser(university, "기존유저", "2022000002"));
+            clearPersistenceContext();
+            mockLoginUser(president.getId());
+
+            // 첫 번째는 이미 등록됨(실패 예상), 두 번째는 신규(성공 예상)
+            List<ClubPreMemberAddRequest> members = List.of(
+                new ClubPreMemberAddRequest(existingUser.getStudentNumber(), existingUser.getName(), ClubPosition.MEMBER),
+                new ClubPreMemberAddRequest("2022000003", "신입생", ClubPosition.MEMBER)
+            );
+            // 먼저 첫 번째 멤버를 등록하여 중복 상황 만들기
+            performPost("/clubs/" + club.getId() + "/pre-members", members.get(0));
+            clearPersistenceContext();
+            mockLoginUser(president.getId());
+
+            ClubPreMemberBatchAddRequest batchRequest = new ClubPreMemberBatchAddRequest(members);
+
+            // when & then - 같은 멤버를 다시 배치 등록 시도
+            performPost("/clubs/" + club.getId() + "/pre-members/batch", batchRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(2))
+                .andExpect(jsonPath("$.successCount").value(1))
+                .andExpect(jsonPath("$.failedCount").value(1))
+                .andExpect(jsonPath("$.results[0].success").value(false))
+                .andExpect(jsonPath("$.results[1].success").value(true));
+        }
+
+        @Test
+        @DisplayName("50명 초과 요청 시 400을 반환한다")
+        void addPreMembersBatchExceedsLimit() throws Exception {
+            // given
+            clearPersistenceContext();
+            mockLoginUser(president.getId());
+
+            List<ClubPreMemberAddRequest> members = new ArrayList<>();
+            for (int i = 0; i < 51; i++) {
+                members.add(new ClubPreMemberAddRequest("2022" + String.format("%06d", i), "학생" + i, ClubPosition.MEMBER));
+            }
+            ClubPreMemberBatchAddRequest request = new ClubPreMemberBatchAddRequest(members);
+
+            // when & then
+            performPost("/clubs/" + club.getId() + "/pre-members/batch", request)
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("일반 멤버는 배치 등록을 할 수 없다")
+        void addPreMembersBatchByMemberFails() throws Exception {
+            // given
+            clearPersistenceContext();
+            mockLoginUser(member.getId());
+
+            List<ClubPreMemberAddRequest> members = List.of(
+                new ClubPreMemberAddRequest("2022000001", "신입생", ClubPosition.MEMBER)
+            );
+            ClubPreMemberBatchAddRequest request = new ClubPreMemberBatchAddRequest(members);
+
+            // when & then
+            performPost("/clubs/" + club.getId() + "/pre-members/batch", request)
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("빈 리스트 요청 시 400을 반환한다")
+        void addPreMembersBatchEmptyListFails() throws Exception {
+            // given
+            clearPersistenceContext();
+            mockLoginUser(president.getId());
+
+            ClubPreMemberBatchAddRequest request = new ClubPreMemberBatchAddRequest(List.of());
+
+            // when & then
+            performPost("/clubs/" + club.getId() + "/pre-members/batch", request)
+                .andExpect(status().isBadRequest());
         }
     }
 

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
@@ -2,7 +2,6 @@ package gg.agit.konect.integration.domain.club;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubMemberApiTest.java
@@ -2,6 +2,7 @@ package gg.agit.konect.integration.domain.club;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 
 import gg.agit.konect.domain.club.dto.ClubPreMemberAddRequest;
 import gg.agit.konect.domain.club.dto.ClubPreMemberBatchAddRequest;
@@ -379,15 +381,18 @@ class ClubMemberApiTest extends IntegrationTestSupport {
             clearPersistenceContext();
             mockLoginUser(president.getId());
 
-            List<ClubPreMemberAddRequest> members = List.of(
-                new ClubPreMemberAddRequest("2022000001", "신입생1", ClubPosition.MEMBER),
-                new ClubPreMemberAddRequest("2022000002", "신입생2", ClubPosition.MEMBER),
-                new ClubPreMemberAddRequest("2022000003", "신입생3", ClubPosition.MANAGER)
-            );
-            ClubPreMemberBatchAddRequest request = new ClubPreMemberBatchAddRequest(members);
+            String requestBody = """
+                {"members": [
+                    {"studentNumber": "2022000001", "name": "신입생1", "clubPosition": "MEMBER"},
+                    {"studentNumber": "2022000002", "name": "신입생2", "clubPosition": "MEMBER"},
+                    {"studentNumber": "2022000003", "name": "신입생3", "clubPosition": "MANAGER"}
+                ]}
+                """;
 
             // when & then
-            performPost("/clubs/" + club.getId() + "/pre-members/batch", request)
+            mockMvc.perform(post("/clubs/" + club.getId() + "/pre-members/batch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCount").value(3))
                 .andExpect(jsonPath("$.successCount").value(3))
@@ -406,20 +411,28 @@ class ClubMemberApiTest extends IntegrationTestSupport {
             clearPersistenceContext();
             mockLoginUser(president.getId());
 
-            // 첫 번째는 이미 등록됨(실패 예상), 두 번째는 신규(성공 예상)
-            List<ClubPreMemberAddRequest> members = List.of(
-                new ClubPreMemberAddRequest(existingUser.getStudentNumber(), existingUser.getName(), ClubPosition.MEMBER),
-                new ClubPreMemberAddRequest("2022000003", "신입생", ClubPosition.MEMBER)
-            );
             // 먼저 첫 번째 멤버를 등록하여 중복 상황 만들기
-            performPost("/clubs/" + club.getId() + "/pre-members", members.get(0));
+            String firstRequest = """
+                {"members": [{"studentNumber": "%s", "name": "%s", "clubPosition": "MEMBER"}]}
+                """.formatted(existingUser.getStudentNumber(), existingUser.getName());
+            mockMvc.perform(post("/clubs/" + club.getId() + "/pre-members/batch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(firstRequest));
             clearPersistenceContext();
             mockLoginUser(president.getId());
 
-            ClubPreMemberBatchAddRequest batchRequest = new ClubPreMemberBatchAddRequest(members);
+            // 같은 멤버를 다시 배치 등록 시도 (첫 번째는 이미 존재해서 실패, 두 번째는 성공)
+            String batchRequest = """
+                {"members": [
+                    {"studentNumber": "%s", "name": "%s", "clubPosition": "MEMBER"},
+                    {"studentNumber": "2022000003", "name": "신입생", "clubPosition": "MEMBER"}
+                ]}
+                """.formatted(existingUser.getStudentNumber(), existingUser.getName());
 
-            // when & then - 같은 멤버를 다시 배치 등록 시도
-            performPost("/clubs/" + club.getId() + "/pre-members/batch", batchRequest)
+            // when & then
+            mockMvc.perform(post("/clubs/" + club.getId() + "/pre-members/batch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(batchRequest))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCount").value(2))
                 .andExpect(jsonPath("$.successCount").value(1))
@@ -474,6 +487,44 @@ class ClubMemberApiTest extends IntegrationTestSupport {
 
             // when & then
             performPost("/clubs/" + club.getId() + "/pre-members/batch", request)
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("null 리스트 요청 시 400을 반환한다")
+        void addPreMembersBatchNullListFails() throws Exception {
+            // given
+            clearPersistenceContext();
+            mockLoginUser(president.getId());
+
+            // JSON에서 members를 null로 설정하여 요청
+            String requestBody = """
+                {"members": null}
+                """;
+
+            // when & then
+            mockMvc.perform(post("/clubs/" + club.getId() + "/pre-members/batch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("null 요소가 포함된 리스트는 400을 반환한다")
+        void addPreMembersBatchNullElementFails() throws Exception {
+            // given
+            clearPersistenceContext();
+            mockLoginUser(president.getId());
+
+            // 리스트에 null 요소가 포함된 요청
+            String requestBody = """
+                {"members": [null]}
+                """;
+
+            // when & then
+            mockMvc.perform(post("/clubs/" + club.getId() + "/pre-members/batch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestBody))
                 .andExpect(status().isBadRequest());
         }
     }


### PR DESCRIPTION
### 🔍 개요

* 동아리 운영진이 학번과 이름을 통해 여러 회원을 한 번에 사전 등록할 수 있는 배치 API를 추가합니다.

* 개별 회원 등록 API와 달리, 일부 실패 시에도 나머지 회원은 정상 등록되는 부분 성공 패턴을 지원합니다.

---

### 🚀 주요 변경 내용

* **신규 API 엔드포인트**: `POST /clubs/{clubId}/pre-members/batch`
  * 최소 1명, 최대 300명까지 일괄 등록 가능
  * 개별 회원 처리 결과를 반환하는 부분 성공 패턴 구현

* **신규 DTO 클래스**:
  * `ClubPreMemberBatchAddRequest`: 배치 등록 요청 (1~300명 유효성 검증)
  * `ClubPreMemberBatchAddResponse`: 처리 결과 요약 (total/success/failed 카운트)
  * `ClubPreMemberBatchResultItem`: 개별 회원 처리 결과 (성공/실패 상세 정보)

* **서비스 로직**:
  * `ClubMemberManagementService#addPreMembersBatch()` 구현
  * `TransactionTemplate`을 활용한 개별 트랜잭션 처리 (일부 실패 시에도 나머지 진행)

* **테스트 코드**:
  * `ClubMemberManagementServiceBatchTest`: 서비스 단위 테스트 (권한 검증, 입력 검증)
  * `ClubMemberApiTest.AddPreMembersBatch`: 통합 테스트 (성공/부분성공/실패/권한 케이스)

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
