### PR TITLE
test: UploadService 단위 테스트 추가 및 버그 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
+++ b/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
@@ -43,7 +43,7 @@ public class UploadService {
         validateS3Configuration();
         validateFile(file);
 
-        String contentType = file.getContentType();
+        String contentType = normalizeContentType(file.getContentType());
         String extension = getExtension(contentType);
         String key = buildKey(extension, target);
 
@@ -96,11 +96,10 @@ public class UploadService {
             throw CustomException.of(ApiResponseCode.PAYLOAD_TOO_LARGE);
         }
 
-        String contentType = file.getContentType();
-        if (contentType == null || contentType.isBlank() || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+        String contentType = normalizeContentType(file.getContentType());
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
             throw CustomException.of(ApiResponseCode.INVALID_FILE_CONTENT_TYPE);
         }
-
     }
 
     private String buildKey(String extension, UploadTarget target) {
@@ -137,8 +136,18 @@ public class UploadService {
         return normalized;
     }
 
+    private String normalizeContentType(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return null;
+        }
+        return contentType.trim().toLowerCase();
+    }
+
     private String getExtension(String contentType) {
-        return switch (contentType.toLowerCase()) {
+        if (contentType == null) {
+            return "bin";
+        }
+        return switch (contentType) {
             case "image/png" -> "png";
             case "image/jpg", "image/jpeg" -> "jpg";
             case "image/webp" -> "webp";
@@ -153,8 +162,8 @@ public class UploadService {
 
         String trimmed = baseUrl.trim();
 
-        if (trimmed.endsWith("/")) {
-            return trimmed.substring(0, trimmed.length() - 1);
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
         }
 
         return trimmed;

--- a/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
+++ b/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
@@ -29,10 +29,10 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 public class UploadService {
 
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
-        "image/png",
-        "image/jpg",
-        "image/jpeg",
-        "image/webp"
+            "image/png",
+            "image/jpg",
+            "image/jpeg",
+            "image/webp"
     );
 
     private final S3Client s3Client;
@@ -48,10 +48,10 @@ public class UploadService {
         String key = buildKey(extension, target);
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-            .bucket(s3StorageProperties.bucket())
-            .key(key)
-            .contentType(contentType)
-            .build();
+                .bucket(s3StorageProperties.bucket())
+                .key(key)
+                .contentType(contentType)
+                .build();
 
         try (InputStream inputStream = file.getInputStream()) {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, file.getSize()));
@@ -60,23 +60,23 @@ public class UploadService {
             String awsErrorMessage = e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage();
 
             log.error(
-                "S3 업로드 실패. bucket: {}, key: {}, statusCode: {}, errorCode: {}, requestId: {}, message: {}",
-                s3StorageProperties.bucket(),
-                key,
-                e.statusCode(),
-                awsErrorCode,
-                e.requestId(),
-                awsErrorMessage,
-                e
+                    "S3 업로드 실패. bucket: {}, key: {}, statusCode: {}, errorCode: {}, requestId: {}, message: {}",
+                    s3StorageProperties.bucket(),
+                    key,
+                    e.statusCode(),
+                    awsErrorCode,
+                    e.requestId(),
+                    awsErrorMessage,
+                    e
             );
             throw CustomException.of(ApiResponseCode.FAILED_UPLOAD_FILE);
         } catch (SdkClientException | IOException e) {
             log.error(
-                "S3 업로드 클라이언트 오류(네트워크/자격증명/설정). bucket: {}, key: {}, message: {}",
-                s3StorageProperties.bucket(),
-                key,
-                e.getMessage(),
-                e
+                    "S3 업로드 클라이언트 오류(네트워크/자격증명/설정). bucket: {}, key: {}, message: {}",
+                    s3StorageProperties.bucket(),
+                    key,
+                    e.getMessage(),
+                    e
             );
             throw CustomException.of(ApiResponseCode.FAILED_UPLOAD_FILE);
         }
@@ -91,8 +91,8 @@ public class UploadService {
         }
 
         if (s3StorageProperties.maxUploadBytes() != null
-            && s3StorageProperties.maxUploadBytes() > 0
-            && file.getSize() > s3StorageProperties.maxUploadBytes()) {
+                && s3StorageProperties.maxUploadBytes() > 0
+                && file.getSize() > s3StorageProperties.maxUploadBytes()) {
             throw CustomException.of(ApiResponseCode.PAYLOAD_TOO_LARGE);
         }
 
@@ -107,10 +107,10 @@ public class UploadService {
         String targetPath = target != null ? target.name().toLowerCase() : "";
         LocalDate today = LocalDate.now();
         String datePath = String.format(
-            "%04d-%02d-%02d",
-            today.getYear(),
-            today.getMonthValue(),
-            today.getDayOfMonth()
+                "%04d-%02d-%02d",
+                today.getYear(),
+                today.getMonthValue(),
+                today.getDayOfMonth()
         );
         String uuid = UUID.randomUUID().toString();
 

--- a/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
+++ b/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
@@ -3,6 +3,7 @@ package gg.agit.konect.domain.upload.service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDate;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 
@@ -140,7 +141,7 @@ public class UploadService {
         if (contentType == null || contentType.isBlank()) {
             return null;
         }
-        return contentType.trim().toLowerCase();
+        return contentType.trim().toLowerCase(Locale.ROOT);
     }
 
     private String getExtension(String contentType) {

--- a/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
+++ b/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
@@ -29,10 +29,10 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 public class UploadService {
 
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
-            "image/png",
-            "image/jpg",
-            "image/jpeg",
-            "image/webp"
+        "image/png",
+        "image/jpg",
+        "image/jpeg",
+        "image/webp"
     );
 
     private final S3Client s3Client;
@@ -48,10 +48,10 @@ public class UploadService {
         String key = buildKey(extension, target);
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                .bucket(s3StorageProperties.bucket())
-                .key(key)
-                .contentType(contentType)
-                .build();
+            .bucket(s3StorageProperties.bucket())
+            .key(key)
+            .contentType(contentType)
+            .build();
 
         try (InputStream inputStream = file.getInputStream()) {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, file.getSize()));
@@ -60,23 +60,23 @@ public class UploadService {
             String awsErrorMessage = e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage();
 
             log.error(
-                    "S3 업로드 실패. bucket: {}, key: {}, statusCode: {}, errorCode: {}, requestId: {}, message: {}",
-                    s3StorageProperties.bucket(),
-                    key,
-                    e.statusCode(),
-                    awsErrorCode,
-                    e.requestId(),
-                    awsErrorMessage,
-                    e
+                "S3 업로드 실패. bucket: {}, key: {}, statusCode: {}, errorCode: {}, requestId: {}, message: {}",
+                s3StorageProperties.bucket(),
+                key,
+                e.statusCode(),
+                awsErrorCode,
+                e.requestId(),
+                awsErrorMessage,
+                e
             );
             throw CustomException.of(ApiResponseCode.FAILED_UPLOAD_FILE);
         } catch (SdkClientException | IOException e) {
             log.error(
-                    "S3 업로드 클라이언트 오류(네트워크/자격증명/설정). bucket: {}, key: {}, message: {}",
-                    s3StorageProperties.bucket(),
-                    key,
-                    e.getMessage(),
-                    e
+                "S3 업로드 클라이언트 오류(네트워크/자격증명/설정). bucket: {}, key: {}, message: {}",
+                s3StorageProperties.bucket(),
+                key,
+                e.getMessage(),
+                e
             );
             throw CustomException.of(ApiResponseCode.FAILED_UPLOAD_FILE);
         }
@@ -91,8 +91,8 @@ public class UploadService {
         }
 
         if (s3StorageProperties.maxUploadBytes() != null
-                && s3StorageProperties.maxUploadBytes() > 0
-                && file.getSize() > s3StorageProperties.maxUploadBytes()) {
+            && s3StorageProperties.maxUploadBytes() > 0
+            && file.getSize() > s3StorageProperties.maxUploadBytes()) {
             throw CustomException.of(ApiResponseCode.PAYLOAD_TOO_LARGE);
         }
 
@@ -107,10 +107,10 @@ public class UploadService {
         String targetPath = target != null ? target.name().toLowerCase() : "";
         LocalDate today = LocalDate.now();
         String datePath = String.format(
-                "%04d-%02d-%02d",
-                today.getYear(),
-                today.getMonthValue(),
-                today.getDayOfMonth()
+            "%04d-%02d-%02d",
+            today.getYear(),
+            today.getMonthValue(),
+            today.getDayOfMonth()
         );
         String uuid = UUID.randomUUID().toString();
 

--- a/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
+++ b/src/main/java/gg/agit/konect/domain/upload/service/UploadService.java
@@ -167,6 +167,10 @@ public class UploadService {
             trimmed = trimmed.substring(0, trimmed.length() - 1);
         }
 
+        if (trimmed.isEmpty()) {
+            throw CustomException.of(ApiResponseCode.ILLEGAL_STATE, "storage.cdn.base-url 설정이 필요합니다.");
+        }
+
         return trimmed;
     }
 

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -711,6 +712,23 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.key()).endsWith(".png");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 터키어 기본 로케일에서도 대문자 content-type을 정규화하여 허용한다")
+    void uploadImageAcceptsUppercaseContentTypeInTurkishLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+
+        try {
+            MultipartFile file = mockFile("image.png", "IMAGE/PNG", 10L);
+
+            ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+            assertThat(response.key()).endsWith(".png");
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -37,7 +37,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 class UploadServiceTest extends ServiceTestSupport {
 
     private static final Pattern CLUB_KEY_PATTERN = Pattern.compile(
-        "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+            "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
     );
 
     @Mock
@@ -48,9 +48,9 @@ class UploadServiceTest extends ServiceTestSupport {
     @BeforeEach
     void setUp() {
         uploadService = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
     }
 
@@ -59,10 +59,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUploadsPngAndReturnsKeyAndCdnUrl() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -85,15 +85,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutPrefixWhenPrefixBlank() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "bank.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "bank.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -108,15 +108,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageNormalizesPrefixWithLeadingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "user.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "user.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -131,8 +131,8 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 null 파일을 거부한다")
     void uploadImageRejectsNullFile() {
         assertCustomException(
-            () -> uploadService.uploadImage(null, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_REQUEST_BODY
+                () -> uploadService.uploadImage(null, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -145,8 +145,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_REQUEST_BODY
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -159,8 +159,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -172,8 +172,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -185,8 +185,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.PAYLOAD_TOO_LARGE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.PAYLOAD_TOO_LARGE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -196,18 +196,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3Exception() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenThrow(S3Exception.builder().message("s3 failed").build());
+                .thenThrow(S3Exception.builder().message("s3 failed").build());
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -216,18 +216,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsSdkClientException() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenThrow(SdkClientException.create("client failed"));
+                .thenThrow(SdkClientException.create("client failed"));
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -243,8 +243,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -253,10 +253,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutTargetWhenTargetNull() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -264,7 +264,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.key()).matches(
-            "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+                "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
         );
         assertThat(response.key()).doesNotContain("//");
     }
@@ -274,10 +274,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpegToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "photo.jpeg",
-            "image/jpeg",
-            "jpeg-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "photo.jpeg",
+                "image/jpeg",
+                "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -293,10 +293,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpgToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "photo.jpg",
-            "image/jpg",
-            "jpg-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "photo.jpg",
+                "image/jpg",
+                "jpg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -311,10 +311,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsWebpToWebpExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "photo.webp",
-            "image/webp",
-            "webp-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "photo.webp",
+                "image/webp",
+                "webp-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -329,10 +329,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageAcceptsFileAtExactMaxSize() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            new byte[5_000]
+                "file",
+                "logo.png",
+                "image/png",
+                new byte[5_000]
         );
 
         // when
@@ -355,8 +355,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -366,15 +366,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "big.png",
-            "image/png",
-            new byte[1_000_000]
+                "file",
+                "big.png",
+                "image/png",
+                new byte[1_000_000]
         );
 
         // when
@@ -390,15 +390,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesZero() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "big.png",
-            "image/png",
-            new byte[1_000_000]
+                "file",
+                "big.png",
+                "image/png",
+                new byte[1_000_000]
         );
 
         // when
@@ -414,15 +414,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageWorksWithCdnUrlWithoutTrailingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -438,15 +438,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithExistingTrailingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -462,15 +462,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithBothLeadingAndTrailingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -487,18 +487,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3ExceptionWithNullErrorDetails() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
+                .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -507,15 +507,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlMissing() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties(" ")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties(" ")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -527,15 +527,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties(null)
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties(null)
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -547,15 +547,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketMissing() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -567,15 +567,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionMissing() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -587,19 +587,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-            () -> service.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.ILLEGAL_STATE
+                () -> service.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -608,19 +608,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-            () -> service.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.ILLEGAL_STATE
+                () -> service.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -629,13 +629,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNegative() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "big.png", "image/png",
-            new byte[1_000_000]
+                "file", "big.png", "image/png",
+                new byte[1_000_000]
         );
 
         // when
@@ -650,13 +650,13 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 CDN baseUrl에 double trailing slash가 있어도 fileUrl에 double slash가 없다")
     void uploadImageRemovesAllTrailingSlashesFromCdnBaseUrl() {
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test//")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test//")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -721,13 +721,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConstructsFileUrlAsBaseUrlSlashKey() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -735,7 +735,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.fileUrl())
-            .isEqualTo("https://cdn.konect.test/" + response.key());
+                .isEqualTo("https://cdn.konect.test/" + response.key());
         assertThat(response.fileUrl()).doesNotMatch(".*://.*//.*");
     }
 
@@ -744,8 +744,8 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImagePassesNormalizedContentTypeToPutObjectRequest() {
         // given — content-type이 정규화(trim + lowercase)되어 S3에 전달됨
         MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "IMAGE/JPEG",
-            "jpeg-data".getBytes(StandardCharsets.UTF_8)
+                "file", "photo.jpg", "IMAGE/JPEG",
+                "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -763,7 +763,7 @@ class UploadServiceTest extends ServiceTestSupport {
         // given
         byte[] content = new byte[1234];
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png", content
+                "file", "logo.png", "image/png", content
         );
 
         // when
@@ -780,13 +780,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUsesConfiguredBucketInPutObjectRequest() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -800,17 +800,17 @@ class UploadServiceTest extends ServiceTestSupport {
 
     private MultipartFile mockFile(String filename, String contentType, long size) {
         return new MockMultipartFile(
-            "file",
-            filename,
-            contentType,
-            new byte[Math.toIntExact(size)]
+                "file",
+                filename,
+                contentType,
+                new byte[Math.toIntExact(size)]
         );
     }
 
     private void assertCustomException(ThrowingCallable callable, ApiResponseCode expectedCode) {
         assertThatThrownBy(callable::call)
-            .isInstanceOf(CustomException.class)
-            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(expectedCode));
+                .isInstanceOf(CustomException.class)
+                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(expectedCode));
     }
 
     @FunctionalInterface

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -34,7 +34,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 class UploadServiceTest extends ServiceTestSupport {
 
     private static final Pattern CLUB_KEY_PATTERN = Pattern.compile(
-        "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+            "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
     );
 
     @Mock
@@ -45,9 +45,9 @@ class UploadServiceTest extends ServiceTestSupport {
     @BeforeEach
     void setUp() {
         uploadService = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
     }
 
@@ -56,10 +56,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUploadsPngAndReturnsKeyAndCdnUrl() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -82,15 +82,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutPrefixWhenPrefixBlank() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "bank.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "bank.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -105,15 +105,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageNormalizesPrefixWithLeadingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "user.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "user.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -128,8 +128,8 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 null 파일을 거부한다")
     void uploadImageRejectsNullFile() {
         assertCustomException(
-            () -> uploadService.uploadImage(null, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_REQUEST_BODY
+                () -> uploadService.uploadImage(null, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -142,8 +142,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_REQUEST_BODY
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -156,8 +156,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -169,8 +169,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -182,8 +182,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.PAYLOAD_TOO_LARGE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.PAYLOAD_TOO_LARGE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -193,18 +193,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3Exception() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenThrow(S3Exception.builder().message("s3 failed").build());
+                .thenThrow(S3Exception.builder().message("s3 failed").build());
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -213,18 +213,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsSdkClientException() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenThrow(SdkClientException.create("client failed"));
+                .thenThrow(SdkClientException.create("client failed"));
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -240,8 +240,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -250,10 +250,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutTargetWhenTargetNull() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -261,7 +261,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.key()).matches(
-            "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+                "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
         );
         assertThat(response.key()).doesNotContain("//");
     }
@@ -271,10 +271,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpegToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "photo.jpeg",
-            "image/jpeg",
-            "jpeg-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "photo.jpeg",
+                "image/jpeg",
+                "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -290,10 +290,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpgToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "photo.jpg",
-            "image/jpg",
-            "jpg-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "photo.jpg",
+                "image/jpg",
+                "jpg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -308,10 +308,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsWebpToWebpExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "photo.webp",
-            "image/webp",
-            "webp-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "photo.webp",
+                "image/webp",
+                "webp-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -326,10 +326,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageAcceptsFileAtExactMaxSize() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            new byte[5_000]
+                "file",
+                "logo.png",
+                "image/png",
+                new byte[5_000]
         );
 
         // when
@@ -352,8 +352,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -363,15 +363,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "big.png",
-            "image/png",
-            new byte[1_000_000]
+                "file",
+                "big.png",
+                "image/png",
+                new byte[1_000_000]
         );
 
         // when
@@ -387,15 +387,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesZero() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "big.png",
-            "image/png",
-            new byte[1_000_000]
+                "file",
+                "big.png",
+                "image/png",
+                new byte[1_000_000]
         );
 
         // when
@@ -411,15 +411,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageWorksWithCdnUrlWithoutTrailingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -435,15 +435,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithExistingTrailingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -459,15 +459,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithBothLeadingAndTrailingSlash() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -484,18 +484,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3ExceptionWithNullErrorDetails() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-            .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
+                .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
 
         // when & then
         assertCustomException(
-            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.FAILED_UPLOAD_FILE
+                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -504,15 +504,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlMissing() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties(" ")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties(" ")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -524,15 +524,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties(null)
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties(null)
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -544,15 +544,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketMissing() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -564,15 +564,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionMissing() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "logo.png",
-            "image/png",
-            "png-data".getBytes(StandardCharsets.UTF_8)
+                "file",
+                "logo.png",
+                "image/png",
+                "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -584,19 +584,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-            () -> service.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.ILLEGAL_STATE
+                () -> service.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -605,19 +605,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionNull() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-            () -> service.uploadImage(file, UploadTarget.CLUB),
-            ApiResponseCode.ILLEGAL_STATE
+                () -> service.uploadImage(file, UploadTarget.CLUB),
+                ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -626,13 +626,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNegative() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
-            new StorageCdnProperties("https://cdn.konect.test/")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
+                new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "big.png", "image/png",
-            new byte[1_000_000]
+                "file", "big.png", "image/png",
+                new byte[1_000_000]
         );
 
         // when
@@ -647,13 +647,13 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 CDN baseUrl에 double trailing slash가 있어도 fileUrl에 double slash가 없다")
     void uploadImageRemovesAllTrailingSlashesFromCdnBaseUrl() {
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test//")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test//")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -718,13 +718,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConstructsFileUrlAsBaseUrlSlashKey() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -732,7 +732,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.fileUrl())
-            .isEqualTo("https://cdn.konect.test/" + response.key());
+                .isEqualTo("https://cdn.konect.test/" + response.key());
         assertThat(response.fileUrl()).doesNotMatch(".*://.*//.*");
     }
 
@@ -741,8 +741,8 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImagePassesNormalizedContentTypeToPutObjectRequest() {
         // given — content-type이 정규화(trim + lowercase)되어 S3에 전달됨
         MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "IMAGE/JPEG",
-            "jpeg-data".getBytes(StandardCharsets.UTF_8)
+                "file", "photo.jpg", "IMAGE/JPEG",
+                "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -760,7 +760,7 @@ class UploadServiceTest extends ServiceTestSupport {
         // given
         byte[] content = new byte[1234];
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png", content
+                "file", "logo.png", "image/png", content
         );
 
         // when
@@ -777,13 +777,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUsesConfiguredBucketInPutObjectRequest() {
         // given
         UploadService service = new UploadService(
-            s3Client,
-            new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
-            new StorageCdnProperties("https://cdn.konect.test")
+                s3Client,
+                new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
+                new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-            "file", "logo.png", "image/png",
-            "data".getBytes(StandardCharsets.UTF_8)
+                "file", "logo.png", "image/png",
+                "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -797,17 +797,17 @@ class UploadServiceTest extends ServiceTestSupport {
 
     private MultipartFile mockFile(String filename, String contentType, long size) {
         return new MockMultipartFile(
-            "file",
-            filename,
-            contentType,
-            new byte[Math.toIntExact(size)]
+                "file",
+                filename,
+                contentType,
+                new byte[Math.toIntExact(size)]
         );
     }
 
     private void assertCustomException(ThrowingCallable callable, ApiResponseCode expectedCode) {
         assertThatThrownBy(callable::call)
-            .isInstanceOf(CustomException.class)
-            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(expectedCode));
+                .isInstanceOf(CustomException.class)
+                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(expectedCode));
     }
 
     @FunctionalInterface

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -541,6 +541,26 @@ class UploadServiceTest extends ServiceTestSupport {
     }
 
     @Test
+    @DisplayName("uploadImage는 CDN URL이 슬래시만 있으면 ILLEGAL_STATE로 실패한다")
+    void uploadImageFailsWhenCdnBaseUrlContainsOnlySlashes() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("////")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        assertCustomException(() -> service.uploadImage(file, UploadTarget.CLUB), ApiResponseCode.ILLEGAL_STATE);
+    }
+
+    @Test
     @DisplayName("uploadImage는 bucket 설정이 비어 있으면 ILLEGAL_STATE로 실패한다")
     void uploadImageFailsWhenBucketMissing() {
         // given

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -3,10 +3,7 @@ package gg.agit.konect.unit.domain.upload.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,7 +34,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 class UploadServiceTest extends ServiceTestSupport {
 
     private static final Pattern CLUB_KEY_PATTERN = Pattern.compile(
-            "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+        "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
     );
 
     @Mock
@@ -48,9 +45,9 @@ class UploadServiceTest extends ServiceTestSupport {
     @BeforeEach
     void setUp() {
         uploadService = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
     }
 
@@ -59,10 +56,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUploadsPngAndReturnsKeyAndCdnUrl() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -85,15 +82,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutPrefixWhenPrefixBlank() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "bank.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "bank.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -108,15 +105,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageNormalizesPrefixWithLeadingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "user.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "user.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -131,8 +128,8 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 null 파일을 거부한다")
     void uploadImageRejectsNullFile() {
         assertCustomException(
-                () -> uploadService.uploadImage(null, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_REQUEST_BODY
+            () -> uploadService.uploadImage(null, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -145,8 +142,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_REQUEST_BODY
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -159,8 +156,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -172,8 +169,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -185,8 +182,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.PAYLOAD_TOO_LARGE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.PAYLOAD_TOO_LARGE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -196,18 +193,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3Exception() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-                .thenThrow(S3Exception.builder().message("s3 failed").build());
+            .thenThrow(S3Exception.builder().message("s3 failed").build());
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -216,18 +213,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsSdkClientException() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-                .thenThrow(SdkClientException.create("client failed"));
+            .thenThrow(SdkClientException.create("client failed"));
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -243,8 +240,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -253,10 +250,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutTargetWhenTargetNull() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -264,7 +261,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.key()).matches(
-                "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+            "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
         );
         assertThat(response.key()).doesNotContain("//");
     }
@@ -274,10 +271,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpegToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "photo.jpeg",
-                "image/jpeg",
-                "jpeg-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "photo.jpeg",
+            "image/jpeg",
+            "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -293,10 +290,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpgToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "photo.jpg",
-                "image/jpg",
-                "jpg-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "photo.jpg",
+            "image/jpg",
+            "jpg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -311,10 +308,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsWebpToWebpExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "photo.webp",
-                "image/webp",
-                "webp-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "photo.webp",
+            "image/webp",
+            "webp-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -329,10 +326,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageAcceptsFileAtExactMaxSize() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                new byte[5_000]
+            "file",
+            "logo.png",
+            "image/png",
+            new byte[5_000]
         );
 
         // when
@@ -355,8 +352,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -366,15 +363,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "big.png",
-                "image/png",
-                new byte[1_000_000]
+            "file",
+            "big.png",
+            "image/png",
+            new byte[1_000_000]
         );
 
         // when
@@ -390,15 +387,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesZero() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "big.png",
-                "image/png",
-                new byte[1_000_000]
+            "file",
+            "big.png",
+            "image/png",
+            new byte[1_000_000]
         );
 
         // when
@@ -414,15 +411,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageWorksWithCdnUrlWithoutTrailingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -438,15 +435,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithExistingTrailingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -462,15 +459,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithBothLeadingAndTrailingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -487,18 +484,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3ExceptionWithNullErrorDetails() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-                .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
+            .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -507,15 +504,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlMissing() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties(" ")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties(" ")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -527,15 +524,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties(null)
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties(null)
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -547,15 +544,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketMissing() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -567,15 +564,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionMissing() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -587,19 +584,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-                () -> service.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.ILLEGAL_STATE
+            () -> service.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -608,19 +605,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-                () -> service.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.ILLEGAL_STATE
+            () -> service.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -629,13 +626,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNegative() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "big.png", "image/png",
-                new byte[1_000_000]
+            "file", "big.png", "image/png",
+            new byte[1_000_000]
         );
 
         // when
@@ -650,13 +647,13 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 CDN baseUrl에 double trailing slash가 있어도 fileUrl에 double slash가 없다")
     void uploadImageRemovesAllTrailingSlashesFromCdnBaseUrl() {
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test//")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test//")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -721,13 +718,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConstructsFileUrlAsBaseUrlSlashKey() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -735,7 +732,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.fileUrl())
-                .isEqualTo("https://cdn.konect.test/" + response.key());
+            .isEqualTo("https://cdn.konect.test/" + response.key());
         assertThat(response.fileUrl()).doesNotMatch(".*://.*//.*");
     }
 
@@ -744,8 +741,8 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImagePassesNormalizedContentTypeToPutObjectRequest() {
         // given — content-type이 정규화(trim + lowercase)되어 S3에 전달됨
         MockMultipartFile file = new MockMultipartFile(
-                "file", "photo.jpg", "IMAGE/JPEG",
-                "jpeg-data".getBytes(StandardCharsets.UTF_8)
+            "file", "photo.jpg", "IMAGE/JPEG",
+            "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -763,7 +760,7 @@ class UploadServiceTest extends ServiceTestSupport {
         // given
         byte[] content = new byte[1234];
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png", content
+            "file", "logo.png", "image/png", content
         );
 
         // when
@@ -780,13 +777,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUsesConfiguredBucketInPutObjectRequest() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -800,17 +797,17 @@ class UploadServiceTest extends ServiceTestSupport {
 
     private MultipartFile mockFile(String filename, String contentType, long size) {
         return new MockMultipartFile(
-                "file",
-                filename,
-                contentType,
-                new byte[Math.toIntExact(size)]
+            "file",
+            filename,
+            contentType,
+            new byte[Math.toIntExact(size)]
         );
     }
 
     private void assertCustomException(ThrowingCallable callable, ApiResponseCode expectedCode) {
         assertThatThrownBy(callable::call)
-                .isInstanceOf(CustomException.class)
-                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(expectedCode));
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(expectedCode));
     }
 
     @FunctionalInterface

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -34,7 +34,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 class UploadServiceTest extends ServiceTestSupport {
 
     private static final Pattern CLUB_KEY_PATTERN = Pattern.compile(
-            "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+        "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
     );
 
     @Mock
@@ -45,9 +45,9 @@ class UploadServiceTest extends ServiceTestSupport {
     @BeforeEach
     void setUp() {
         uploadService = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
     }
 
@@ -56,10 +56,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUploadsPngAndReturnsKeyAndCdnUrl() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -82,15 +82,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutPrefixWhenPrefixBlank() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "bank.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "bank.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -105,15 +105,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageNormalizesPrefixWithLeadingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "user.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "user.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -128,8 +128,8 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 null 파일을 거부한다")
     void uploadImageRejectsNullFile() {
         assertCustomException(
-                () -> uploadService.uploadImage(null, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_REQUEST_BODY
+            () -> uploadService.uploadImage(null, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -142,8 +142,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_REQUEST_BODY
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_REQUEST_BODY
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -156,8 +156,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -169,8 +169,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
     }
 
@@ -182,8 +182,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.PAYLOAD_TOO_LARGE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.PAYLOAD_TOO_LARGE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -193,18 +193,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3Exception() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-                .thenThrow(S3Exception.builder().message("s3 failed").build());
+            .thenThrow(S3Exception.builder().message("s3 failed").build());
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -213,18 +213,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsSdkClientException() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-                .thenThrow(SdkClientException.create("client failed"));
+            .thenThrow(SdkClientException.create("client failed"));
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -240,8 +240,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -250,10 +250,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageBuildsKeyWithoutTargetWhenTargetNull() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -261,7 +261,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.key()).matches(
-                "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+            "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
         );
         assertThat(response.key()).doesNotContain("//");
     }
@@ -271,10 +271,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpegToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "photo.jpeg",
-                "image/jpeg",
-                "jpeg-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "photo.jpeg",
+            "image/jpeg",
+            "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -290,10 +290,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsJpgToJpgExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "photo.jpg",
-                "image/jpg",
-                "jpg-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "photo.jpg",
+            "image/jpg",
+            "jpg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -308,10 +308,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsWebpToWebpExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "photo.webp",
-                "image/webp",
-                "webp-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "photo.webp",
+            "image/webp",
+            "webp-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -326,10 +326,10 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageAcceptsFileAtExactMaxSize() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                new byte[5_000]
+            "file",
+            "logo.png",
+            "image/png",
+            new byte[5_000]
         );
 
         // when
@@ -352,8 +352,8 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
         );
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -363,15 +363,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "big.png",
-                "image/png",
-                new byte[1_000_000]
+            "file",
+            "big.png",
+            "image/png",
+            new byte[1_000_000]
         );
 
         // when
@@ -387,15 +387,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesZero() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "big.png",
-                "image/png",
-                new byte[1_000_000]
+            "file",
+            "big.png",
+            "image/png",
+            new byte[1_000_000]
         );
 
         // when
@@ -411,15 +411,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageWorksWithCdnUrlWithoutTrailingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -435,15 +435,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithExistingTrailingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -459,15 +459,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageHandlesPrefixWithBothLeadingAndTrailingSlash() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -484,18 +484,18 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConvertsS3ExceptionWithNullErrorDetails() {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
         when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
-                .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
+            .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
 
         // when & then
         assertCustomException(
-                () -> uploadService.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.FAILED_UPLOAD_FILE
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
         );
     }
 
@@ -504,15 +504,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlMissing() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties(" ")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties(" ")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -524,15 +524,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenCdnBaseUrlNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties(null)
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties(null)
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -544,15 +544,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketMissing() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -564,15 +564,15 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionMissing() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file",
-                "logo.png",
-                "image/png",
-                "png-data".getBytes(StandardCharsets.UTF_8)
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
@@ -584,19 +584,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenBucketNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-                () -> service.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.ILLEGAL_STATE
+            () -> service.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -605,19 +605,19 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageFailsWhenRegionNull() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when & then
         assertCustomException(
-                () -> service.uploadImage(file, UploadTarget.CLUB),
-                ApiResponseCode.ILLEGAL_STATE
+            () -> service.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.ILLEGAL_STATE
         );
     }
 
@@ -626,13 +626,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageSkipsSizeCheckWhenMaxUploadBytesNegative() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
-                new StorageCdnProperties("https://cdn.konect.test/")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
+            new StorageCdnProperties("https://cdn.konect.test/")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "big.png", "image/png",
-                new byte[1_000_000]
+            "file", "big.png", "image/png",
+            new byte[1_000_000]
         );
 
         // when
@@ -647,13 +647,13 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 CDN baseUrl에 double trailing slash가 있어도 fileUrl에 double slash가 없다")
     void uploadImageRemovesAllTrailingSlashesFromCdnBaseUrl() {
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test//")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test//")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -718,13 +718,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageConstructsFileUrlAsBaseUrlSlashKey() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -732,7 +732,7 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.fileUrl())
-                .isEqualTo("https://cdn.konect.test/" + response.key());
+            .isEqualTo("https://cdn.konect.test/" + response.key());
         assertThat(response.fileUrl()).doesNotMatch(".*://.*//.*");
     }
 
@@ -741,8 +741,8 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImagePassesNormalizedContentTypeToPutObjectRequest() {
         // given — content-type이 정규화(trim + lowercase)되어 S3에 전달됨
         MockMultipartFile file = new MockMultipartFile(
-                "file", "photo.jpg", "IMAGE/JPEG",
-                "jpeg-data".getBytes(StandardCharsets.UTF_8)
+            "file", "photo.jpg", "IMAGE/JPEG",
+            "jpeg-data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -760,7 +760,7 @@ class UploadServiceTest extends ServiceTestSupport {
         // given
         byte[] content = new byte[1234];
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png", content
+            "file", "logo.png", "image/png", content
         );
 
         // when
@@ -777,13 +777,13 @@ class UploadServiceTest extends ServiceTestSupport {
     void uploadImageUsesConfiguredBucketInPutObjectRequest() {
         // given
         UploadService service = new UploadService(
-                s3Client,
-                new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
-                new StorageCdnProperties("https://cdn.konect.test")
+            s3Client,
+            new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
         );
         MockMultipartFile file = new MockMultipartFile(
-                "file", "logo.png", "image/png",
-                "data".getBytes(StandardCharsets.UTF_8)
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
         );
 
         // when
@@ -797,17 +797,17 @@ class UploadServiceTest extends ServiceTestSupport {
 
     private MultipartFile mockFile(String filename, String contentType, long size) {
         return new MockMultipartFile(
-                "file",
-                filename,
-                contentType,
-                new byte[Math.toIntExact(size)]
+            "file",
+            filename,
+            contentType,
+            new byte[Math.toIntExact(size)]
         );
     }
 
     private void assertCustomException(ThrowingCallable callable, ApiResponseCode expectedCode) {
         assertThatThrownBy(callable::call)
-                .isInstanceOf(CustomException.class)
-                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(expectedCode));
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(expectedCode));
     }
 
     @FunctionalInterface

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -3,6 +3,7 @@ package gg.agit.konect.unit.domain.upload.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -234,7 +235,7 @@ class UploadServiceTest extends ServiceTestSupport {
     @DisplayName("uploadImage는 InputStream IOException을 FAILED_UPLOAD_FILE로 변환한다")
     void uploadImageConvertsIOException() throws IOException {
         // given
-        MultipartFile file = org.mockito.Mockito.mock(MultipartFile.class);
+        MultipartFile file = mock(MultipartFile.class);
         when(file.isEmpty()).thenReturn(false);
         when(file.getSize()).thenReturn(10L);
         when(file.getContentType()).thenReturn("image/png");
@@ -248,13 +249,287 @@ class UploadServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("uploadImage는 CDN base URL이 비어 있으면 ILLEGAL_STATE로 실패한다")
+    @DisplayName("uploadImage는 target이 null이면 target 경로 없이 key를 생성한다")
+    void uploadImageBuildsKeyWithoutTargetWhenTargetNull() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, null);
+
+        // then
+        assertThat(response.key()).matches(
+            "konect/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+        );
+        assertThat(response.key()).doesNotContain("//");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 image/jpeg를 .jpg 확장자로 변환한다")
+    void uploadImageConvertsJpegToJpgExtension() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "photo.jpeg",
+            "image/jpeg",
+            "jpeg-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).endsWith(".jpg");
+        assertThat(response.fileUrl()).endsWith(".jpg");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 image/jpg를 .jpg 확장자로 변환한다")
+    void uploadImageConvertsJpgToJpgExtension() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "photo.jpg",
+            "image/jpg",
+            "jpg-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).endsWith(".jpg");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 image/webp를 .webp 확장자로 변환한다")
+    void uploadImageConvertsWebpToWebpExtension() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "photo.webp",
+            "image/webp",
+            "webp-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).endsWith(".webp");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 파일 크기가 maxUploadBytes와 정확히 일치하면 업로드에 성공한다")
+    void uploadImageAcceptsFileAtExactMaxSize() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            new byte[5_000]
+        );
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).isNotBlank();
+        assertThat(response.fileUrl()).isNotBlank();
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 content-type이 null이면 INVALID_FILE_CONTENT_TYPE으로 실패한다")
+    void uploadImageRejectsNullContentType() {
+        // given
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn(10L);
+        when(file.getContentType()).thenReturn(null);
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+        );
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 maxUploadBytes가 null이면 용량 검증을 생략한다")
+    void uploadImageSkipsSizeCheckWhenMaxUploadBytesNull() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", null),
+            new StorageCdnProperties("https://cdn.konect.test/")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "big.png",
+            "image/png",
+            new byte[1_000_000]
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).isNotBlank();
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 maxUploadBytes가 0이면 용량 검증을 생략한다")
+    void uploadImageSkipsSizeCheckWhenMaxUploadBytesZero() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 0L),
+            new StorageCdnProperties("https://cdn.konect.test/")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "big.png",
+            "image/png",
+            new byte[1_000_000]
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).isNotBlank();
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 CDN URL에 trailing slash가 없어도 정상 동작한다")
+    void uploadImageWorksWithCdnUrlWithoutTrailingSlash() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.fileUrl()).startsWith("https://cdn.konect.test/");
+        assertThat(response.fileUrl()).doesNotContain("//cdn.konect.test//");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 prefix에 이미 trailing slash가 있으면 중복 slash 없이 key를 생성한다")
+    void uploadImageHandlesPrefixWithExistingTrailingSlash() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect/", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).matches("konect/club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png");
+        assertThat(response.key()).doesNotContain("konect//");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 prefix에 leading과 trailing slash가 모두 있어도 정상 동작한다")
+    void uploadImageHandlesPrefixWithBothLeadingAndTrailingSlash() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets/", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.COUNCIL);
+
+        // then
+        assertThat(response.key()).matches("assets/council/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png");
+        assertThat(response.key()).doesNotStartWith("/");
+        assertThat(response.key()).doesNotContain("//");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 S3Exception의 awsErrorDetails가 null이어도 FAILED_UPLOAD_FILE로 변환한다")
+    void uploadImageConvertsS3ExceptionWithNullErrorDetails() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .thenThrow(S3Exception.builder().message("s3 failed").statusCode(500).build());
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 CDN URL이 비어 있으면 ILLEGAL_STATE로 실패한다")
     void uploadImageFailsWhenCdnBaseUrlMissing() {
         // given
         UploadService service = new UploadService(
             s3Client,
             new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
             new StorageCdnProperties(" ")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        assertCustomException(() -> service.uploadImage(file, UploadTarget.CLUB), ApiResponseCode.ILLEGAL_STATE);
+    }
+
+    @Test
+    @DisplayName("uploadImage는 CDN URL이 null이면 ILLEGAL_STATE로 실패한다")
+    void uploadImageFailsWhenCdnBaseUrlNull() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties(null)
         );
         MockMultipartFile file = new MockMultipartFile(
             "file",
@@ -305,6 +580,222 @@ class UploadServiceTest extends ServiceTestSupport {
 
         // when & then
         assertCustomException(() -> service.uploadImage(file, UploadTarget.CLUB), ApiResponseCode.ILLEGAL_STATE);
+    }
+
+    @Test
+    @DisplayName("uploadImage는 bucket이 null이면 ILLEGAL_STATE로 실패한다")
+    void uploadImageFailsWhenBucketNull() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties(null, "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        assertCustomException(
+            () -> service.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.ILLEGAL_STATE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 region이 null이면 ILLEGAL_STATE로 실패한다")
+    void uploadImageFailsWhenRegionNull() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", null, "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        assertCustomException(
+            () -> service.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.ILLEGAL_STATE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 maxUploadBytes가 음수면 용량 검증을 생략한다")
+    void uploadImageSkipsSizeCheckWhenMaxUploadBytesNegative() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", -1L),
+            new StorageCdnProperties("https://cdn.konect.test/")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "big.png", "image/png",
+            new byte[1_000_000]
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).isNotBlank();
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 CDN baseUrl에 double trailing slash가 있어도 fileUrl에 double slash가 없다")
+    void uploadImageRemovesAllTrailingSlashesFromCdnBaseUrl() {
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test//")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.fileUrl()).startsWith("https://cdn.konect.test/");
+        assertThat(response.fileUrl()).doesNotContain("cdn.konect.test//");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 대문자 content-type 'IMAGE/PNG'을 정규화하여 허용한다")
+    void uploadImageAcceptsUppercaseContentType() {
+        MultipartFile file = mockFile("image.png", "IMAGE/PNG", 10L);
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).endsWith(".png");
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 혼합 대소문자 content-type 'image/PNG'을 정규화하여 허용한다")
+    void uploadImageAcceptsMixedCaseContentType() {
+        MultipartFile file = mockFile("image.png", "image/PNG", 10L);
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).endsWith(".png");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 content-type에 leading whitespace가 있어도 정규화하여 허용한다")
+    void uploadImageAcceptsContentTypeWithLeadingWhitespace() {
+        MultipartFile file = mockFile("image.png", " image/png", 10L);
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).endsWith(".png");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 content-type에 trailing whitespace가 있어도 정규화하여 허용한다")
+    void uploadImageAcceptsContentTypeWithTrailingWhitespace() {
+        MultipartFile file = mockFile("image.png", "image/png ", 10L);
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.key()).endsWith(".png");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 fileUrl을 baseUrl + '/' + key 형식으로 정확히 생성한다")
+    void uploadImageConstructsFileUrlAsBaseUrlSlashKey() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        assertThat(response.fileUrl())
+            .isEqualTo("https://cdn.konect.test/" + response.key());
+        assertThat(response.fileUrl()).doesNotMatch(".*://.*//.*");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 PutObjectRequest에 정규화된 content-type을 전달한다")
+    void uploadImagePassesNormalizedContentTypeToPutObjectRequest() {
+        // given — content-type이 정규화(trim + lowercase)되어 S3에 전달됨
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "photo.jpg", "IMAGE/JPEG",
+            "jpeg-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(requestCaptor.capture(), any(RequestBody.class));
+        assertThat(requestCaptor.getValue().contentType()).isEqualTo("image/jpeg");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 RequestBody에 file.getSize() 값을 그대로 전달한다")
+    void uploadImagePassesExactFileSizeToRequestBody() {
+        // given
+        byte[] content = new byte[1234];
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "logo.png", "image/png", content
+        );
+
+        // when
+        uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        ArgumentCaptor<RequestBody> bodyCaptor = ArgumentCaptor.forClass(RequestBody.class);
+        verify(s3Client).putObject(any(PutObjectRequest.class), bodyCaptor.capture());
+        assertThat(bodyCaptor.getValue().contentLength()).isEqualTo(1234);
+    }
+
+    @Test
+    @DisplayName("uploadImage는 PutObjectRequest의 bucket이 설정값과 일치한다")
+    void uploadImageUsesConfiguredBucketInPutObjectRequest() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("my-custom-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "logo.png", "image/png",
+            "data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        service.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(requestCaptor.capture(), any(RequestBody.class));
+        assertThat(requestCaptor.getValue().bucket()).isEqualTo("my-custom-bucket");
     }
 
     private MultipartFile mockFile(String filename, String contentType, long size) {

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -1,0 +1,329 @@
+package gg.agit.konect.unit.domain.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import gg.agit.konect.domain.upload.dto.ImageUploadResponse;
+import gg.agit.konect.domain.upload.enums.UploadTarget;
+import gg.agit.konect.domain.upload.service.UploadService;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.infrastructure.storage.cdn.StorageCdnProperties;
+import gg.agit.konect.infrastructure.storage.s3.S3StorageProperties;
+import gg.agit.konect.support.ServiceTestSupport;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+class UploadServiceTest extends ServiceTestSupport {
+
+    private static final Pattern CLUB_KEY_PATTERN = Pattern.compile(
+        "(?:[\\w-]+/)*club/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+    );
+
+    @Mock
+    private S3Client s3Client;
+
+    private UploadService uploadService;
+
+    @BeforeEach
+    void setUp() {
+        uploadService = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test/")
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 유효한 PNG 파일을 업로드하고 key와 CDN URL을 반환한다")
+    void uploadImageUploadsPngAndReturnsKeyAndCdnUrl() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.CLUB);
+
+        // then
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(requestCaptor.capture(), any(RequestBody.class));
+
+        PutObjectRequest request = requestCaptor.getValue();
+        assertThat(request.bucket()).isEqualTo("konect-bucket");
+        assertThat(request.contentType()).isEqualTo("image/png");
+        assertThat(request.key()).matches(CLUB_KEY_PATTERN);
+        assertThat(response.key()).isEqualTo(request.key());
+        assertThat(response.fileUrl()).isEqualTo("https://cdn.konect.test/" + request.key());
+    }
+
+    @Test
+    @DisplayName("uploadImage는 blank prefix여도 target 경로만 포함한 key를 만든다")
+    void uploadImageBuildsKeyWithoutPrefixWhenPrefixBlank() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", " ", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "bank.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.BANK);
+
+        // then
+        assertThat(response.key()).matches("bank/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 leading slash prefix를 제거하고 trailing slash를 보정한다")
+    void uploadImageNormalizesPrefixWithLeadingSlash() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "/assets", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "user.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = service.uploadImage(file, UploadTarget.USER);
+
+        // then
+        assertThat(response.key()).matches("assets/user/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png");
+        assertThat(response.key()).doesNotStartWith("/");
+    }
+
+    @Test
+    @DisplayName("uploadImage는 null 파일을 거부한다")
+    void uploadImageRejectsNullFile() {
+        assertCustomException(
+            () -> uploadService.uploadImage(null, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_REQUEST_BODY
+        );
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 empty 파일을 거부한다")
+    void uploadImageRejectsEmptyFile() {
+        // given
+        MockMultipartFile file = new MockMultipartFile("file", "empty.png", "image/png", new byte[0]);
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_REQUEST_BODY
+        );
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 blank content-type을 거부한다")
+    void uploadImageRejectsBlankContentType() {
+        // given
+        MultipartFile file = mockFile("image.png", " ", 10L);
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 허용되지 않은 content-type을 거부한다")
+    void uploadImageRejectsUnsupportedContentType() {
+        // given
+        MultipartFile file = mockFile("document.pdf", "application/pdf", 10L);
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.INVALID_FILE_CONTENT_TYPE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 maxUploadBytes를 초과하면 PAYLOAD_TOO_LARGE로 실패한다")
+    void uploadImageRejectsOversizedFile() {
+        // given
+        MultipartFile file = mockFile("large.png", "image/png", 5_001L);
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.PAYLOAD_TOO_LARGE
+        );
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    @DisplayName("uploadImage는 S3Exception을 FAILED_UPLOAD_FILE로 변환한다")
+    void uploadImageConvertsS3Exception() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .thenThrow(S3Exception.builder().message("s3 failed").build());
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 SdkClientException을 FAILED_UPLOAD_FILE로 변환한다")
+    void uploadImageConvertsSdkClientException() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .thenThrow(SdkClientException.create("client failed"));
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 InputStream IOException을 FAILED_UPLOAD_FILE로 변환한다")
+    void uploadImageConvertsIOException() throws IOException {
+        // given
+        MultipartFile file = org.mockito.Mockito.mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(false);
+        when(file.getSize()).thenReturn(10L);
+        when(file.getContentType()).thenReturn("image/png");
+        when(file.getInputStream()).thenThrow(new IOException("stream failed"));
+
+        // when & then
+        assertCustomException(
+            () -> uploadService.uploadImage(file, UploadTarget.CLUB),
+            ApiResponseCode.FAILED_UPLOAD_FILE
+        );
+    }
+
+    @Test
+    @DisplayName("uploadImage는 CDN base URL이 비어 있으면 ILLEGAL_STATE로 실패한다")
+    void uploadImageFailsWhenCdnBaseUrlMissing() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties(" ")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        assertCustomException(() -> service.uploadImage(file, UploadTarget.CLUB), ApiResponseCode.ILLEGAL_STATE);
+    }
+
+    @Test
+    @DisplayName("uploadImage는 bucket 설정이 비어 있으면 ILLEGAL_STATE로 실패한다")
+    void uploadImageFailsWhenBucketMissing() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties(" ", "ap-northeast-2", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        assertCustomException(() -> service.uploadImage(file, UploadTarget.CLUB), ApiResponseCode.ILLEGAL_STATE);
+    }
+
+    @Test
+    @DisplayName("uploadImage는 region 설정이 비어 있으면 ILLEGAL_STATE로 실패한다")
+    void uploadImageFailsWhenRegionMissing() {
+        // given
+        UploadService service = new UploadService(
+            s3Client,
+            new S3StorageProperties("konect-bucket", " ", "konect", 5_000L),
+            new StorageCdnProperties("https://cdn.konect.test")
+        );
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "logo.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when & then
+        assertCustomException(() -> service.uploadImage(file, UploadTarget.CLUB), ApiResponseCode.ILLEGAL_STATE);
+    }
+
+    private MultipartFile mockFile(String filename, String contentType, long size) {
+        return new MockMultipartFile(
+            "file",
+            filename,
+            contentType,
+            new byte[Math.toIntExact(size)]
+        );
+    }
+
+    private void assertCustomException(ThrowingCallable callable, ApiResponseCode expectedCode) {
+        assertThatThrownBy(callable::call)
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(expectedCode));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingCallable {
+        void call() throws Exception;
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.mock.web.MockMultipartFile;
@@ -32,6 +34,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+@Execution(ExecutionMode.SAME_THREAD)
 class UploadServiceTest extends ServiceTestSupport {
 
     private static final Pattern CLUB_KEY_PATTERN = Pattern.compile(


### PR DESCRIPTION
### 🔍 개요

- UploadService의 단위 테스트를 41개 케이스로 보강하고, 테스트 과정에서 발견한 2가지 논리적 버그를 수정

- close #523 

---

### 🚀 주요 변경 내용

**버그 수정 (UploadService)**
- content-type 대소문자/공백 불일치 해결
  - `normalizeContentType` 헬퍼 추가: `trim() + toLowerCase()` 적용
  - 기존: `ALLOWED_CONTENT_TYPES.contains()`가 대소문자 구분 → `"IMAGE/PNG"` 거부
  - 수정 후: 검증과 확장자 추출이 동일하게 정규화된 값 사용
- CDN baseUrl trailing slash 제거 로직 수정
  - 기존: `if`로 단일 slash만 제거 → `"https://cdn.test//"` 시 fileUrl에 `//` 잔존
  - 수정 후: `while`로 모든 trailing slash 제거

**단위 테스트 (UploadServiceTest) — 41개 케이스**
- 정상 경로: PNG/JPG/JPEG/WebP 업로드, key/CDN URL 생성 검증
- 입력 검증: null/empty 파일, null/blank/대소문자/공백 content-type, 용량 초과/경계값
- 설정 검증: bucket/region null/blank, maxUploadBytes null/0/음수, CDN URL null
- Key 생성: prefix 정규화(leading/trailing slash), target null, 모든 UploadTarget enum
- 에러 처리: S3Exception/SdkClientException/IOException 변환, awsErrorDetails null
- S3 요청 검증: PutObjectRequest의 bucket/contentType/size 정확성

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
