### PR TITLE
fix: 구글 시트 preview API의 request 제거

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationApi.java
@@ -38,14 +38,14 @@ public interface ClubSheetMigrationApi {
     @Operation(
         summary = "시트 불러오기 전 부원 목록을 미리본다",
         description = """
-            스프레드시트 URL을 읽어 등록 예정인 부원 목록을 JSON으로 반환합니다.
+            PUT /clubs/{clubId}/sheet 로 AI 분석 및 등록이 완료된 스프레드시트를 읽어
+            등록 예정인 부원 목록을 JSON으로 반환합니다.
             이 API는 데이터를 저장하지 않고 미리보기 용도로만 사용합니다.
             """
     )
     @PostMapping("/{clubId}/sheet/import/preview")
     ResponseEntity<SheetImportPreviewResponse> previewPreMembers(
         @PathVariable(name = "clubId") Integer clubId,
-        @Valid @RequestBody SheetImportRequest request,
         @UserId Integer requesterId
     );
 

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubSheetMigrationController.java
@@ -43,11 +43,10 @@ public class ClubSheetMigrationController implements ClubSheetMigrationApi {
     @Override
     public ResponseEntity<SheetImportPreviewResponse> previewPreMembers(
         @PathVariable(name = "clubId") Integer clubId,
-        @Valid @RequestBody SheetImportRequest request,
         @UserId Integer requesterId
     ) {
         SheetImportPreviewResponse response = sheetImportService.previewPreMembersFromSheet(
-            clubId, requesterId, request.spreadsheetUrl()
+            clubId, requesterId
         );
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
@@ -21,8 +21,22 @@ public interface ClubRepository extends Repository<Club, Integer> {
         """)
     Optional<Club> findById(@Param(value = "id") Integer id);
 
+    @Query(value = """
+        SELECT c
+        FROM Club c
+        LEFT JOIN FETCH c.university
+        LEFT JOIN FETCH c.clubRecruitment cr
+        WHERE c.id = :id
+        """)
+    Optional<Club> findByIdWithUniversity(@Param(value = "id") Integer id);
+
     default Club getById(Integer id) {
         return findById(id).orElseThrow(() ->
+            CustomException.of(ApiResponseCode.NOT_FOUND_CLUB));
+    }
+
+    default Club getByIdWithUniversity(Integer id) {
+        return findByIdWithUniversity(id).orElseThrow(() ->
             CustomException.of(ApiResponseCode.NOT_FOUND_CLUB));
     }
 

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -59,13 +59,12 @@ public class SheetImportService {
         Integer requesterId
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
-
-        String spreadsheetId = resolveRegisteredSpreadsheetId(clubId);
-        SheetHeaderMapper.SheetAnalysisResult analysis =
-            sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
-        SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
         return executeReadOnlyTransaction(() -> {
-            Club club = clubRepository.getById(clubId);
+            Club club = resolveRegisteredSpreadsheetId(clubId);
+            String spreadsheetId = club.getGoogleSheetId();
+            SheetHeaderMapper.SheetAnalysisResult analysis =
+                sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
+            SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
             SheetImportPlan plan = buildImportPlan(
                 clubId,
                 club,
@@ -76,13 +75,13 @@ public class SheetImportService {
         });
     }
 
-    private String resolveRegisteredSpreadsheetId(Integer clubId) {
+    private Club resolveRegisteredSpreadsheetId(Integer clubId) {
         Club club = clubRepository.getById(clubId);
         String spreadsheetId = club.getGoogleSheetId();
         if (spreadsheetId == null || spreadsheetId.isBlank()) {
             throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
         }
-        return spreadsheetId;
+        return club;
     }
 
     @Transactional

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
@@ -53,35 +55,55 @@ public class SheetImportService {
     private final ChatRoomMembershipService chatRoomMembershipService;
     private final ClubPermissionValidator clubPermissionValidator;
     private final PlatformTransactionManager transactionManager;
+    private final ObjectMapper objectMapper;
 
     public SheetImportPreviewResponse previewPreMembersFromSheet(
         Integer clubId,
         Integer requesterId
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
-        return executeReadOnlyTransaction(() -> {
-            Club club = resolveRegisteredSpreadsheetId(clubId);
-            String spreadsheetId = club.getGoogleSheetId();
-            SheetHeaderMapper.SheetAnalysisResult analysis =
-                sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
-            SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
-            SheetImportPlan plan = buildImportPlan(
-                clubId,
-                club,
-                source.members(),
-                source.warnings()
-            );
-            return SheetImportPreviewResponse.of(plan.previewMembers(), plan.warnings());
-        });
+        Club club = resolveClubWithRegisteredSheet(clubId);
+        String spreadsheetId = club.getGoogleSheetId();
+        SheetColumnMapping mapping = resolveRegisteredMemberListMapping(club);
+        SheetImportSource source = loadSheetImportSource(spreadsheetId, mapping);
+        SheetImportPlan plan = buildImportPlan(
+            clubId,
+            club,
+            source.members(),
+            source.warnings()
+        );
+        return SheetImportPreviewResponse.of(plan.previewMembers(), plan.warnings());
     }
 
-    private Club resolveRegisteredSpreadsheetId(Integer clubId) {
+    private Club resolveClubWithRegisteredSheet(Integer clubId) {
         Club club = clubRepository.getById(clubId);
         String spreadsheetId = club.getGoogleSheetId();
         if (spreadsheetId == null || spreadsheetId.isBlank()) {
             throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
         }
         return club;
+    }
+
+    private SheetColumnMapping resolveRegisteredMemberListMapping(Club club) {
+        String mappingJson = club.getSheetColumnMapping();
+        if (mappingJson == null || mappingJson.isBlank()) {
+            throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
+        }
+
+        try {
+            Map<String, Object> raw = objectMapper.readValue(mappingJson, new TypeReference<>() {});
+            int dataStartRow = raw.containsKey("dataStartRow")
+                ? ((Number)raw.get("dataStartRow")).intValue() : 2;
+            Map<String, Integer> fieldMap = new HashMap<>();
+            raw.forEach((key, value) -> {
+                if (!"dataStartRow".equals(key) && value instanceof Number number) {
+                    fieldMap.put(key, number.intValue());
+                }
+            });
+            return new SheetColumnMapping(fieldMap, dataStartRow);
+        } catch (Exception e) {
+            throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
+        }
     }
 
     @Transactional

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -56,12 +56,11 @@ public class SheetImportService {
 
     public SheetImportPreviewResponse previewPreMembersFromSheet(
         Integer clubId,
-        Integer requesterId,
-        String spreadsheetUrl
+        Integer requesterId
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
-        String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
+        String spreadsheetId = resolveRegisteredSpreadsheetId(clubId);
         SheetHeaderMapper.SheetAnalysisResult analysis =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
         SheetImportSource source = loadSheetImportSource(spreadsheetId, analysis.memberListMapping());
@@ -75,6 +74,15 @@ public class SheetImportService {
             );
             return SheetImportPreviewResponse.of(plan.previewMembers(), plan.warnings());
         });
+    }
+
+    private String resolveRegisteredSpreadsheetId(Integer clubId) {
+        Club club = clubRepository.getById(clubId);
+        String spreadsheetId = club.getGoogleSheetId();
+        if (spreadsheetId == null || spreadsheetId.isBlank()) {
+            throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
+        }
+        return spreadsheetId;
     }
 
     @Transactional

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetImportService.java
@@ -76,7 +76,7 @@ public class SheetImportService {
     }
 
     private Club resolveClubWithRegisteredSheet(Integer clubId) {
-        Club club = clubRepository.getById(clubId);
+        Club club = clubRepository.getByIdWithUniversity(clubId);
         String spreadsheetId = club.getGoogleSheetId();
         if (spreadsheetId == null || spreadsheetId.isBlank()) {
             throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);

--- a/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
+++ b/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
@@ -49,6 +49,8 @@ public enum ApiResponseCode {
     INVALID_NOTIFICATION_TOKEN(HttpStatus.BAD_REQUEST, "푸시 알림 토큰이 유효하지 않습니다."),
     FEE_PAYMENT_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "회비 납부가 필요한 동아리입니다. 납부 증빙 사진을 첨부해주세요."),
     AMBIGUOUS_USER_MATCH(HttpStatus.BAD_REQUEST, "동일한 정보로 식별되는 사용자가 2명 이상입니다. 관리자에게 문의해주세요."),
+    CLUB_SHEET_ANALYSIS_REQUIRED(HttpStatus.BAD_REQUEST,
+        "구글 시트 파일에서 동아리 부원을 가져오기 전에 먼저 AI 분석 및 등록이 완료되어야 합니다."),
 
     // 401 Unauthorized
     INVALID_SESSION(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 정보 입니다."),

--- a/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
@@ -1,6 +1,7 @@
 package gg.agit.konect.domain.club.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -33,6 +34,8 @@ import gg.agit.konect.domain.club.repository.ClubPreMemberRepository;
 import gg.agit.konect.domain.club.repository.ClubRepository;
 import gg.agit.konect.domain.user.model.User;
 import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
 import gg.agit.konect.support.ServiceTestSupport;
 import gg.agit.konect.support.fixture.ClubFixture;
 import gg.agit.konect.support.fixture.UniversityFixture;
@@ -43,8 +46,6 @@ class SheetImportServiceTest extends ServiceTestSupport {
     private static final Integer CLUB_ID = 1;
     private static final Integer REQUESTER_ID = 2;
     private static final String SPREADSHEET_ID = "sheet-id";
-    private static final String SPREADSHEET_URL =
-        "https://docs.google.com/spreadsheets/d/" + SPREADSHEET_ID + "/edit";
 
     @Mock
     private Sheets googleSheetsService;
@@ -88,6 +89,7 @@ class SheetImportServiceTest extends ServiceTestSupport {
     @Test
     void previewPreMembersFromSheetReturnsDirectAndPreMembers() throws IOException {
         Club club = ClubFixture.create(UniversityFixture.create());
+        club.updateGoogleSheetId(SPREADSHEET_ID);
         User directUser = UserFixture.createUser(club.getUniversity(), "Alex Kim", "2021232948");
 
         given(clubRepository.getById(CLUB_ID)).willReturn(club);
@@ -115,8 +117,7 @@ class SheetImportServiceTest extends ServiceTestSupport {
 
         SheetImportPreviewResponse response = sheetImportService.previewPreMembersFromSheet(
             CLUB_ID,
-            REQUESTER_ID,
-            SPREADSHEET_URL
+            REQUESTER_ID
         );
 
         assertThat(response.previewCount()).isEqualTo(2);
@@ -131,6 +132,20 @@ class SheetImportServiceTest extends ServiceTestSupport {
         assertThat(response.members())
             .extracting(SheetImportPreviewResponse.PreviewMember::enabled)
             .containsExactly(true, true);
+    }
+
+    @Test
+    void previewPreMembersFromSheetThrowsWhenSheetIsNotRegistered() {
+        Club club = ClubFixture.create(UniversityFixture.create());
+
+        given(clubRepository.getById(CLUB_ID)).willReturn(club);
+
+        assertThatThrownBy(() -> sheetImportService.previewPreMembersFromSheet(CLUB_ID, REQUESTER_ID))
+            .isInstanceOf(CustomException.class)
+            .extracting(exception -> ((CustomException)exception).getErrorCode())
+            .isEqualTo(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
+
+        verifyNoInteractions(googleSheetsService, sheetHeaderMapper);
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
@@ -18,7 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.sheets.v4.Sheets;
@@ -100,7 +99,7 @@ class SheetImportServiceTest extends ServiceTestSupport {
         ));
         User directUser = UserFixture.createUser(club.getUniversity(), "Alex Kim", "2021232948");
 
-        given(clubRepository.getById(CLUB_ID)).willReturn(club);
+        given(clubRepository.getByIdWithUniversity(CLUB_ID)).willReturn(club);
         given(clubMemberRepository.findStudentNumbersByClubId(CLUB_ID)).willReturn(Set.of());
         given(clubPreMemberRepository.findStudentNumberAndNameByClubId(CLUB_ID))
             .willReturn(List.<ClubPreMemberRepository.PreMemberKey>of());
@@ -142,7 +141,7 @@ class SheetImportServiceTest extends ServiceTestSupport {
     void previewPreMembersFromSheetThrowsWhenSheetIsNotRegistered() {
         Club club = ClubFixture.create(UniversityFixture.create());
 
-        given(clubRepository.getById(CLUB_ID)).willReturn(club);
+        given(clubRepository.getByIdWithUniversity(CLUB_ID)).willReturn(club);
 
         assertThatThrownBy(() -> sheetImportService.previewPreMembersFromSheet(CLUB_ID, REQUESTER_ID))
             .isInstanceOf(CustomException.class)
@@ -157,7 +156,7 @@ class SheetImportServiceTest extends ServiceTestSupport {
         Club club = ClubFixture.create(UniversityFixture.create());
         club.updateGoogleSheetId(SPREADSHEET_ID);
 
-        given(clubRepository.getById(CLUB_ID)).willReturn(club);
+        given(clubRepository.getByIdWithUniversity(CLUB_ID)).willReturn(club);
 
         assertThatThrownBy(() -> sheetImportService.previewPreMembersFromSheet(CLUB_ID, REQUESTER_ID))
             .isInstanceOf(CustomException.class)

--- a/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/SheetImportServiceTest.java
@@ -16,9 +16,11 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
@@ -83,6 +85,9 @@ class SheetImportServiceTest extends ServiceTestSupport {
     @Mock
     private PlatformTransactionManager transactionManager;
 
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     @InjectMocks
     private SheetImportService sheetImportService;
 
@@ -90,17 +95,16 @@ class SheetImportServiceTest extends ServiceTestSupport {
     void previewPreMembersFromSheetReturnsDirectAndPreMembers() throws IOException {
         Club club = ClubFixture.create(UniversityFixture.create());
         club.updateGoogleSheetId(SPREADSHEET_ID);
+        club.updateSheetColumnMapping(objectMapper.writeValueAsString(
+            SheetColumnMapping.defaultMapping().toMap()
+        ));
         User directUser = UserFixture.createUser(club.getUniversity(), "Alex Kim", "2021232948");
 
         given(clubRepository.getById(CLUB_ID)).willReturn(club);
-        given(sheetHeaderMapper.analyzeAllSheets(SPREADSHEET_ID)).willReturn(
-            new SheetHeaderMapper.SheetAnalysisResult(SheetColumnMapping.defaultMapping(), null, null)
-        );
         given(clubMemberRepository.findStudentNumbersByClubId(CLUB_ID)).willReturn(Set.of());
         given(clubPreMemberRepository.findStudentNumberAndNameByClubId(CLUB_ID))
             .willReturn(List.<ClubPreMemberRepository.PreMemberKey>of());
         given(clubMemberRepository.findUserIdsByClubId(CLUB_ID)).willReturn(List.of());
-        given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
         given(userRepository.findAllByUniversityIdAndStudentNumberIn(
             eq(club.getUniversity().getId()),
             anySet()
@@ -137,6 +141,21 @@ class SheetImportServiceTest extends ServiceTestSupport {
     @Test
     void previewPreMembersFromSheetThrowsWhenSheetIsNotRegistered() {
         Club club = ClubFixture.create(UniversityFixture.create());
+
+        given(clubRepository.getById(CLUB_ID)).willReturn(club);
+
+        assertThatThrownBy(() -> sheetImportService.previewPreMembersFromSheet(CLUB_ID, REQUESTER_ID))
+            .isInstanceOf(CustomException.class)
+            .extracting(exception -> ((CustomException)exception).getErrorCode())
+            .isEqualTo(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
+
+        verifyNoInteractions(googleSheetsService, sheetHeaderMapper);
+    }
+
+    @Test
+    void previewPreMembersFromSheetThrowsWhenSheetMappingIsMissing() {
+        Club club = ClubFixture.create(UniversityFixture.create());
+        club.updateGoogleSheetId(SPREADSHEET_ID);
 
         given(clubRepository.getById(CLUB_ID)).willReturn(club);
 

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubSheetMigrationApiTest.java
@@ -71,13 +71,10 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
 
             given(sheetImportService.previewPreMembersFromSheet(
                 eq(CLUB_ID),
-                eq(REQUESTER_ID),
-                eq(SPREADSHEET_URL)
+                eq(REQUESTER_ID)
             )).willReturn(response);
 
-            SheetImportRequest request = new SheetImportRequest(SPREADSHEET_URL);
-
-            performPost("/clubs/" + CLUB_ID + "/sheet/import/preview", request)
+            performPost("/clubs/" + CLUB_ID + "/sheet/import/preview")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.previewCount").value(2))
                 .andExpect(jsonPath("$.autoRegisteredCount").value(1))
@@ -96,18 +93,31 @@ class ClubSheetMigrationApiTest extends IntegrationTestSupport {
         void previewPreMembersForbiddenGoogleSheetAccess() throws Exception {
             given(sheetImportService.previewPreMembersFromSheet(
                 eq(CLUB_ID),
-                eq(REQUESTER_ID),
-                eq(SPREADSHEET_URL)
+                eq(REQUESTER_ID)
             )).willThrow(CustomException.of(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS));
 
-            SheetImportRequest request = new SheetImportRequest(SPREADSHEET_URL);
-
-            performPost("/clubs/" + CLUB_ID + "/sheet/import/preview", request)
+            performPost("/clubs/" + CLUB_ID + "/sheet/import/preview")
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code")
                     .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.name()))
                 .andExpect(jsonPath("$.message")
                     .value(ApiResponseCode.FORBIDDEN_GOOGLE_SHEET_ACCESS.getMessage()));
+        }
+
+        @Test
+        @DisplayName("returns 400 when sheet analysis and registration are not completed")
+        void previewPreMembersRequiresRegisteredSheet() throws Exception {
+            given(sheetImportService.previewPreMembersFromSheet(
+                eq(CLUB_ID),
+                eq(REQUESTER_ID)
+            )).willThrow(CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED));
+
+            performPost("/clubs/" + CLUB_ID + "/sheet/import/preview")
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code")
+                    .value(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED.name()))
+                .andExpect(jsonPath("$.message")
+                    .value(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED.getMessage()));
         }
     }
 


### PR DESCRIPTION
### 📌 개요

* `/clubs/{clubId}/sheet/import/preview`가 더 이상 요청 body의 URL을 직접 읽지 않고, `PUT /clubs/{clubId}/sheet`로 분석 및 등록이 완료된 시트만 사용하도록 정리했습니다.
* 등록되지 않은 시트에 대해 preview를 호출하면 안내 메시지와 함께 예외 응답을 반환하도록 보강했습니다.

---

### ✅ 주요 변경 내용

* `/sheet/import/preview` 컨트롤러에서 request body를 제거하고 등록된 시트 기준으로 서비스 메서드를 호출하도록 변경
* `SheetImportService`에서 `club.googleSheetId`를 기준으로 preview를 수행하고, 미등록 시 `CLUB_SHEET_ANALYSIS_REQUIRED` 예외를 반환하도록 추가
* `ApiResponseCode`에 "구글 시트 파일에서 동아리 부원을 가져오기 전에 먼저 AI 분석 및 등록이 완료되어야 합니다." 메시지의 예외 코드 추가

---

### 🙏 참고 사항

* 
---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수 변경, 개인정보 노출 여부)
