### PR TITLE
test: ClubApplicationService 단위 테스트 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationApi.java
@@ -160,6 +160,7 @@ public interface ClubApplicationApi {
 
         ## 에러
         - ALREADY_CLUB_MEMBER (409): 이미 동아리 회원입니다.
+        - ALREADY_PROCESSED_CLUB_APPLY (409): 이미 처리된 동아리 가입 신청입니다.
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
         - NOT_FOUND_CLUB_APPLY (404): 동아리 지원 내역을 찾을 수 없습니다.
@@ -174,8 +175,9 @@ public interface ClubApplicationApi {
     @Operation(summary = "동아리 가입 신청을 거절한다.", description = """
         동아리 운영진 권한부터 가입 신청을 거절할 수 있습니다.
         거절 시 상태를 REJECTED로 변경합니다.
-        
+
         ## 에러
+        - ALREADY_PROCESSED_CLUB_APPLY (409): 이미 처리된 동아리 가입 신청입니다.
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
         - NOT_FOUND_CLUB_APPLY (404): 동아리 지원 내역을 찾을 수 없습니다.

--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationApi.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubApplicationApi.java
@@ -34,7 +34,7 @@ public interface ClubApplicationApi {
         동아리 가입 신청서를 제출합니다.
         설문 질문이 없는 경우 answers는 빈 배열을 전달합니다.
         모집 공고에서 회비 납부가 필요한 경우(isFeeRequired=true), feePaymentImageUrl은 필수입니다.
-
+        
         ## 에러
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
         - NOT_FOUND_USER (404): 유저를 찾을 수 없습니다.
@@ -82,7 +82,7 @@ public interface ClubApplicationApi {
         - 정렬 기준: APPLIED_AT(신청 일시), STUDENT_NUMBER(학번), NAME(이름)
         - 정렬 방향: ASC(오름차순), DESC(내림차순)
         - 기본 정렬: 신청 일시 오래된 순 (APPLIED_AT ASC)
-
+        
         ## 에러
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
@@ -102,7 +102,7 @@ public interface ClubApplicationApi {
     @Operation(summary = "승인된 회원의 동아리 지원 답변을 조회한다.", description = """
         - 동아리 관리자만 해당 동아리의 승인된 회원 지원 답변을 조회할 수 있습니다.
         - 사용자 ID(userId) 기준으로 해당 사용자의 지원서를 찾아 문항/답변을 반환합니다.
-
+        
         ## 에러
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
@@ -122,7 +122,7 @@ public interface ClubApplicationApi {
         - 정렬 기준: APPLIED_AT(신청 일시), STUDENT_NUMBER(학번), NAME(이름)
         - 정렬 방향: ASC(오름차순), DESC(내림차순)
         - 기본 정렬: 신청 일시 오래된 순 (APPLIED_AT ASC)
-
+        
         ## 에러
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
@@ -141,7 +141,7 @@ public interface ClubApplicationApi {
 
     @Operation(summary = "동아리 지원 답변을 조회한다.", description = """
         - 동아리 관리자만 해당 동아리의 지원 답변을 조회할 수 있습니다.
-
+        
         ## 에러
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
@@ -157,7 +157,7 @@ public interface ClubApplicationApi {
     @Operation(summary = "동아리 가입 신청을 승인한다.", description = """
         동아리 운영진 권한부터 가입 신청을 승인할 수 있습니다.
         승인 시 지원자는 일반회원으로 등록되며, 지원 내역은 보관됩니다.
-
+        
         ## 에러
         - ALREADY_CLUB_MEMBER (409): 이미 동아리 회원입니다.
         - ALREADY_PROCESSED_CLUB_APPLY (409): 이미 처리된 동아리 가입 신청입니다.
@@ -175,7 +175,7 @@ public interface ClubApplicationApi {
     @Operation(summary = "동아리 가입 신청을 거절한다.", description = """
         동아리 운영진 권한부터 가입 신청을 거절할 수 있습니다.
         거절 시 상태를 REJECTED로 변경합니다.
-
+        
         ## 에러
         - ALREADY_PROCESSED_CLUB_APPLY (409): 이미 처리된 동아리 가입 신청입니다.
         - FORBIDDEN_CLUB_MANAGER_ACCESS (403): 동아리 매니저 권한이 없습니다.
@@ -218,7 +218,7 @@ public interface ClubApplicationApi {
 
     @Operation(summary = "동아리 회비 정보를 조회한다.", description = """
         동아리의 회비 계좌 정보를 조회합니다.
-
+        
         ## 에러
         - NOT_FOUND_CLUB (404): 동아리를 찾을 수 없습니다.
         """)

--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubApplyRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubApplyRepository.java
@@ -4,9 +4,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.LockModeType;
 
 import gg.agit.konect.domain.club.model.ClubApply;
 import gg.agit.konect.domain.club.enums.ClubApplyStatus;
@@ -55,6 +58,24 @@ public interface ClubApplyRepository extends Repository<ClubApply, Integer> {
 
     default ClubApply getByIdAndClubId(Integer id, Integer clubId) {
         return findByIdAndClubId(id, clubId)
+            .orElseThrow(() -> CustomException.of(ApiResponseCode.NOT_FOUND_CLUB_APPLY));
+    }
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT clubApply
+        FROM ClubApply clubApply
+        JOIN FETCH clubApply.user user
+        WHERE clubApply.id = :id
+          AND clubApply.club.id = :clubId
+        """)
+    Optional<ClubApply> findByIdAndClubIdForUpdate(
+        @Param("id") Integer id,
+        @Param("clubId") Integer clubId
+    );
+
+    default ClubApply getByIdAndClubIdForUpdate(Integer id, Integer clubId) {
+        return findByIdAndClubIdForUpdate(id, clubId)
             .orElseThrow(() -> CustomException.of(ApiResponseCode.NOT_FOUND_CLUB_APPLY));
     }
 

--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubApplyRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubApplyRepository.java
@@ -65,7 +65,6 @@ public interface ClubApplyRepository extends Repository<ClubApply, Integer> {
     @Query("""
         SELECT clubApply
         FROM ClubApply clubApply
-        JOIN FETCH clubApply.user user
         WHERE clubApply.id = :id
           AND clubApply.club.id = :clubId
         """)

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
@@ -79,9 +79,9 @@ public class ClubApplicationService {
     }
 
     public ClubApplicationsResponse getClubApplications(
-            Integer clubId,
-            Integer userId,
-            ClubApplicationCondition condition
+        Integer clubId,
+        Integer userId,
+        ClubApplicationCondition condition
     ) {
         clubRepository.getById(clubId);
 
@@ -94,26 +94,26 @@ public class ClubApplicationService {
     }
 
     public ClubApplicationsResponse getApprovedMemberApplications(
-            Integer clubId,
-            Integer userId,
-            ClubApplicationCondition condition
+        Integer clubId,
+        Integer userId,
+        ClubApplicationCondition condition
     ) {
         clubRepository.getById(clubId);
 
         clubPermissionValidator.validateManagerAccess(clubId, userId);
 
         Page<ClubApply> clubAppliesPage = clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(
-                clubId,
-                condition
+            clubId,
+            condition
         );
 
         return ClubApplicationsResponse.from(clubAppliesPage);
     }
 
     public ClubApplicationAnswersResponse getApprovedMemberApplicationAnswers(
-            Integer clubId,
-            Integer targetUserId,
-            Integer requesterId
+        Integer clubId,
+        Integer targetUserId,
+        Integer requesterId
     ) {
         clubRepository.getById(clubId);
 
@@ -126,16 +126,16 @@ public class ClubApplicationService {
     }
 
     public ClubMemberApplicationAnswersResponse getApprovedMemberApplicationAnswersList(
-            Integer clubId,
-            Integer requesterId,
-            ClubApplicationCondition condition
+        Integer clubId,
+        Integer requesterId,
+        ClubApplicationCondition condition
     ) {
         clubRepository.getById(clubId);
 
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         Page<ClubApply> approvedApplicationsPage =
-                clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(clubId, condition);
+            clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(clubId, condition);
         List<ClubApply> approvedApplications = approvedApplicationsPage.getContent();
 
         if (approvedApplications.isEmpty()) {
@@ -143,49 +143,49 @@ public class ClubApplicationService {
         }
 
         List<Integer> applyIds = approvedApplications.stream()
-                .map(ClubApply::getId)
-                .toList();
+            .map(ClubApply::getId)
+            .toList();
         List<LocalDateTime> appliedAts = approvedApplications.stream()
-                .map(ClubApply::getCreatedAt)
-                .distinct()
-                .toList();
+            .map(ClubApply::getCreatedAt)
+            .distinct()
+            .toList();
 
         LocalDateTime minAppliedAt = appliedAts.stream()
-                .min(LocalDateTime::compareTo)
-                .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
+            .min(LocalDateTime::compareTo)
+            .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
         LocalDateTime maxAppliedAt = appliedAts.stream()
-                .max(LocalDateTime::compareTo)
-                .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
+            .max(LocalDateTime::compareTo)
+            .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
 
         Map<Integer, List<ClubApplyAnswer>> answersByApplyId = clubApplyAnswerRepository
-                .findAllByApplyIdsWithQuestion(applyIds)
-                .stream()
-                .collect(Collectors.groupingBy(answer -> answer.getApply().getId()));
+            .findAllByApplyIdsWithQuestion(applyIds)
+            .stream()
+            .collect(Collectors.groupingBy(answer -> answer.getApply().getId()));
         List<ClubApplyQuestion> questionCandidates = clubApplyQuestionRepository
-                .findAllCandidatesVisibleBetweenApplyTimes(clubId, minAppliedAt, maxAppliedAt);
+            .findAllCandidatesVisibleBetweenApplyTimes(clubId, minAppliedAt, maxAppliedAt);
         Map<LocalDateTime, List<ClubApplyQuestion>> questionsByAppliedAt = appliedAts.stream()
-                .collect(Collectors.toMap(
-                        appliedAt -> appliedAt,
-                        appliedAt -> questionCandidates.stream()
-                                .filter(question -> isVisibleAtApplyTime(question, appliedAt))
-                                .toList()
-                ));
+            .collect(Collectors.toMap(
+                appliedAt -> appliedAt,
+                appliedAt -> questionCandidates.stream()
+                    .filter(question -> isVisibleAtApplyTime(question, appliedAt))
+                    .toList()
+            ));
 
         List<ClubApplicationAnswersResponse> responses = approvedApplications.stream()
-                .map(application -> toClubApplicationAnswersResponse(
-                        application,
-                        questionsByAppliedAt.getOrDefault(application.getCreatedAt(), List.of()),
-                        answersByApplyId.getOrDefault(application.getId(), List.of())
-                ))
-                .toList();
+            .map(application -> toClubApplicationAnswersResponse(
+                application,
+                questionsByAppliedAt.getOrDefault(application.getCreatedAt(), List.of()),
+                answersByApplyId.getOrDefault(application.getId(), List.of())
+            ))
+            .toList();
 
         return ClubMemberApplicationAnswersResponse.from(approvedApplicationsPage, responses);
     }
 
     public ClubApplicationAnswersResponse getClubApplicationAnswers(
-            Integer clubId,
-            Integer applicationId,
-            Integer userId
+        Integer clubId,
+        Integer applicationId,
+        Integer userId
     ) {
         clubRepository.getById(clubId);
 
@@ -201,20 +201,20 @@ public class ClubApplicationService {
     }
 
     private ClubApplicationAnswersResponse toClubApplicationAnswersResponse(
-            Integer clubId,
-            ClubApply clubApply,
-            List<ClubApplyAnswer> answers
+        Integer clubId,
+        ClubApply clubApply,
+        List<ClubApplyAnswer> answers
     ) {
         List<ClubApplyQuestion> questions =
-                clubApplyQuestionRepository.findAllVisibleAtApplyTime(clubId, clubApply.getCreatedAt());
+            clubApplyQuestionRepository.findAllVisibleAtApplyTime(clubId, clubApply.getCreatedAt());
 
         return toClubApplicationAnswersResponse(clubApply, questions, answers);
     }
 
     private ClubApplicationAnswersResponse toClubApplicationAnswersResponse(
-            ClubApply clubApply,
-            List<ClubApplyQuestion> questions,
-            List<ClubApplyAnswer> answers
+        ClubApply clubApply,
+        List<ClubApplyQuestion> questions,
+        List<ClubApplyAnswer> answers
     ) {
         return ClubApplicationAnswersResponse.of(clubApply, questions, answers);
     }
@@ -223,7 +223,7 @@ public class ClubApplicationService {
         LocalDateTime createdAt = question.getCreatedAt();
         LocalDateTime deletedAt = question.getDeletedAt();
         return (createdAt.isBefore(appliedAt) || createdAt.isEqual(appliedAt))
-                && (deletedAt == null || deletedAt.isAfter(appliedAt));
+            && (deletedAt == null || deletedAt.isAfter(appliedAt));
     }
 
     @Transactional
@@ -245,19 +245,19 @@ public class ClubApplicationService {
         }
 
         ClubMember newMember = ClubMember.builder()
-                .club(club)
-                .user(applicant)
-                .clubPosition(MEMBER)
-                .build();
+            .club(club)
+            .user(applicant)
+            .clubPosition(MEMBER)
+            .build();
 
         ClubMember savedMember = clubMemberRepository.save(newMember);
         chatRoomMembershipService.addClubMember(savedMember);
         clubApply.approve();
 
         applicationEventPublisher.publishEvent(ClubApplicationApprovedEvent.of(
-                applicant.getId(),
-                clubId,
-                club.getName()
+            applicant.getId(),
+            clubId,
+            club.getName()
         ));
     }
 
@@ -277,9 +277,9 @@ public class ClubApplicationService {
         clubApply.reject();
 
         applicationEventPublisher.publishEvent(ClubApplicationRejectedEvent.of(
-                applicant.getId(),
-                clubId,
-                club.getName()
+            applicant.getId(),
+            clubId,
+            club.getName()
         ));
     }
 
@@ -299,11 +299,11 @@ public class ClubApplicationService {
         validateFeePaymentImage(club, request.feePaymentImageUrl());
 
         List<ClubApplyQuestion> questions =
-                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
         ClubApplyQuestionAnswers answers = ClubApplyQuestionAnswers.of(questions, request.toAnswerMap());
 
         ClubApply apply = clubApplyRepository.save(
-                ClubApply.of(club, user, request.feePaymentImageUrl())
+            ClubApply.of(club, user, request.feePaymentImageUrl())
         );
 
         List<ClubApplyAnswer> applyAnswers = answers.toEntities(apply);
@@ -313,18 +313,18 @@ public class ClubApplicationService {
         }
 
         List<Integer> managerIds = clubMemberRepository
-                .findAllByClubIdAndPositionIn(clubId, ClubPosition.MANAGERS)
-                .stream()
-                .map(manager -> manager.getUser().getId())
-                .toList();
+            .findAllByClubIdAndPositionIn(clubId, ClubPosition.MANAGERS)
+            .stream()
+            .map(manager -> manager.getUser().getId())
+            .toList();
 
         if (!managerIds.isEmpty()) {
             applicationEventPublisher.publishEvent(ClubApplicationSubmittedEvent.of(
-                    managerIds,
-                    apply.getId(),
-                    clubId,
-                    club.getName(),
-                    user.getName()
+                managerIds,
+                apply.getId(),
+                clubId,
+                club.getName(),
+                user.getName()
             ));
         }
 
@@ -334,23 +334,23 @@ public class ClubApplicationService {
 
     private void validateFeePaymentImage(Club club, String feePaymentImageUrl) {
         if (Boolean.TRUE.equals(club.getIsFeeRequired())
-                && !StringUtils.hasText(feePaymentImageUrl)) {
+            && !StringUtils.hasText(feePaymentImageUrl)) {
             throw CustomException.of(FEE_PAYMENT_IMAGE_REQUIRED);
         }
     }
 
     public ClubApplyQuestionsResponse getApplyQuestions(Integer clubId, Integer userId) {
         List<ClubApplyQuestion> questions =
-                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
 
         return ClubApplyQuestionsResponse.from(questions);
     }
 
     @Transactional
     public ClubApplyQuestionsResponse replaceApplyQuestions(
-            Integer clubId,
-            Integer userId,
-            ClubApplyQuestionsReplaceRequest request
+        Integer clubId,
+        Integer userId,
+        ClubApplyQuestionsReplaceRequest request
     ) {
         Club club = clubRepository.getById(clubId);
 
@@ -362,17 +362,17 @@ public class ClubApplicationService {
         List<ClubApplyQuestion> questionsToSoftDelete = new ArrayList<>();
 
         List<ClubApplyQuestion> existingQuestions =
-                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
         Map<Integer, ClubApplyQuestion> existingQuestionMap = existingQuestions.stream()
-                .collect(Collectors.toMap(ClubApplyQuestion::getId, question -> question));
+            .collect(Collectors.toMap(ClubApplyQuestion::getId, question -> question));
 
         prepareQuestions(
-                club,
-                existingQuestionMap,
-                questionRequests,
-                requestedQuestionIds,
-                questionsToCreate,
-                questionsToSoftDelete
+            club,
+            existingQuestionMap,
+            questionRequests,
+            requestedQuestionIds,
+            questionsToCreate,
+            questionsToSoftDelete
         );
 
         deleteQuestions(existingQuestions, requestedQuestionIds, questionsToSoftDelete);
@@ -385,18 +385,18 @@ public class ClubApplicationService {
         }
 
         List<ClubApplyQuestion> questions =
-                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
 
         return ClubApplyQuestionsResponse.from(questions);
     }
 
     private void prepareQuestions(
-            Club club,
-            Map<Integer, ClubApplyQuestion> existingQuestionMap,
-            List<ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest> questionRequests,
-            Set<Integer> requestedQuestionIds,
-            List<ClubApplyQuestion> questionsToCreate,
-            List<ClubApplyQuestion> questionsToSoftDelete
+        Club club,
+        Map<Integer, ClubApplyQuestion> existingQuestionMap,
+        List<ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest> questionRequests,
+        Set<Integer> requestedQuestionIds,
+        List<ClubApplyQuestion> questionsToCreate,
+        List<ClubApplyQuestion> questionsToSoftDelete
     ) {
         for (int index = 0; index < questionRequests.size(); index++) {
             int displayOrder = index + 1;
@@ -405,10 +405,10 @@ public class ClubApplicationService {
 
             if (questionId == null) {
                 questionsToCreate.add(ClubApplyQuestion.of(
-                        club,
-                        questionRequest.question(),
-                        questionRequest.isRequiredOrDefault(),
-                        displayOrder)
+                    club,
+                    questionRequest.question(),
+                    questionRequest.isRequiredOrDefault(),
+                    displayOrder)
                 );
                 continue;
             }
@@ -436,13 +436,13 @@ public class ClubApplicationService {
     }
 
     private void deleteQuestions(
-            List<ClubApplyQuestion> existingQuestions,
-            Set<Integer> requestedQuestionIds,
-            List<ClubApplyQuestion> questionsToSoftDelete
+        List<ClubApplyQuestion> existingQuestions,
+        Set<Integer> requestedQuestionIds,
+        List<ClubApplyQuestion> questionsToSoftDelete
     ) {
         List<ClubApplyQuestion> questionsToDelete = existingQuestions.stream()
-                .filter(question -> !requestedQuestionIds.contains(question.getId()))
-                .toList();
+            .filter(question -> !requestedQuestionIds.contains(question.getId()))
+            .toList();
 
         if (!questionsToDelete.isEmpty()) {
             questionsToSoftDelete.addAll(questionsToDelete);
@@ -450,19 +450,19 @@ public class ClubApplicationService {
     }
 
     private Page<ClubApply> findApplicationsByRecruitmentPeriod(
-            Integer clubId,
-            ClubRecruitment recruitment,
-            ClubApplicationCondition condition
+        Integer clubId,
+        ClubRecruitment recruitment,
+        ClubApplicationCondition condition
     ) {
         if (recruitment.getIsAlwaysRecruiting()) {
             return clubApplyQueryRepository.findAllByClubId(clubId, condition);
         }
 
         return clubApplyQueryRepository.findAllByClubIdAndCreatedAtBetween(
-                clubId,
-                recruitment.getStartAt(),
-                recruitment.getEndAt(),
-                condition
+            clubId,
+            recruitment.getStartAt(),
+            recruitment.getEndAt(),
+            condition
         );
     }
 
@@ -489,10 +489,10 @@ public class ClubApplicationService {
         String bankName = bankRepository.getById(request.bankId()).getName();
 
         club.replaceFeeInfo(
-                request.amount(),
-                bankName,
-                request.accountNumber(),
-                request.accountHolder()
+            request.amount(),
+            bankName,
+            request.accountNumber(),
+            request.accountHolder()
         );
 
         return ClubFeeInfoResponse.of(club, request.bankId(), bankName);

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
@@ -2,6 +2,7 @@ package gg.agit.konect.domain.club.service;
 
 import static gg.agit.konect.domain.club.enums.ClubPosition.MEMBER;
 
+import gg.agit.konect.domain.club.enums.ClubApplyStatus;
 import gg.agit.konect.domain.club.enums.ClubPosition;
 
 import static gg.agit.konect.global.code.ApiResponseCode.*;
@@ -232,6 +233,11 @@ public class ClubApplicationService {
         clubPermissionValidator.validateManagerAccess(clubId, userId);
 
         ClubApply clubApply = clubApplyRepository.getByIdAndClubId(applicationId, clubId);
+
+        if (clubApply.getStatus() != ClubApplyStatus.PENDING) {
+            throw CustomException.of(ALREADY_PROCESSED_CLUB_APPLY);
+        }
+
         User applicant = clubApply.getUser();
 
         if (clubMemberRepository.existsByClubIdAndUserId(clubId, applicant.getId())) {
@@ -262,6 +268,11 @@ public class ClubApplicationService {
         clubPermissionValidator.validateManagerAccess(clubId, userId);
 
         ClubApply clubApply = clubApplyRepository.getByIdAndClubId(applicationId, clubId);
+
+        if (clubApply.getStatus() != ClubApplyStatus.PENDING) {
+            throw CustomException.of(ALREADY_PROCESSED_CLUB_APPLY);
+        }
+
         User applicant = clubApply.getUser();
         clubApply.reject();
 

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
@@ -79,9 +79,9 @@ public class ClubApplicationService {
     }
 
     public ClubApplicationsResponse getClubApplications(
-        Integer clubId,
-        Integer userId,
-        ClubApplicationCondition condition
+            Integer clubId,
+            Integer userId,
+            ClubApplicationCondition condition
     ) {
         clubRepository.getById(clubId);
 
@@ -94,26 +94,26 @@ public class ClubApplicationService {
     }
 
     public ClubApplicationsResponse getApprovedMemberApplications(
-        Integer clubId,
-        Integer userId,
-        ClubApplicationCondition condition
+            Integer clubId,
+            Integer userId,
+            ClubApplicationCondition condition
     ) {
         clubRepository.getById(clubId);
 
         clubPermissionValidator.validateManagerAccess(clubId, userId);
 
         Page<ClubApply> clubAppliesPage = clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(
-            clubId,
-            condition
+                clubId,
+                condition
         );
 
         return ClubApplicationsResponse.from(clubAppliesPage);
     }
 
     public ClubApplicationAnswersResponse getApprovedMemberApplicationAnswers(
-        Integer clubId,
-        Integer targetUserId,
-        Integer requesterId
+            Integer clubId,
+            Integer targetUserId,
+            Integer requesterId
     ) {
         clubRepository.getById(clubId);
 
@@ -126,16 +126,16 @@ public class ClubApplicationService {
     }
 
     public ClubMemberApplicationAnswersResponse getApprovedMemberApplicationAnswersList(
-        Integer clubId,
-        Integer requesterId,
-        ClubApplicationCondition condition
+            Integer clubId,
+            Integer requesterId,
+            ClubApplicationCondition condition
     ) {
         clubRepository.getById(clubId);
 
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         Page<ClubApply> approvedApplicationsPage =
-            clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(clubId, condition);
+                clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(clubId, condition);
         List<ClubApply> approvedApplications = approvedApplicationsPage.getContent();
 
         if (approvedApplications.isEmpty()) {
@@ -143,49 +143,49 @@ public class ClubApplicationService {
         }
 
         List<Integer> applyIds = approvedApplications.stream()
-            .map(ClubApply::getId)
-            .toList();
+                .map(ClubApply::getId)
+                .toList();
         List<LocalDateTime> appliedAts = approvedApplications.stream()
-            .map(ClubApply::getCreatedAt)
-            .distinct()
-            .toList();
+                .map(ClubApply::getCreatedAt)
+                .distinct()
+                .toList();
 
         LocalDateTime minAppliedAt = appliedAts.stream()
-            .min(LocalDateTime::compareTo)
-            .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
+                .min(LocalDateTime::compareTo)
+                .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
         LocalDateTime maxAppliedAt = appliedAts.stream()
-            .max(LocalDateTime::compareTo)
-            .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
+                .max(LocalDateTime::compareTo)
+                .orElseThrow(() -> new IllegalStateException("지원서 신청 시점이 비어 있습니다."));
 
         Map<Integer, List<ClubApplyAnswer>> answersByApplyId = clubApplyAnswerRepository
-            .findAllByApplyIdsWithQuestion(applyIds)
-            .stream()
-            .collect(Collectors.groupingBy(answer -> answer.getApply().getId()));
+                .findAllByApplyIdsWithQuestion(applyIds)
+                .stream()
+                .collect(Collectors.groupingBy(answer -> answer.getApply().getId()));
         List<ClubApplyQuestion> questionCandidates = clubApplyQuestionRepository
-            .findAllCandidatesVisibleBetweenApplyTimes(clubId, minAppliedAt, maxAppliedAt);
+                .findAllCandidatesVisibleBetweenApplyTimes(clubId, minAppliedAt, maxAppliedAt);
         Map<LocalDateTime, List<ClubApplyQuestion>> questionsByAppliedAt = appliedAts.stream()
-            .collect(Collectors.toMap(
-                appliedAt -> appliedAt,
-                appliedAt -> questionCandidates.stream()
-                    .filter(question -> isVisibleAtApplyTime(question, appliedAt))
-                    .toList()
-            ));
+                .collect(Collectors.toMap(
+                        appliedAt -> appliedAt,
+                        appliedAt -> questionCandidates.stream()
+                                .filter(question -> isVisibleAtApplyTime(question, appliedAt))
+                                .toList()
+                ));
 
         List<ClubApplicationAnswersResponse> responses = approvedApplications.stream()
-            .map(application -> toClubApplicationAnswersResponse(
-                application,
-                questionsByAppliedAt.getOrDefault(application.getCreatedAt(), List.of()),
-                answersByApplyId.getOrDefault(application.getId(), List.of())
-            ))
-            .toList();
+                .map(application -> toClubApplicationAnswersResponse(
+                        application,
+                        questionsByAppliedAt.getOrDefault(application.getCreatedAt(), List.of()),
+                        answersByApplyId.getOrDefault(application.getId(), List.of())
+                ))
+                .toList();
 
         return ClubMemberApplicationAnswersResponse.from(approvedApplicationsPage, responses);
     }
 
     public ClubApplicationAnswersResponse getClubApplicationAnswers(
-        Integer clubId,
-        Integer applicationId,
-        Integer userId
+            Integer clubId,
+            Integer applicationId,
+            Integer userId
     ) {
         clubRepository.getById(clubId);
 
@@ -201,20 +201,20 @@ public class ClubApplicationService {
     }
 
     private ClubApplicationAnswersResponse toClubApplicationAnswersResponse(
-        Integer clubId,
-        ClubApply clubApply,
-        List<ClubApplyAnswer> answers
+            Integer clubId,
+            ClubApply clubApply,
+            List<ClubApplyAnswer> answers
     ) {
         List<ClubApplyQuestion> questions =
-            clubApplyQuestionRepository.findAllVisibleAtApplyTime(clubId, clubApply.getCreatedAt());
+                clubApplyQuestionRepository.findAllVisibleAtApplyTime(clubId, clubApply.getCreatedAt());
 
         return toClubApplicationAnswersResponse(clubApply, questions, answers);
     }
 
     private ClubApplicationAnswersResponse toClubApplicationAnswersResponse(
-        ClubApply clubApply,
-        List<ClubApplyQuestion> questions,
-        List<ClubApplyAnswer> answers
+            ClubApply clubApply,
+            List<ClubApplyQuestion> questions,
+            List<ClubApplyAnswer> answers
     ) {
         return ClubApplicationAnswersResponse.of(clubApply, questions, answers);
     }
@@ -223,7 +223,7 @@ public class ClubApplicationService {
         LocalDateTime createdAt = question.getCreatedAt();
         LocalDateTime deletedAt = question.getDeletedAt();
         return (createdAt.isBefore(appliedAt) || createdAt.isEqual(appliedAt))
-            && (deletedAt == null || deletedAt.isAfter(appliedAt));
+                && (deletedAt == null || deletedAt.isAfter(appliedAt));
     }
 
     @Transactional
@@ -245,19 +245,19 @@ public class ClubApplicationService {
         }
 
         ClubMember newMember = ClubMember.builder()
-            .club(club)
-            .user(applicant)
-            .clubPosition(MEMBER)
-            .build();
+                .club(club)
+                .user(applicant)
+                .clubPosition(MEMBER)
+                .build();
 
         ClubMember savedMember = clubMemberRepository.save(newMember);
         chatRoomMembershipService.addClubMember(savedMember);
         clubApply.approve();
 
         applicationEventPublisher.publishEvent(ClubApplicationApprovedEvent.of(
-            applicant.getId(),
-            clubId,
-            club.getName()
+                applicant.getId(),
+                clubId,
+                club.getName()
         ));
     }
 
@@ -277,9 +277,9 @@ public class ClubApplicationService {
         clubApply.reject();
 
         applicationEventPublisher.publishEvent(ClubApplicationRejectedEvent.of(
-            applicant.getId(),
-            clubId,
-            club.getName()
+                applicant.getId(),
+                clubId,
+                club.getName()
         ));
     }
 
@@ -299,11 +299,11 @@ public class ClubApplicationService {
         validateFeePaymentImage(club, request.feePaymentImageUrl());
 
         List<ClubApplyQuestion> questions =
-            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
         ClubApplyQuestionAnswers answers = ClubApplyQuestionAnswers.of(questions, request.toAnswerMap());
 
         ClubApply apply = clubApplyRepository.save(
-            ClubApply.of(club, user, request.feePaymentImageUrl())
+                ClubApply.of(club, user, request.feePaymentImageUrl())
         );
 
         List<ClubApplyAnswer> applyAnswers = answers.toEntities(apply);
@@ -313,18 +313,18 @@ public class ClubApplicationService {
         }
 
         List<Integer> managerIds = clubMemberRepository
-            .findAllByClubIdAndPositionIn(clubId, ClubPosition.MANAGERS)
-            .stream()
-            .map(manager -> manager.getUser().getId())
-            .toList();
+                .findAllByClubIdAndPositionIn(clubId, ClubPosition.MANAGERS)
+                .stream()
+                .map(manager -> manager.getUser().getId())
+                .toList();
 
         if (!managerIds.isEmpty()) {
             applicationEventPublisher.publishEvent(ClubApplicationSubmittedEvent.of(
-                managerIds,
-                apply.getId(),
-                clubId,
-                club.getName(),
-                user.getName()
+                    managerIds,
+                    apply.getId(),
+                    clubId,
+                    club.getName(),
+                    user.getName()
             ));
         }
 
@@ -334,23 +334,23 @@ public class ClubApplicationService {
 
     private void validateFeePaymentImage(Club club, String feePaymentImageUrl) {
         if (Boolean.TRUE.equals(club.getIsFeeRequired())
-            && !StringUtils.hasText(feePaymentImageUrl)) {
+                && !StringUtils.hasText(feePaymentImageUrl)) {
             throw CustomException.of(FEE_PAYMENT_IMAGE_REQUIRED);
         }
     }
 
     public ClubApplyQuestionsResponse getApplyQuestions(Integer clubId, Integer userId) {
         List<ClubApplyQuestion> questions =
-            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
 
         return ClubApplyQuestionsResponse.from(questions);
     }
 
     @Transactional
     public ClubApplyQuestionsResponse replaceApplyQuestions(
-        Integer clubId,
-        Integer userId,
-        ClubApplyQuestionsReplaceRequest request
+            Integer clubId,
+            Integer userId,
+            ClubApplyQuestionsReplaceRequest request
     ) {
         Club club = clubRepository.getById(clubId);
 
@@ -362,17 +362,17 @@ public class ClubApplicationService {
         List<ClubApplyQuestion> questionsToSoftDelete = new ArrayList<>();
 
         List<ClubApplyQuestion> existingQuestions =
-            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
         Map<Integer, ClubApplyQuestion> existingQuestionMap = existingQuestions.stream()
-            .collect(Collectors.toMap(ClubApplyQuestion::getId, question -> question));
+                .collect(Collectors.toMap(ClubApplyQuestion::getId, question -> question));
 
         prepareQuestions(
-            club,
-            existingQuestionMap,
-            questionRequests,
-            requestedQuestionIds,
-            questionsToCreate,
-            questionsToSoftDelete
+                club,
+                existingQuestionMap,
+                questionRequests,
+                requestedQuestionIds,
+                questionsToCreate,
+                questionsToSoftDelete
         );
 
         deleteQuestions(existingQuestions, requestedQuestionIds, questionsToSoftDelete);
@@ -385,18 +385,18 @@ public class ClubApplicationService {
         }
 
         List<ClubApplyQuestion> questions =
-            clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
+                clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(clubId);
 
         return ClubApplyQuestionsResponse.from(questions);
     }
 
     private void prepareQuestions(
-        Club club,
-        Map<Integer, ClubApplyQuestion> existingQuestionMap,
-        List<ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest> questionRequests,
-        Set<Integer> requestedQuestionIds,
-        List<ClubApplyQuestion> questionsToCreate,
-        List<ClubApplyQuestion> questionsToSoftDelete
+            Club club,
+            Map<Integer, ClubApplyQuestion> existingQuestionMap,
+            List<ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest> questionRequests,
+            Set<Integer> requestedQuestionIds,
+            List<ClubApplyQuestion> questionsToCreate,
+            List<ClubApplyQuestion> questionsToSoftDelete
     ) {
         for (int index = 0; index < questionRequests.size(); index++) {
             int displayOrder = index + 1;
@@ -405,10 +405,10 @@ public class ClubApplicationService {
 
             if (questionId == null) {
                 questionsToCreate.add(ClubApplyQuestion.of(
-                    club,
-                    questionRequest.question(),
-                    questionRequest.isRequiredOrDefault(),
-                    displayOrder)
+                        club,
+                        questionRequest.question(),
+                        questionRequest.isRequiredOrDefault(),
+                        displayOrder)
                 );
                 continue;
             }
@@ -436,13 +436,13 @@ public class ClubApplicationService {
     }
 
     private void deleteQuestions(
-        List<ClubApplyQuestion> existingQuestions,
-        Set<Integer> requestedQuestionIds,
-        List<ClubApplyQuestion> questionsToSoftDelete
+            List<ClubApplyQuestion> existingQuestions,
+            Set<Integer> requestedQuestionIds,
+            List<ClubApplyQuestion> questionsToSoftDelete
     ) {
         List<ClubApplyQuestion> questionsToDelete = existingQuestions.stream()
-            .filter(question -> !requestedQuestionIds.contains(question.getId()))
-            .toList();
+                .filter(question -> !requestedQuestionIds.contains(question.getId()))
+                .toList();
 
         if (!questionsToDelete.isEmpty()) {
             questionsToSoftDelete.addAll(questionsToDelete);
@@ -450,19 +450,19 @@ public class ClubApplicationService {
     }
 
     private Page<ClubApply> findApplicationsByRecruitmentPeriod(
-        Integer clubId,
-        ClubRecruitment recruitment,
-        ClubApplicationCondition condition
+            Integer clubId,
+            ClubRecruitment recruitment,
+            ClubApplicationCondition condition
     ) {
         if (recruitment.getIsAlwaysRecruiting()) {
             return clubApplyQueryRepository.findAllByClubId(clubId, condition);
         }
 
         return clubApplyQueryRepository.findAllByClubIdAndCreatedAtBetween(
-            clubId,
-            recruitment.getStartAt(),
-            recruitment.getEndAt(),
-            condition
+                clubId,
+                recruitment.getStartAt(),
+                recruitment.getEndAt(),
+                condition
         );
     }
 
@@ -489,10 +489,10 @@ public class ClubApplicationService {
         String bankName = bankRepository.getById(request.bankId()).getName();
 
         club.replaceFeeInfo(
-            request.amount(),
-            bankName,
-            request.accountNumber(),
-            request.accountHolder()
+                request.amount(),
+                bankName,
+                request.accountNumber(),
+                request.accountHolder()
         );
 
         return ClubFeeInfoResponse.of(club, request.bankId(), bankName);

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubApplicationService.java
@@ -232,7 +232,7 @@ public class ClubApplicationService {
 
         clubPermissionValidator.validateManagerAccess(clubId, userId);
 
-        ClubApply clubApply = clubApplyRepository.getByIdAndClubId(applicationId, clubId);
+        ClubApply clubApply = clubApplyRepository.getByIdAndClubIdForUpdate(applicationId, clubId);
 
         if (clubApply.getStatus() != ClubApplyStatus.PENDING) {
             throw CustomException.of(ALREADY_PROCESSED_CLUB_APPLY);
@@ -267,7 +267,7 @@ public class ClubApplicationService {
 
         clubPermissionValidator.validateManagerAccess(clubId, userId);
 
-        ClubApply clubApply = clubApplyRepository.getByIdAndClubId(applicationId, clubId);
+        ClubApply clubApply = clubApplyRepository.getByIdAndClubIdForUpdate(applicationId, clubId);
 
         if (clubApply.getStatus() != ClubApplyStatus.PENDING) {
             throw CustomException.of(ALREADY_PROCESSED_CLUB_APPLY);

--- a/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
+++ b/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
@@ -119,6 +119,7 @@ public enum ApiResponseCode {
     ALREADY_CLUB_MEMBER(HttpStatus.CONFLICT, "이미 동아리 회원입니다."),
     ALREADY_CLUB_PRE_MEMBER(HttpStatus.CONFLICT, "이미 동아리에 사전 등록된 회원입니다."),
     DUPLICATE_CLUB_APPLY_QUESTION(HttpStatus.CONFLICT, "중복된 가입 문항이 포함되어 있습니다."),
+    ALREADY_PROCESSED_CLUB_APPLY(HttpStatus.CONFLICT, "이미 처리된 동아리 가입 신청입니다."),
     VICE_PRESIDENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "부회장은 이미 존재합니다."),
     ALREADY_RUNNING_STUDY_TIMER(HttpStatus.CONFLICT, "이미 실행 중인 스터디 타이머가 있습니다."),
     ALREADY_EXIST_CLUB_RECRUITMENT(HttpStatus.CONFLICT, "이미 동아리 모집 공고가 존재합니다."),

--- a/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
+++ b/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
@@ -19,7 +19,7 @@ public enum ApiResponseCode {
     FAILED_EXTRACT_EMAIL(HttpStatus.BAD_REQUEST, "OAuth 로그인 과정에서 이메일 정보를 가져올 수 없습니다."),
     FAILED_EXTRACT_PROVIDER_ID(HttpStatus.BAD_REQUEST, "OAuth 로그인 과정에서 제공자 식별자를 가져올 수 없습니다."),
     INVALID_GOOGLE_DRIVE_AUTH(HttpStatus.BAD_REQUEST,
-        "Google Drive 인증이 만료되었거나 올바르지 않습니다. Drive 권한을 다시 연결해 주세요."),
+            "Google Drive 인증이 만료되었거나 올바르지 않습니다. Drive 권한을 다시 연결해 주세요."),
     CANNOT_CREATE_CHAT_ROOM_WITH_SELF(HttpStatus.BAD_REQUEST, "자기 자신과는 채팅방을 만들 수 없습니다."),
     CANNOT_LEAVE_GROUP_CHAT_ROOM(HttpStatus.BAD_REQUEST, "동아리 채팅방은 나갈 수 없습니다."),
     CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 강퇴할 수 없습니다."),
@@ -50,7 +50,7 @@ public enum ApiResponseCode {
     FEE_PAYMENT_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "회비 납부가 필요한 동아리입니다. 납부 증빙 사진을 첨부해주세요."),
     AMBIGUOUS_USER_MATCH(HttpStatus.BAD_REQUEST, "동일한 정보로 식별되는 사용자가 2명 이상입니다. 관리자에게 문의해주세요."),
     CLUB_SHEET_ANALYSIS_REQUIRED(HttpStatus.BAD_REQUEST,
-        "구글 시트 파일에서 동아리 부원을 가져오기 전에 먼저 AI 분석 및 등록이 완료되어야 합니다."),
+            "구글 시트 파일에서 동아리 부원을 가져오기 전에 먼저 AI 분석 및 등록이 완료되어야 합니다."),
 
     // 401 Unauthorized
     INVALID_SESSION(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 정보 입니다."),
@@ -76,7 +76,7 @@ public enum ApiResponseCode {
     FORBIDDEN_POSITION_NAME_CHANGE(HttpStatus.FORBIDDEN, "해당 직책의 이름은 변경할 수 없습니다."),
     FORBIDDEN_ROLE_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     FORBIDDEN_GOOGLE_SHEET_ACCESS(HttpStatus.FORBIDDEN,
-        "구글 스프레드시트 접근 권한이 없습니다. 서비스 계정을 공유하거나 Google Drive 권한을 연결한 뒤 다시 시도해 주세요."),
+            "구글 스프레드시트 접근 권한이 없습니다. 서비스 계정을 공유하거나 Google Drive 권한을 연결한 뒤 다시 시도해 주세요."),
     FORBIDDEN_ORIGIN_ACCESS(HttpStatus.FORBIDDEN, "허용되지 않은 Origin 입니다."),
     FORBIDDEN_CHAT_ROOM_KICK(HttpStatus.FORBIDDEN, "채팅방 방장만 멤버를 강퇴할 수 있습니다."),
 

--- a/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
+++ b/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
@@ -19,7 +19,7 @@ public enum ApiResponseCode {
     FAILED_EXTRACT_EMAIL(HttpStatus.BAD_REQUEST, "OAuth 로그인 과정에서 이메일 정보를 가져올 수 없습니다."),
     FAILED_EXTRACT_PROVIDER_ID(HttpStatus.BAD_REQUEST, "OAuth 로그인 과정에서 제공자 식별자를 가져올 수 없습니다."),
     INVALID_GOOGLE_DRIVE_AUTH(HttpStatus.BAD_REQUEST,
-            "Google Drive 인증이 만료되었거나 올바르지 않습니다. Drive 권한을 다시 연결해 주세요."),
+        "Google Drive 인증이 만료되었거나 올바르지 않습니다. Drive 권한을 다시 연결해 주세요."),
     CANNOT_CREATE_CHAT_ROOM_WITH_SELF(HttpStatus.BAD_REQUEST, "자기 자신과는 채팅방을 만들 수 없습니다."),
     CANNOT_LEAVE_GROUP_CHAT_ROOM(HttpStatus.BAD_REQUEST, "동아리 채팅방은 나갈 수 없습니다."),
     CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 강퇴할 수 없습니다."),
@@ -50,7 +50,7 @@ public enum ApiResponseCode {
     FEE_PAYMENT_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "회비 납부가 필요한 동아리입니다. 납부 증빙 사진을 첨부해주세요."),
     AMBIGUOUS_USER_MATCH(HttpStatus.BAD_REQUEST, "동일한 정보로 식별되는 사용자가 2명 이상입니다. 관리자에게 문의해주세요."),
     CLUB_SHEET_ANALYSIS_REQUIRED(HttpStatus.BAD_REQUEST,
-            "구글 시트 파일에서 동아리 부원을 가져오기 전에 먼저 AI 분석 및 등록이 완료되어야 합니다."),
+        "구글 시트 파일에서 동아리 부원을 가져오기 전에 먼저 AI 분석 및 등록이 완료되어야 합니다."),
 
     // 401 Unauthorized
     INVALID_SESSION(HttpStatus.UNAUTHORIZED, "올바르지 않은 인증 정보 입니다."),
@@ -76,7 +76,7 @@ public enum ApiResponseCode {
     FORBIDDEN_POSITION_NAME_CHANGE(HttpStatus.FORBIDDEN, "해당 직책의 이름은 변경할 수 없습니다."),
     FORBIDDEN_ROLE_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     FORBIDDEN_GOOGLE_SHEET_ACCESS(HttpStatus.FORBIDDEN,
-            "구글 스프레드시트 접근 권한이 없습니다. 서비스 계정을 공유하거나 Google Drive 권한을 연결한 뒤 다시 시도해 주세요."),
+        "구글 스프레드시트 접근 권한이 없습니다. 서비스 계정을 공유하거나 Google Drive 권한을 연결한 뒤 다시 시도해 주세요."),
     FORBIDDEN_ORIGIN_ACCESS(HttpStatus.FORBIDDEN, "허용되지 않은 Origin 입니다."),
     FORBIDDEN_CHAT_ROOM_KICK(HttpStatus.FORBIDDEN, "채팅방 방장만 멤버를 강퇴할 수 있습니다."),
 

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -4,6 +4,9 @@ import static gg.agit.konect.global.code.ApiResponseCode.ALREADY_APPLIED_CLUB;
 import static gg.agit.konect.global.code.ApiResponseCode.ALREADY_CLUB_MEMBER;
 import static gg.agit.konect.global.code.ApiResponseCode.DUPLICATE_CLUB_APPLY_QUESTION;
 import static gg.agit.konect.global.code.ApiResponseCode.FEE_PAYMENT_IMAGE_REQUIRED;
+import static gg.agit.konect.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB_APPLY_QUESTION;
+import static gg.agit.konect.global.code.ApiResponseCode.REQUIRED_CLUB_APPLY_ANSWER_MISSING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,8 +33,12 @@ import gg.agit.konect.domain.bank.repository.BankRepository;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.club.dto.ClubApplicationAnswersResponse;
 import gg.agit.konect.domain.club.dto.ClubApplicationCondition;
+import gg.agit.konect.domain.club.dto.ClubApplicationsResponse;
+import gg.agit.konect.domain.club.dto.ClubAppliedClubsResponse;
 import gg.agit.konect.domain.club.dto.ClubApplyQuestionsReplaceRequest;
+import gg.agit.konect.domain.club.dto.ClubApplyQuestionsResponse;
 import gg.agit.konect.domain.club.dto.ClubApplyRequest;
+import gg.agit.konect.domain.club.dto.ClubFeeInfoReplaceRequest;
 import gg.agit.konect.domain.club.dto.ClubFeeInfoResponse;
 import gg.agit.konect.domain.club.dto.ClubMemberApplicationAnswersResponse;
 import gg.agit.konect.domain.club.enums.ClubApplyStatus;
@@ -43,6 +50,7 @@ import gg.agit.konect.domain.club.model.ClubApply;
 import gg.agit.konect.domain.club.model.ClubApplyAnswer;
 import gg.agit.konect.domain.club.model.ClubApplyQuestion;
 import gg.agit.konect.domain.club.model.ClubMember;
+import gg.agit.konect.domain.club.model.ClubRecruitment;
 import gg.agit.konect.domain.club.repository.ClubApplyAnswerRepository;
 import gg.agit.konect.domain.club.repository.ClubApplyQueryRepository;
 import gg.agit.konect.domain.club.repository.ClubApplyQuestionRepository;
@@ -394,6 +402,772 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         assertThat(secondResponse.answers())
             .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
             .containsExactly("공통 질문", "신규 질문");
+    }
+
+    @Test
+    @DisplayName("applyClub은 필수 질문에 답변이 누락되면 실패한다")
+    void applyClubRejectsMissingRequiredAnswer() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyQuestion requiredQuestion = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
+        ClubApplyRequest request = new ClubApplyRequest(List.of(), null);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(requiredQuestion));
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), REQUIRED_CLUB_APPLY_ANSWER_MISSING);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 존재하지 않는 질문 ID에 답변하면 실패한다")
+    void applyClubRejectsAnswerToNonExistentQuestion() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyRequest request = new ClubApplyRequest(
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(999, "답변")),
+            null
+        );
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), NOT_FOUND_CLUB_APPLY_QUESTION);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 답변에 중복 질문 ID가 있으면 실패한다")
+    void applyClubRejectsDuplicateAnswerQuestionIds() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyRequest request = new ClubApplyRequest(
+            List.of(
+                new ClubApplyRequest.InnerClubQuestionAnswer(100, "첫 답변"),
+                new ClubApplyRequest.InnerClubQuestionAnswer(100, "중복 답변")
+            ),
+            null
+        );
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), DUPLICATE_CLUB_APPLY_QUESTION);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 운영진이 없으면 제출 이벤트를 발행하지 않는다")
+    void applyClubDoesNotPublishEventWhenNoManagers() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApply savedApply = ClubApply.of(club, user, null);
+        setId(savedApply, 300);
+        ClubApplyRequest request = new ClubApplyRequest(List.of(), null);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
+        given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of());
+
+        // when
+        clubApplicationService.applyClub(1, 10, request);
+
+        // then
+        verify(applicationEventPublisher, never()).publishEvent(any());
+        verify(clubApplyAnswerRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 회비 불필요 동아리에서 이미지 없이도 성공한다")
+    void applyClubSucceedsWithoutFeeImage() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApply savedApply = ClubApply.of(club, user, null);
+        setId(savedApply, 300);
+        ClubApplyRequest request = new ClubApplyRequest(List.of(), null);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
+        given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of());
+
+        // when
+        ClubFeeInfoResponse response = clubApplicationService.applyClub(1, 10, request);
+
+        // then
+        assertThat(response.bankId()).isNull();
+        assertThat(response.bankName()).isNull();
+        assertThat(response.amount()).isNull();
+    }
+
+    @Test
+    @DisplayName("applyClub은 선택 질문에 빈 답변을 허용한다")
+    void applyClubAllowsEmptyAnswerForOptionalQuestion() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyQuestion optionalQuestion = createQuestion(club, 100, "관심 분야", false, 1, at(2026, 4, 1, 12, 0));
+        ClubApply savedApply = ClubApply.of(club, user, null);
+        setId(savedApply, 300);
+        ClubApplyRequest request = new ClubApplyRequest(
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "")),
+            null
+        );
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(optionalQuestion));
+        given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of());
+
+        // when
+        clubApplicationService.applyClub(1, 10, request);
+
+        // then
+        verify(clubApplyAnswerRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("replaceApplyQuestions는 존재하지 않는 질문 ID를 거부한다")
+    void replaceApplyQuestionsRejectsNonExistentQuestionId() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(999, "수정된 질문", true)
+        ));
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.replaceApplyQuestions(1, 99, request), NOT_FOUND_CLUB_APPLY_QUESTION);
+        verify(clubApplyQuestionRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("replaceApplyQuestions는 모든 질문이 새로 생성되는 경우 정상 동작한다")
+    void replaceApplyQuestionsCreatesAllNewQuestions() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestion newQuestion1 = createQuestion(club, 10, "새 질문 1", true, 1, at(2026, 4, 2, 10, 0));
+        ClubApplyQuestion newQuestion2 = createQuestion(club, 11, "새 질문 2", false, 2, at(2026, 4, 2, 10, 0));
+        ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 1", true),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 2", false)
+        ));
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
+            .willReturn(List.of())
+            .willReturn(List.of(newQuestion1, newQuestion2));
+
+        // when
+        ClubApplyQuestionsResponse response = clubApplicationService.replaceApplyQuestions(1, 99, request);
+
+        // then
+        verify(clubApplyQuestionRepository).saveAll(argThat(list -> ((List<?>) list).size() == 2));
+        assertThat(response.questions()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("replaceApplyQuestions는 빈 질문 목록이면 기존 질문을 모두 soft delete한다")
+    void replaceApplyQuestionsSoftDeletesAllWhenEmptyRequest() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestion existingQ1 = createQuestion(club, 1, "질문 1", true, 1, at(2026, 4, 1, 10, 0));
+        ClubApplyQuestion existingQ2 = createQuestion(club, 2, "질문 2", false, 2, at(2026, 4, 1, 10, 0));
+        ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of());
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
+            .willReturn(List.of(existingQ1, existingQ2))
+            .willReturn(List.of());
+
+        // when
+        ClubApplyQuestionsResponse response = clubApplicationService.replaceApplyQuestions(1, 99, request);
+
+        // then
+        assertThat(existingQ1.getDeletedAt()).isNotNull();
+        assertThat(existingQ2.getDeletedAt()).isNotNull();
+        verify(clubApplyQuestionRepository, never()).saveAll(any());
+        assertThat(response.questions()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getClubApplicationAnswers는 특정 지원서의 답변을 질문과 함께 반환한다")
+    void getClubApplicationAnswersReturnsAnswersWithQuestions() {
+        // given
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        LocalDateTime appliedAt = at(2026, 4, 2, 10, 0);
+        ClubApply clubApply = createApprovedApply(club, applicant, 100, appliedAt);
+        ClubApplyQuestion question = createQuestion(club, 200, "지원 동기", true, 1, at(2026, 4, 1, 9, 0));
+        ClubApplyAnswer answer = ClubApplyAnswer.of(clubApply, question, "성장하고 싶습니다.");
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(clubApply);
+        given(clubApplyAnswerRepository.findAllByApplyIdWithQuestion(100)).willReturn(List.of(answer));
+        given(clubApplyQuestionRepository.findAllVisibleAtApplyTime(1, appliedAt)).willReturn(List.of(question));
+
+        // when
+        ClubApplicationAnswersResponse response = clubApplicationService.getClubApplicationAnswers(1, 100, 99);
+
+        // then
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        assertThat(response.applicationId()).isEqualTo(100);
+        assertThat(response.answers()).hasSize(1);
+        assertThat(response.answers().get(0).question()).isEqualTo("지원 동기");
+        assertThat(response.answers().get(0).answer()).isEqualTo("성장하고 싶습니다.");
+    }
+
+    @Test
+    @DisplayName("getApplyQuestions는 삭제되지 않은 질문 목록을 반환한다")
+    void getApplyQuestionsReturnsActiveQuestions() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestion q1 = createQuestion(club, 1, "지원 동기", true, 1, at(2026, 4, 1, 10, 0));
+        ClubApplyQuestion q2 = createQuestion(club, 2, "관심 분야", false, 2, at(2026, 4, 1, 10, 0));
+
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(q1, q2));
+
+        // when
+        ClubApplyQuestionsResponse response = clubApplicationService.getApplyQuestions(1, 99);
+
+        // then
+        assertThat(response.questions()).hasSize(2);
+        assertThat(response.questions().get(0).question()).isEqualTo("지원 동기");
+        assertThat(response.questions().get(1).isRequired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("getAppliedClubs는 사용자의 대기 중인 지원 목록을 반환한다")
+    void getAppliedClubsReturnsPendingApplications() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApply apply = ClubApply.of(club, user, null);
+        setId(apply, 100);
+
+        given(clubApplyRepository.findAllPendingByUserIdWithClub(10)).willReturn(List.of(apply));
+
+        // when
+        ClubAppliedClubsResponse response = clubApplicationService.getAppliedClubs(10);
+
+        // then
+        assertThat(response.appliedClubs()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getAppliedClubs는 대기 중인 지원이 없으면 빈 목록을 반환한다")
+    void getAppliedClubsReturnsEmptyWhenNoPendingApplications() {
+        // given
+        given(clubApplyRepository.findAllPendingByUserIdWithClub(10)).willReturn(List.of());
+
+        // when
+        ClubAppliedClubsResponse response = clubApplicationService.getAppliedClubs(10);
+
+        // then
+        assertThat(response.appliedClubs()).isEmpty();
+    }
+
+    // ========== US-001: applyClub validation boundary cases ==========
+
+    @Test
+    @DisplayName("applyClub은 필수 질문에 공백만 있는 답변을 거부한다")
+    void applyClubRejectsWhitespaceOnlyRequiredAnswer() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyQuestion requiredQuestion = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
+        ClubApplyRequest request = new ClubApplyRequest(
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "   ")),
+            null
+        );
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(requiredQuestion));
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), REQUIRED_CLUB_APPLY_ANSWER_MISSING);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 필수 질문에 null 답변을 거부한다")
+    void applyClubRejectsNullAnswerForRequiredQuestion() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyQuestion requiredQuestion = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
+        ClubApplyRequest request = new ClubApplyRequest(
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, null)),
+            null
+        );
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(requiredQuestion));
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), REQUIRED_CLUB_APPLY_ANSWER_MISSING);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 여러 운영진의 ID를 모두 제출 이벤트에 포함한다")
+    void applyClubPublishesEventWithMultipleManagers() {
+        // given
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        User manager1 = createUser(20, "2021136002", "운영진1");
+        User manager2 = createUser(21, "2021136003", "운영진2");
+        ClubMember member1 = ClubMemberFixture.createManager(club, manager1);
+        ClubMember member2 = ClubMemberFixture.createManager(club, manager2);
+        ClubApply savedApply = ClubApply.of(club, applicant, null);
+        setId(savedApply, 300);
+        ClubApplyRequest request = new ClubApplyRequest(List.of(), null);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(applicant);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
+        given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of(member1, member2));
+
+        // when
+        clubApplicationService.applyClub(1, 10, request);
+
+        // then
+        verify(applicationEventPublisher).publishEvent(ClubApplicationSubmittedEvent.of(
+            List.of(20, 21),
+            300,
+            1,
+            club.getName(),
+            applicant.getName()
+        ));
+    }
+
+    // ========== US-002: Approve/reject logical state transitions ==========
+
+    @Test
+    @DisplayName("approveClubApplication은 이미 승인된 지원서를 재승인하면 ALREADY_CLUB_MEMBER을 던진다")
+    void approveClubApplicationRejectsDoubleApproval() {
+        // given - first approval already happened (member exists)
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        ClubApply approvedApply = ClubApply.of(club, applicant, null);
+        approvedApply.approve();
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(approvedApply);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(true);
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.approveClubApplication(1, 100, 99), ALREADY_CLUB_MEMBER);
+        verify(clubMemberRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("approveClubApplication은 거절된 지원서를 승인할 수 있다")
+    void approveClubApplicationSucceedsAfterRejection() {
+        // given
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        ClubApply rejectedApply = ClubApply.of(club, applicant, null);
+        rejectedApply.reject();
+        ClubMember savedMember = ClubMemberFixture.createMember(club, applicant);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(rejectedApply);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubMemberRepository.save(any(ClubMember.class))).willReturn(savedMember);
+
+        // when
+        clubApplicationService.approveClubApplication(1, 100, 99);
+
+        // then
+        assertThat(rejectedApply.getStatus()).isEqualTo(ClubApplyStatus.APPROVED);
+        verify(chatRoomMembershipService).addClubMember(savedMember);
+        verify(applicationEventPublisher).publishEvent(ClubApplicationApprovedEvent.of(10, 1, club.getName()));
+    }
+
+    @Test
+    @DisplayName("rejectClubApplication은 이미 승인된 지원서도 거절 상태로 변경한다")
+    void rejectClubApplicationChangesStatusAfterApproval() {
+        // given - application was already approved, member already in club
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        ClubApply approvedApply = ClubApply.of(club, applicant, null);
+        approvedApply.approve();
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(approvedApply);
+
+        // when
+        clubApplicationService.rejectClubApplication(1, 100, 99);
+
+        // then
+        assertThat(approvedApply.getStatus()).isEqualTo(ClubApplyStatus.REJECTED);
+        verify(applicationEventPublisher).publishEvent(ClubApplicationRejectedEvent.of(10, 1, club.getName()));
+    }
+
+    // ========== US-003: replaceApplyQuestions edge cases ==========
+
+    @Test
+    @DisplayName("replaceApplyQuestions는 isRequired가 null이면 기본값 true로 질문을 생성한다")
+    void replaceApplyQuestionsDefaultsIsRequiredToTrue() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestion createdQuestion = createQuestion(club, 10, "새 질문", true, 1, at(2026, 4, 2, 10, 0));
+        ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", null)
+        ));
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
+            .willReturn(List.of())
+            .willReturn(List.of(createdQuestion));
+
+        // when
+        clubApplicationService.replaceApplyQuestions(1, 99, request);
+
+        // then
+        verify(clubApplyQuestionRepository).saveAll(argThat(list -> {
+            List<ClubApplyQuestion> questions = (List<ClubApplyQuestion>) list;
+            return questions.size() == 1 && questions.get(0).getIsRequired().equals(true);
+        }));
+    }
+
+    @Test
+    @DisplayName("replaceApplyQuestions는 내용이 동일하면 displayOrder만 변경하고 soft delete하지 않는다")
+    void replaceApplyQuestionsOnlyChangesDisplayOrderWhenContentSame() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestion question = createQuestion(club, 1, "지원 동기", true, 2, at(2026, 4, 1, 10, 0));
+        // Same content, only repositioning to display order 1
+        ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true)
+        ));
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
+            .willReturn(List.of(question))
+            .willReturn(List.of(question));
+
+        // when
+        clubApplicationService.replaceApplyQuestions(1, 99, request);
+
+        // then
+        assertThat(question.getDisplayOrder()).isEqualTo(1);
+        assertThat(question.getDeletedAt()).isNull();
+        verify(clubApplyQuestionRepository, never()).saveAll(any());
+    }
+
+    // ========== US-004: Question visibility boundary tests ==========
+
+    @Test
+    @DisplayName("createdAt이 appliedAt과 정확히 같은 질문도 가입 시점에 보이는 것으로 처리된다")
+    void questionCreatedAtEqualToAppliedAtIsVisible() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        LocalDateTime appliedAt = at(2026, 4, 2, 10, 0);
+        ClubApply apply = createApprovedApply(club, user, 100, appliedAt);
+        Page<ClubApply> page = new PageImpl<>(List.of(apply));
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+
+        ClubApplyQuestion question = createQuestion(club, 1, "질문", true, 1, appliedAt);
+        ClubApplyAnswer answer = ClubApplyAnswer.of(apply, question, "답변");
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
+        given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of(answer));
+        given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
+            .willReturn(List.of(question));
+
+        // when
+        ClubMemberApplicationAnswersResponse response =
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+
+        // then
+        assertThat(response.applications()).hasSize(1);
+        assertThat(response.applications().get(0).answers()).hasSize(1);
+        assertThat(response.applications().get(0).answers().get(0).question()).isEqualTo("질문");
+    }
+
+    @Test
+    @DisplayName("deletedAt이 appliedAt과 정확히 같은 질문은 가입 시점에 보이지 않는다")
+    void questionDeletedAtEqualToAppliedAtIsNotVisible() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        LocalDateTime appliedAt = at(2026, 4, 2, 10, 0);
+        ClubApply apply = createApprovedApply(club, user, 100, appliedAt);
+        Page<ClubApply> page = new PageImpl<>(List.of(apply));
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+
+        ClubApplyQuestion question = createQuestion(club, 1, "삭제된 질문", true, 1, at(2026, 4, 1, 9, 0));
+        question.softDelete(appliedAt);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
+        given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of());
+        given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
+            .willReturn(List.of(question));
+
+        // when
+        ClubMemberApplicationAnswersResponse response =
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+
+        // then - isAfter returns false for equal timestamps, so question is filtered out
+        assertThat(response.applications()).hasSize(1);
+        assertThat(response.applications().get(0).answers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getApprovedMemberApplicationAnswersList는 지원서가 하나뿐이어도 정상 동작한다")
+    void getApprovedMemberApplicationAnswersListWithSingleApplication() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        LocalDateTime appliedAt = at(2026, 4, 2, 10, 0);
+        ClubApply apply = createApprovedApply(club, user, 100, appliedAt);
+        Page<ClubApply> page = new PageImpl<>(List.of(apply));
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+
+        ClubApplyQuestion question = createQuestion(club, 1, "질문", true, 1, at(2026, 4, 1, 9, 0));
+        ClubApplyAnswer answer = ClubApplyAnswer.of(apply, question, "답변");
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
+        given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of(answer));
+        given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
+            .willReturn(List.of(question));
+
+        // when
+        ClubMemberApplicationAnswersResponse response =
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+
+        // then - minAppliedAt == maxAppliedAt
+        assertThat(response.applications()).hasSize(1);
+        assertThat(response.applications().get(0).applicationId()).isEqualTo(100);
+    }
+
+    // ========== US-005: Untested service method coverage ==========
+
+    @Test
+    @DisplayName("getApprovedMemberApplicationAnswers는 특정 회원의 최신 승인 지원서를 반환한다")
+    void getApprovedMemberApplicationAnswersReturnsLatestApproved() {
+        // given
+        Club club = createClub(1);
+        User targetUser = createUser(10, "2021136001", "회원");
+        ClubMember targetMember = ClubMemberFixture.createMember(club, targetUser);
+        LocalDateTime appliedAt = at(2026, 4, 2, 10, 0);
+        ClubApply clubApply = createApprovedApply(club, targetUser, 100, appliedAt);
+        ClubApplyQuestion question = createQuestion(club, 200, "지원 동기", true, 1, at(2026, 4, 1, 9, 0));
+        ClubApplyAnswer answer = ClubApplyAnswer.of(clubApply, question, "성장하고 싶습니다.");
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubMemberRepository.getByClubIdAndUserId(1, 10)).willReturn(targetMember);
+        given(clubApplyRepository.getLatestApprovedByClubIdAndUserId(1, 10)).willReturn(clubApply);
+        given(clubApplyAnswerRepository.findAllByApplyIdWithQuestion(100)).willReturn(List.of(answer));
+        given(clubApplyQuestionRepository.findAllVisibleAtApplyTime(1, appliedAt)).willReturn(List.of(question));
+
+        // when
+        ClubApplicationAnswersResponse response =
+            clubApplicationService.getApprovedMemberApplicationAnswers(1, 10, 99);
+
+        // then
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        assertThat(response.applicationId()).isEqualTo(100);
+        assertThat(response.answers()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getClubApplications은 상시 모집 동아리의 전체 지원서를 조회한다")
+    void getClubApplicationsWithAlwaysRecruiting() {
+        // given
+        Club club = createClub(1);
+        ClubRecruitment recruitment = ClubRecruitment.of(null, null, true, "상시 모집", club);
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+        Page<ClubApply> page = new PageImpl<>(List.of());
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubRecruitmentRepository.getByClubId(1)).willReturn(recruitment);
+        given(clubApplyQueryRepository.findAllByClubId(1, condition)).willReturn(page);
+
+        // when
+        ClubApplicationsResponse response = clubApplicationService.getClubApplications(1, 99, condition);
+
+        // then
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        verify(clubApplyQueryRepository).findAllByClubId(1, condition);
+        verify(clubApplyQueryRepository, never()).findAllByClubIdAndCreatedAtBetween(any(), any(), any(), any());
+        assertThat(response.applications()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getClubApplications은 기간 모집 동아리의 기간 내 지원서만 조회한다")
+    void getClubApplicationsWithPeriodBasedRecruitment() {
+        // given
+        Club club = createClub(1);
+        LocalDateTime startAt = at(2026, 4, 1, 0, 0);
+        LocalDateTime endAt = at(2026, 4, 30, 23, 59);
+        ClubRecruitment recruitment = ClubRecruitment.of(startAt, endAt, false, "4월 모집", club);
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+        Page<ClubApply> page = new PageImpl<>(List.of());
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubRecruitmentRepository.getByClubId(1)).willReturn(recruitment);
+        given(clubApplyQueryRepository.findAllByClubIdAndCreatedAtBetween(1, startAt, endAt, condition)).willReturn(page);
+
+        // when
+        ClubApplicationsResponse response = clubApplicationService.getClubApplications(1, 99, condition);
+
+        // then
+        verify(clubApplyQueryRepository).findAllByClubIdAndCreatedAtBetween(1, startAt, endAt, condition);
+        verify(clubApplyQueryRepository, never()).findAllByClubId(any(), any());
+        assertThat(response.applications()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getApprovedMemberApplications은 승인된 회원 지원서를 페이지네이션하여 반환한다")
+    void getApprovedMemberApplicationsReturnsPagedResults() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "회원");
+        ClubApply apply = createApprovedApply(club, user, 100, at(2026, 4, 2, 10, 0));
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+        Page<ClubApply> page = new PageImpl<>(List.of(apply));
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
+
+        // when
+        ClubApplicationsResponse response =
+            clubApplicationService.getApprovedMemberApplications(1, 99, condition);
+
+        // then
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        assertThat(response.applications()).hasSize(1);
+        assertThat(response.totalCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("getFeeInfo는 동아리 회비 정보를 반환한다")
+    void getFeeInfoReturnsClubFeeInfo() {
+        // given
+        Club club = createClubWithFeeInfo(1, "국민은행");
+        Bank bank = org.mockito.Mockito.mock(Bank.class);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(bankRepository.getByName("국민은행")).willReturn(bank);
+        given(bank.getId()).willReturn(7);
+
+        // when
+        ClubFeeInfoResponse response = clubApplicationService.getFeeInfo(1);
+
+        // then
+        assertThat(response.bankId()).isEqualTo(7);
+        assertThat(response.bankName()).isEqualTo("국민은행");
+        assertThat(response.accountNumber()).isEqualTo("123-456-7890");
+        assertThat(response.accountHolder()).isEqualTo("BCSD");
+    }
+
+    @Test
+    @DisplayName("getFeeInfo는 회비 은행 정보가 없으면 bankRepository를 호출하지 않고 null을 반환한다")
+    void getFeeInfoReturnsNullBankWhenNoFeeInfo() {
+        // given
+        Club club = createClub(1);
+
+        given(clubRepository.getById(1)).willReturn(club);
+
+        // when
+        ClubFeeInfoResponse response = clubApplicationService.getFeeInfo(1);
+
+        // then
+        assertThat(response.bankId()).isNull();
+        assertThat(response.bankName()).isNull();
+        verify(bankRepository, never()).getByName(any());
+    }
+
+    @Test
+    @DisplayName("replaceFeeInfo는 동아리 회비 정보를 업데이트하고 응답을 반환한다")
+    void replaceFeeInfoUpdatesClubFeeInfo() {
+        // given
+        Club club = createClub(1);
+        User managerUser = createUser(99, "2021136000", "운영진");
+        Bank newBank = org.mockito.Mockito.mock(Bank.class);
+        ClubFeeInfoReplaceRequest request = new ClubFeeInfoReplaceRequest("5만원", 3, "987-654-3210", "BCSD");
+
+        given(userRepository.getById(99)).willReturn(managerUser);
+        given(clubRepository.getById(1)).willReturn(club);
+        given(bankRepository.getById(3)).willReturn(newBank);
+        given(newBank.getName()).willReturn("신한은행");
+
+        // when
+        ClubFeeInfoResponse response = clubApplicationService.replaceFeeInfo(1, 99, request);
+
+        // then
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        assertThat(response.amount()).isEqualTo("5만원");
+        assertThat(response.bankId()).isEqualTo(3);
+        assertThat(response.bankName()).isEqualTo("신한은행");
+        assertThat(response.accountNumber()).isEqualTo("987-654-3210");
+        assertThat(response.accountHolder()).isEqualTo("BCSD");
+    }
+
+    @Test
+    @DisplayName("replaceFeeInfo는 회비 정보가 일부만 입력되면 INVALID_REQUEST_BODY를 던진다")
+    void replaceFeeInfoRejectsPartialFeeInfo() {
+        // given
+        Club club = createClub(1);
+        User managerUser = createUser(99, "2021136000", "운영진");
+        Bank bank = org.mockito.Mockito.mock(Bank.class);
+        ClubFeeInfoReplaceRequest request = new ClubFeeInfoReplaceRequest("5만원", 3, null, null);
+
+        given(userRepository.getById(99)).willReturn(managerUser);
+        given(clubRepository.getById(1)).willReturn(club);
+        given(bankRepository.getById(3)).willReturn(bank);
+        given(bank.getName()).willReturn("신한은행");
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.replaceFeeInfo(1, 99, request), INVALID_REQUEST_BODY);
     }
 
     private Club createClub(Integer clubId) {

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -223,7 +223,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubMember savedMember = ClubMemberFixture.createMember(club, applicant);
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(clubApply);
+        given(clubApplyRepository.getByIdAndClubIdForUpdate(100, 1)).willReturn(clubApply);
         given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubMemberRepository.save(any(ClubMember.class))).willReturn(savedMember);
 
@@ -246,7 +246,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApply clubApply = ClubApply.of(club, applicant, null);
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(clubApply);
+        given(clubApplyRepository.getByIdAndClubIdForUpdate(100, 1)).willReturn(clubApply);
         given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(true);
 
         // when & then
@@ -265,7 +265,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApply clubApply = ClubApply.of(club, applicant, null);
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(clubApply);
+        given(clubApplyRepository.getByIdAndClubIdForUpdate(100, 1)).willReturn(clubApply);
 
         // when
         clubApplicationService.rejectClubApplication(1, 100, 99);
@@ -807,7 +807,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         approvedApply.approve();
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(approvedApply);
+        given(clubApplyRepository.getByIdAndClubIdForUpdate(100, 1)).willReturn(approvedApply);
 
         // when & then
         assertErrorCode(() -> clubApplicationService.approveClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);
@@ -824,7 +824,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         rejectedApply.reject();
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(rejectedApply);
+        given(clubApplyRepository.getByIdAndClubIdForUpdate(100, 1)).willReturn(rejectedApply);
 
         // when & then
         assertErrorCode(() -> clubApplicationService.approveClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);
@@ -841,7 +841,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         approvedApply.approve();
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(approvedApply);
+        given(clubApplyRepository.getByIdAndClubIdForUpdate(100, 1)).willReturn(approvedApply);
 
         // when & then
         assertErrorCode(() -> clubApplicationService.rejectClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);
@@ -858,7 +858,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         rejectedApply.reject();
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(rejectedApply);
+        given(clubApplyRepository.getByIdAndClubIdForUpdate(100, 1)).willReturn(rejectedApply);
 
         // when & then
         assertErrorCode(() -> clubApplicationService.rejectClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -172,8 +172,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubMember manager = ClubMemberFixture.createManager(club, managerUser);
         ClubApplyQuestion question = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
         ClubApplyRequest request = new ClubApplyRequest(
-            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "백엔드를 공부하고 싶습니다.")),
-            "https://example.com/payment.png"
+                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "백엔드를 공부하고 싶습니다.")),
+                "https://example.com/payment.png"
         );
         Bank bank = org.mockito.Mockito.mock(Bank.class);
         ClubApply savedApply = ClubApply.of(club, applicant, request.feePaymentImageUrl());
@@ -186,7 +186,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(question));
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
         given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-            .willReturn(List.of(manager));
+                .willReturn(List.of(manager));
         given(bankRepository.getByName("국민은행")).willReturn(bank);
         given(bank.getId()).willReturn(7);
 
@@ -195,17 +195,17 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // then
         verify(clubApplyAnswerRepository).saveAll(argThat(answers -> {
-            List<ClubApplyAnswer> savedAnswers = (List<ClubApplyAnswer>)answers;
+            List<ClubApplyAnswer> savedAnswers = (List<ClubApplyAnswer>) answers;
             return savedAnswers.size() == 1
-                && savedAnswers.get(0).getQuestion().getId().equals(100)
-                && savedAnswers.get(0).getAnswer().equals("백엔드를 공부하고 싶습니다.");
+                    && savedAnswers.get(0).getQuestion().getId().equals(100)
+                    && savedAnswers.get(0).getAnswer().equals("백엔드를 공부하고 싶습니다.");
         }));
         verify(applicationEventPublisher).publishEvent(ClubApplicationSubmittedEvent.of(
-            List.of(20),
-            300,
-            1,
-            club.getName(),
-            applicant.getName()
+                List.of(20),
+                300,
+                1,
+                club.getName(),
+                applicant.getName()
         ));
         assertThat(response.bankId()).isEqualTo(7);
         assertThat(response.bankName()).isEqualTo("국민은행");
@@ -285,17 +285,17 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplyQuestion removedQuestion = createQuestion(club, 3, "자기소개", true, 3, at(2026, 4, 1, 10, 0));
         ClubApplyQuestion createdQuestion = createQuestion(club, 4, "새 질문", true, 2, at(2026, 4, 2, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(2, "관심 기술", false),
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", true)
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(2, "관심 기술", false),
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", true)
         ));
         List<ClubApplyQuestion> existingQuestions = List.of(unchangedQuestion, changedQuestion, removedQuestion);
         ArgumentCaptor<List<ClubApplyQuestion>> questionsCaptor = ArgumentCaptor.forClass(List.class);
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-            .willReturn(existingQuestions)
-            .willReturn(List.of(unchangedQuestion, createdQuestion));
+                .willReturn(existingQuestions)
+                .willReturn(List.of(unchangedQuestion, createdQuestion));
 
         // when
         var response = clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -306,8 +306,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         List<ClubApplyQuestion> createdQuestions = questionsCaptor.getValue();
         assertThat(createdQuestions).hasSize(2);
         assertThat(createdQuestions)
-            .extracting(ClubApplyQuestion::getQuestion)
-            .containsExactly("관심 기술", "새 질문");
+                .extracting(ClubApplyQuestion::getQuestion)
+                .containsExactly("관심 기술", "새 질문");
         assertThat(unchangedQuestion.getDisplayOrder()).isEqualTo(1);
         assertThat(changedQuestion.getDeletedAt()).isNotNull();
         assertThat(removedQuestion.getDeletedAt()).isNotNull();
@@ -321,8 +321,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         ClubApplyQuestion existingQuestion = createQuestion(club, 1, "지원 동기", true, 1, at(2026, 4, 1, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기 수정", true)
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기 수정", true)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -344,7 +344,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // when
         ClubMemberApplicationAnswersResponse response =
-            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then
         assertThat(response.applications()).isEmpty();
@@ -381,13 +381,13 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100, 200)))
-            .willReturn(List.of(firstAnswer1, firstAnswer2, secondAnswer1, secondAnswer2));
+                .willReturn(List.of(firstAnswer1, firstAnswer2, secondAnswer1, secondAnswer2));
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, firstAppliedAt, secondAppliedAt))
-            .willReturn(List.of(oldQuestion, deletedQuestion, newQuestion));
+                .willReturn(List.of(oldQuestion, deletedQuestion, newQuestion));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then
         assertThat(response.applications()).hasSize(2);
@@ -395,14 +395,14 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplicationAnswersResponse firstResponse = response.applications().get(0);
         assertThat(firstResponse.applicationId()).isEqualTo(100);
         assertThat(firstResponse.answers())
-            .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
-            .containsExactly("공통 질문", "이전 질문");
+                .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
+                .containsExactly("공통 질문", "이전 질문");
 
         ClubApplicationAnswersResponse secondResponse = response.applications().get(1);
         assertThat(secondResponse.applicationId()).isEqualTo(200);
         assertThat(secondResponse.answers())
-            .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
-            .containsExactly("공통 질문", "신규 질문");
+                .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
+                .containsExactly("공통 질문", "신규 질문");
     }
 
     @Test
@@ -432,8 +432,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyRequest request = new ClubApplyRequest(
-            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(999, "답변")),
-            null
+                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(999, "답변")),
+                null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -454,11 +454,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyRequest request = new ClubApplyRequest(
-            List.of(
-                new ClubApplyRequest.InnerClubQuestionAnswer(100, "첫 답변"),
-                new ClubApplyRequest.InnerClubQuestionAnswer(100, "중복 답변")
-            ),
-            null
+                List.of(
+                        new ClubApplyRequest.InnerClubQuestionAnswer(100, "첫 답변"),
+                        new ClubApplyRequest.InnerClubQuestionAnswer(100, "중복 답변")
+                ),
+                null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -488,7 +488,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
         given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-            .willReturn(List.of());
+                .willReturn(List.of());
 
         // when
         clubApplicationService.applyClub(1, 10, request);
@@ -515,7 +515,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
         given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-            .willReturn(List.of());
+                .willReturn(List.of());
 
         // when
         ClubFeeInfoResponse response = clubApplicationService.applyClub(1, 10, request);
@@ -536,8 +536,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApply savedApply = ClubApply.of(club, user, null);
         setId(savedApply, 300);
         ClubApplyRequest request = new ClubApplyRequest(
-            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "")),
-            null
+                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "")),
+                null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -547,7 +547,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(optionalQuestion));
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
         given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-            .willReturn(List.of());
+                .willReturn(List.of());
 
         // when
         clubApplicationService.applyClub(1, 10, request);
@@ -562,7 +562,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         // given
         Club club = createClub(1);
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(999, "수정된 질문", true)
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(999, "수정된 질문", true)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -581,14 +581,14 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplyQuestion newQuestion1 = createQuestion(club, 10, "새 질문 1", true, 1, at(2026, 4, 2, 10, 0));
         ClubApplyQuestion newQuestion2 = createQuestion(club, 11, "새 질문 2", false, 2, at(2026, 4, 2, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 1", true),
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 2", false)
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 1", true),
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 2", false)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-            .willReturn(List.of())
-            .willReturn(List.of(newQuestion1, newQuestion2));
+                .willReturn(List.of())
+                .willReturn(List.of(newQuestion1, newQuestion2));
 
         // when
         ClubApplyQuestionsResponse response = clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -609,8 +609,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-            .willReturn(List.of(existingQ1, existingQ2))
-            .willReturn(List.of());
+                .willReturn(List.of(existingQ1, existingQ2))
+                .willReturn(List.of());
 
         // when
         ClubApplyQuestionsResponse response = clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -709,8 +709,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyQuestion requiredQuestion = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
         ClubApplyRequest request = new ClubApplyRequest(
-            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "   ")),
-            null
+                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "   ")),
+                null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -732,8 +732,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyQuestion requiredQuestion = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
         ClubApplyRequest request = new ClubApplyRequest(
-            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, null)),
-            null
+                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, null)),
+                null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -768,18 +768,18 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
         given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-            .willReturn(List.of(member1, member2));
+                .willReturn(List.of(member1, member2));
 
         // when
         clubApplicationService.applyClub(1, 10, request);
 
         // then
         verify(applicationEventPublisher).publishEvent(ClubApplicationSubmittedEvent.of(
-            List.of(20, 21),
-            300,
-            1,
-            club.getName(),
-            applicant.getName()
+                List.of(20, 21),
+                300,
+                1,
+                club.getName(),
+                applicant.getName()
         ));
     }
 
@@ -861,13 +861,13 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         ClubApplyQuestion createdQuestion = createQuestion(club, 10, "새 질문", true, 1, at(2026, 4, 2, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", null)
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", null)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-            .willReturn(List.of())
-            .willReturn(List.of(createdQuestion));
+                .willReturn(List.of())
+                .willReturn(List.of(createdQuestion));
 
         // when
         clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -887,13 +887,13 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplyQuestion question = createQuestion(club, 1, "지원 동기", true, 2, at(2026, 4, 1, 10, 0));
         // Same content, only repositioning to display order 1
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true)
+                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-            .willReturn(List.of(question))
-            .willReturn(List.of(question));
+                .willReturn(List.of(question))
+                .willReturn(List.of(question));
 
         // when
         clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -924,11 +924,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of(answer));
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
-            .willReturn(List.of(question));
+                .willReturn(List.of(question));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then
         assertThat(response.applications()).hasSize(1);
@@ -954,11 +954,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of());
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
-            .willReturn(List.of(question));
+                .willReturn(List.of(question));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then - isAfter returns false for equal timestamps, so question is filtered out
         assertThat(response.applications()).hasSize(1);
@@ -983,11 +983,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of(answer));
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
-            .willReturn(List.of(question));
+                .willReturn(List.of(question));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then - minAppliedAt == maxAppliedAt
         assertThat(response.applications()).hasSize(1);
@@ -1016,7 +1016,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // when
         ClubApplicationAnswersResponse response =
-            clubApplicationService.getApprovedMemberApplicationAnswers(1, 10, 99);
+                clubApplicationService.getApprovedMemberApplicationAnswers(1, 10, 99);
 
         // then
         verify(clubPermissionValidator).validateManagerAccess(1, 99);
@@ -1086,7 +1086,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // when
         ClubApplicationsResponse response =
-            clubApplicationService.getApprovedMemberApplications(1, 99, condition);
+                clubApplicationService.getApprovedMemberApplications(1, 99, condition);
 
         // then
         verify(clubPermissionValidator).validateManagerAccess(1, 99);
@@ -1194,21 +1194,21 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
     private User createUser(Integer id, String studentNumber, String name) {
         return UserFixture.createUserWithId(
-            UniversityFixture.createWithId(1),
-            id,
-            name,
-            studentNumber,
-            gg.agit.konect.domain.user.enums.UserRole.USER
+                UniversityFixture.createWithId(1),
+                id,
+                name,
+                studentNumber,
+                gg.agit.konect.domain.user.enums.UserRole.USER
         );
     }
 
     private ClubApplyQuestion createQuestion(
-        Club club,
-        Integer id,
-        String question,
-        boolean isRequired,
-        int displayOrder,
-        LocalDateTime createdAt
+            Club club,
+            Integer id,
+            String question,
+            boolean isRequired,
+            int displayOrder,
+            LocalDateTime createdAt
     ) {
         ClubApplyQuestion applyQuestion = ClubApplyQuestion.of(club, question, isRequired, displayOrder);
         setId(applyQuestion, id);
@@ -1239,8 +1239,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
     private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
         assertThatThrownBy(callable::call)
-            .isInstanceOf(CustomException.class)
-            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(errorCode));
+                .isInstanceOf(CustomException.class)
+                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(errorCode));
     }
 
     @FunctionalInterface

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -172,8 +172,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubMember manager = ClubMemberFixture.createManager(club, managerUser);
         ClubApplyQuestion question = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
         ClubApplyRequest request = new ClubApplyRequest(
-                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "백엔드를 공부하고 싶습니다.")),
-                "https://example.com/payment.png"
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "백엔드를 공부하고 싶습니다.")),
+            "https://example.com/payment.png"
         );
         Bank bank = org.mockito.Mockito.mock(Bank.class);
         ClubApply savedApply = ClubApply.of(club, applicant, request.feePaymentImageUrl());
@@ -185,8 +185,9 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(question));
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
-        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-                .willReturn(List.of(manager));
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1,
+            gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of(manager));
         given(bankRepository.getByName("국민은행")).willReturn(bank);
         given(bank.getId()).willReturn(7);
 
@@ -195,17 +196,17 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // then
         verify(clubApplyAnswerRepository).saveAll(argThat(answers -> {
-            List<ClubApplyAnswer> savedAnswers = (List<ClubApplyAnswer>) answers;
+            List<ClubApplyAnswer> savedAnswers = (List<ClubApplyAnswer>)answers;
             return savedAnswers.size() == 1
-                    && savedAnswers.get(0).getQuestion().getId().equals(100)
-                    && savedAnswers.get(0).getAnswer().equals("백엔드를 공부하고 싶습니다.");
+                && savedAnswers.get(0).getQuestion().getId().equals(100)
+                && savedAnswers.get(0).getAnswer().equals("백엔드를 공부하고 싶습니다.");
         }));
         verify(applicationEventPublisher).publishEvent(ClubApplicationSubmittedEvent.of(
-                List.of(20),
-                300,
-                1,
-                club.getName(),
-                applicant.getName()
+            List.of(20),
+            300,
+            1,
+            club.getName(),
+            applicant.getName()
         ));
         assertThat(response.bankId()).isEqualTo(7);
         assertThat(response.bankName()).isEqualTo("국민은행");
@@ -285,17 +286,17 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplyQuestion removedQuestion = createQuestion(club, 3, "자기소개", true, 3, at(2026, 4, 1, 10, 0));
         ClubApplyQuestion createdQuestion = createQuestion(club, 4, "새 질문", true, 2, at(2026, 4, 2, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(2, "관심 기술", false),
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", true)
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(2, "관심 기술", false),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", true)
         ));
         List<ClubApplyQuestion> existingQuestions = List.of(unchangedQuestion, changedQuestion, removedQuestion);
         ArgumentCaptor<List<ClubApplyQuestion>> questionsCaptor = ArgumentCaptor.forClass(List.class);
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-                .willReturn(existingQuestions)
-                .willReturn(List.of(unchangedQuestion, createdQuestion));
+            .willReturn(existingQuestions)
+            .willReturn(List.of(unchangedQuestion, createdQuestion));
 
         // when
         var response = clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -306,8 +307,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         List<ClubApplyQuestion> createdQuestions = questionsCaptor.getValue();
         assertThat(createdQuestions).hasSize(2);
         assertThat(createdQuestions)
-                .extracting(ClubApplyQuestion::getQuestion)
-                .containsExactly("관심 기술", "새 질문");
+            .extracting(ClubApplyQuestion::getQuestion)
+            .containsExactly("관심 기술", "새 질문");
         assertThat(unchangedQuestion.getDisplayOrder()).isEqualTo(1);
         assertThat(changedQuestion.getDeletedAt()).isNotNull();
         assertThat(removedQuestion.getDeletedAt()).isNotNull();
@@ -321,15 +322,17 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         ClubApplyQuestion existingQuestion = createQuestion(club, 1, "지원 동기", true, 1, at(2026, 4, 1, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기 수정", true)
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기 수정", true)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
-        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(existingQuestion));
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(
+            List.of(existingQuestion));
 
         // when & then
-        assertErrorCode(() -> clubApplicationService.replaceApplyQuestions(1, 99, request), DUPLICATE_CLUB_APPLY_QUESTION);
+        assertErrorCode(() -> clubApplicationService.replaceApplyQuestions(1, 99, request),
+            DUPLICATE_CLUB_APPLY_QUESTION);
         verify(clubApplyQuestionRepository, never()).saveAll(any());
     }
 
@@ -344,7 +347,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // when
         ClubMemberApplicationAnswersResponse response =
-                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then
         assertThat(response.applications()).isEmpty();
@@ -381,13 +384,13 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100, 200)))
-                .willReturn(List.of(firstAnswer1, firstAnswer2, secondAnswer1, secondAnswer2));
+            .willReturn(List.of(firstAnswer1, firstAnswer2, secondAnswer1, secondAnswer2));
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, firstAppliedAt, secondAppliedAt))
-                .willReturn(List.of(oldQuestion, deletedQuestion, newQuestion));
+            .willReturn(List.of(oldQuestion, deletedQuestion, newQuestion));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then
         assertThat(response.applications()).hasSize(2);
@@ -395,14 +398,14 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplicationAnswersResponse firstResponse = response.applications().get(0);
         assertThat(firstResponse.applicationId()).isEqualTo(100);
         assertThat(firstResponse.answers())
-                .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
-                .containsExactly("공통 질문", "이전 질문");
+            .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
+            .containsExactly("공통 질문", "이전 질문");
 
         ClubApplicationAnswersResponse secondResponse = response.applications().get(1);
         assertThat(secondResponse.applicationId()).isEqualTo(200);
         assertThat(secondResponse.answers())
-                .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
-                .containsExactly("공통 질문", "신규 질문");
+            .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
+            .containsExactly("공통 질문", "신규 질문");
     }
 
     @Test
@@ -418,7 +421,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(userRepository.getById(10)).willReturn(user);
         given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
-        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(requiredQuestion));
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(
+            List.of(requiredQuestion));
 
         // when & then
         assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), REQUIRED_CLUB_APPLY_ANSWER_MISSING);
@@ -432,8 +436,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyRequest request = new ClubApplyRequest(
-                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(999, "답변")),
-                null
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(999, "답변")),
+            null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -454,11 +458,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyRequest request = new ClubApplyRequest(
-                List.of(
-                        new ClubApplyRequest.InnerClubQuestionAnswer(100, "첫 답변"),
-                        new ClubApplyRequest.InnerClubQuestionAnswer(100, "중복 답변")
-                ),
-                null
+            List.of(
+                new ClubApplyRequest.InnerClubQuestionAnswer(100, "첫 답변"),
+                new ClubApplyRequest.InnerClubQuestionAnswer(100, "중복 답변")
+            ),
+            null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
@@ -487,8 +491,9 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
-        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-                .willReturn(List.of());
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1,
+            gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of());
 
         // when
         clubApplicationService.applyClub(1, 10, request);
@@ -514,8 +519,9 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
-        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-                .willReturn(List.of());
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1,
+            gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of());
 
         // when
         ClubFeeInfoResponse response = clubApplicationService.applyClub(1, 10, request);
@@ -536,18 +542,20 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApply savedApply = ClubApply.of(club, user, null);
         setId(savedApply, 300);
         ClubApplyRequest request = new ClubApplyRequest(
-                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "")),
-                null
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "")),
+            null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
         given(userRepository.getById(10)).willReturn(user);
         given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
-        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(optionalQuestion));
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(
+            List.of(optionalQuestion));
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
-        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-                .willReturn(List.of());
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1,
+            gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of());
 
         // when
         clubApplicationService.applyClub(1, 10, request);
@@ -562,14 +570,15 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         // given
         Club club = createClub(1);
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(999, "수정된 질문", true)
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(999, "수정된 질문", true)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
 
         // when & then
-        assertErrorCode(() -> clubApplicationService.replaceApplyQuestions(1, 99, request), NOT_FOUND_CLUB_APPLY_QUESTION);
+        assertErrorCode(() -> clubApplicationService.replaceApplyQuestions(1, 99, request),
+            NOT_FOUND_CLUB_APPLY_QUESTION);
         verify(clubApplyQuestionRepository, never()).saveAll(any());
     }
 
@@ -581,20 +590,20 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplyQuestion newQuestion1 = createQuestion(club, 10, "새 질문 1", true, 1, at(2026, 4, 2, 10, 0));
         ClubApplyQuestion newQuestion2 = createQuestion(club, 11, "새 질문 2", false, 2, at(2026, 4, 2, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 1", true),
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 2", false)
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 1", true),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문 2", false)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-                .willReturn(List.of())
-                .willReturn(List.of(newQuestion1, newQuestion2));
+            .willReturn(List.of())
+            .willReturn(List.of(newQuestion1, newQuestion2));
 
         // when
         ClubApplyQuestionsResponse response = clubApplicationService.replaceApplyQuestions(1, 99, request);
 
         // then
-        verify(clubApplyQuestionRepository).saveAll(argThat(list -> ((List<?>) list).size() == 2));
+        verify(clubApplyQuestionRepository).saveAll(argThat(list -> ((List<?>)list).size() == 2));
         assertThat(response.questions()).hasSize(2);
     }
 
@@ -609,8 +618,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-                .willReturn(List.of(existingQ1, existingQ2))
-                .willReturn(List.of());
+            .willReturn(List.of(existingQ1, existingQ2))
+            .willReturn(List.of());
 
         // when
         ClubApplyQuestionsResponse response = clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -709,15 +718,16 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyQuestion requiredQuestion = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
         ClubApplyRequest request = new ClubApplyRequest(
-                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "   ")),
-                null
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "   ")),
+            null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
         given(userRepository.getById(10)).willReturn(user);
         given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
-        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(requiredQuestion));
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(
+            List.of(requiredQuestion));
 
         // when & then
         assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), REQUIRED_CLUB_APPLY_ANSWER_MISSING);
@@ -732,15 +742,16 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         User user = createUser(10, "2021136001", "지원자");
         ClubApplyQuestion requiredQuestion = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
         ClubApplyRequest request = new ClubApplyRequest(
-                List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, null)),
-                null
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, null)),
+            null
         );
 
         given(clubRepository.getById(1)).willReturn(club);
         given(userRepository.getById(10)).willReturn(user);
         given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
-        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(requiredQuestion));
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(
+            List.of(requiredQuestion));
 
         // when & then
         assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), REQUIRED_CLUB_APPLY_ANSWER_MISSING);
@@ -767,19 +778,20 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of());
         given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
-        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
-                .willReturn(List.of(member1, member2));
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1,
+            gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of(member1, member2));
 
         // when
         clubApplicationService.applyClub(1, 10, request);
 
         // then
         verify(applicationEventPublisher).publishEvent(ClubApplicationSubmittedEvent.of(
-                List.of(20, 21),
-                300,
-                1,
-                club.getName(),
-                applicant.getName()
+            List.of(20, 21),
+            300,
+            1,
+            club.getName(),
+            applicant.getName()
         ));
     }
 
@@ -861,20 +873,20 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         ClubApplyQuestion createdQuestion = createQuestion(club, 10, "새 질문", true, 1, at(2026, 4, 2, 10, 0));
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", null)
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", null)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-                .willReturn(List.of())
-                .willReturn(List.of(createdQuestion));
+            .willReturn(List.of())
+            .willReturn(List.of(createdQuestion));
 
         // when
         clubApplicationService.replaceApplyQuestions(1, 99, request);
 
         // then
         verify(clubApplyQuestionRepository).saveAll(argThat(list -> {
-            List<ClubApplyQuestion> questions = (List<ClubApplyQuestion>) list;
+            List<ClubApplyQuestion> questions = (List<ClubApplyQuestion>)list;
             return questions.size() == 1 && questions.get(0).getIsRequired().equals(true);
         }));
     }
@@ -887,13 +899,13 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         ClubApplyQuestion question = createQuestion(club, 1, "지원 동기", true, 2, at(2026, 4, 1, 10, 0));
         // Same content, only repositioning to display order 1
         ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
-                new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true)
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true)
         ));
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
-                .willReturn(List.of(question))
-                .willReturn(List.of(question));
+            .willReturn(List.of(question))
+            .willReturn(List.of(question));
 
         // when
         clubApplicationService.replaceApplyQuestions(1, 99, request);
@@ -924,11 +936,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of(answer));
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
-                .willReturn(List.of(question));
+            .willReturn(List.of(question));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then
         assertThat(response.applications()).hasSize(1);
@@ -954,11 +966,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of());
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
-                .willReturn(List.of(question));
+            .willReturn(List.of(question));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then - isAfter returns false for equal timestamps, so question is filtered out
         assertThat(response.applications()).hasSize(1);
@@ -983,11 +995,11 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
         given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100))).willReturn(List.of(answer));
         given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, appliedAt, appliedAt))
-                .willReturn(List.of(question));
+            .willReturn(List.of(question));
 
         // when
         ClubMemberApplicationAnswersResponse response =
-                clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
 
         // then - minAppliedAt == maxAppliedAt
         assertThat(response.applications()).hasSize(1);
@@ -1016,7 +1028,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // when
         ClubApplicationAnswersResponse response =
-                clubApplicationService.getApprovedMemberApplicationAnswers(1, 10, 99);
+            clubApplicationService.getApprovedMemberApplicationAnswers(1, 10, 99);
 
         // then
         verify(clubPermissionValidator).validateManagerAccess(1, 99);
@@ -1060,7 +1072,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubRecruitmentRepository.getByClubId(1)).willReturn(recruitment);
-        given(clubApplyQueryRepository.findAllByClubIdAndCreatedAtBetween(1, startAt, endAt, condition)).willReturn(page);
+        given(clubApplyQueryRepository.findAllByClubIdAndCreatedAtBetween(1, startAt, endAt, condition)).willReturn(
+            page);
 
         // when
         ClubApplicationsResponse response = clubApplicationService.getClubApplications(1, 99, condition);
@@ -1086,7 +1099,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         // when
         ClubApplicationsResponse response =
-                clubApplicationService.getApprovedMemberApplications(1, 99, condition);
+            clubApplicationService.getApprovedMemberApplications(1, 99, condition);
 
         // then
         verify(clubPermissionValidator).validateManagerAccess(1, 99);
@@ -1194,21 +1207,21 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
     private User createUser(Integer id, String studentNumber, String name) {
         return UserFixture.createUserWithId(
-                UniversityFixture.createWithId(1),
-                id,
-                name,
-                studentNumber,
-                gg.agit.konect.domain.user.enums.UserRole.USER
+            UniversityFixture.createWithId(1),
+            id,
+            name,
+            studentNumber,
+            gg.agit.konect.domain.user.enums.UserRole.USER
         );
     }
 
     private ClubApplyQuestion createQuestion(
-            Club club,
-            Integer id,
-            String question,
-            boolean isRequired,
-            int displayOrder,
-            LocalDateTime createdAt
+        Club club,
+        Integer id,
+        String question,
+        boolean isRequired,
+        int displayOrder,
+        LocalDateTime createdAt
     ) {
         ClubApplyQuestion applyQuestion = ClubApplyQuestion.of(club, question, isRequired, displayOrder);
         setId(applyQuestion, id);
@@ -1239,8 +1252,8 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
     private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
         assertThatThrownBy(callable::call)
-                .isInstanceOf(CustomException.class)
-                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(errorCode));
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(errorCode));
     }
 
     @FunctionalInterface

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -638,7 +638,9 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         User applicant = createUser(10, "2021136001", "지원자");
         LocalDateTime appliedAt = at(2026, 4, 2, 10, 0);
-        ClubApply clubApply = createApprovedApply(club, applicant, 100, appliedAt);
+        ClubApply clubApply = ClubApply.of(club, applicant, null);
+        setId(clubApply, 100);
+        setCreatedAt(clubApply, appliedAt);
         ClubApplyQuestion question = createQuestion(club, 200, "지원 동기", true, 1, at(2026, 4, 1, 9, 0));
         ClubApplyAnswer answer = ClubApplyAnswer.of(clubApply, question, "성장하고 싶습니다.");
 

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -1,0 +1,470 @@
+package gg.agit.konect.unit.domain.club.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.ALREADY_APPLIED_CLUB;
+import static gg.agit.konect.global.code.ApiResponseCode.ALREADY_CLUB_MEMBER;
+import static gg.agit.konect.global.code.ApiResponseCode.DUPLICATE_CLUB_APPLY_QUESTION;
+import static gg.agit.konect.global.code.ApiResponseCode.FEE_PAYMENT_IMAGE_REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gg.agit.konect.domain.bank.model.Bank;
+import gg.agit.konect.domain.bank.repository.BankRepository;
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.dto.ClubApplicationAnswersResponse;
+import gg.agit.konect.domain.club.dto.ClubApplicationCondition;
+import gg.agit.konect.domain.club.dto.ClubApplyQuestionsReplaceRequest;
+import gg.agit.konect.domain.club.dto.ClubApplyRequest;
+import gg.agit.konect.domain.club.dto.ClubFeeInfoResponse;
+import gg.agit.konect.domain.club.dto.ClubMemberApplicationAnswersResponse;
+import gg.agit.konect.domain.club.enums.ClubApplyStatus;
+import gg.agit.konect.domain.club.event.ClubApplicationApprovedEvent;
+import gg.agit.konect.domain.club.event.ClubApplicationRejectedEvent;
+import gg.agit.konect.domain.club.event.ClubApplicationSubmittedEvent;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.ClubApply;
+import gg.agit.konect.domain.club.model.ClubApplyAnswer;
+import gg.agit.konect.domain.club.model.ClubApplyQuestion;
+import gg.agit.konect.domain.club.model.ClubMember;
+import gg.agit.konect.domain.club.repository.ClubApplyAnswerRepository;
+import gg.agit.konect.domain.club.repository.ClubApplyQueryRepository;
+import gg.agit.konect.domain.club.repository.ClubApplyQuestionRepository;
+import gg.agit.konect.domain.club.repository.ClubApplyRepository;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubRecruitmentRepository;
+import gg.agit.konect.domain.club.repository.ClubRepository;
+import gg.agit.konect.domain.club.service.ClubApplicationService;
+import gg.agit.konect.domain.club.service.ClubPermissionValidator;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
+import gg.agit.konect.support.fixture.ClubMemberFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ClubApplicationServiceTest extends ServiceTestSupport {
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubRecruitmentRepository clubRecruitmentRepository;
+
+    @Mock
+    private ClubApplyRepository clubApplyRepository;
+
+    @Mock
+    private ClubApplyQuestionRepository clubApplyQuestionRepository;
+
+    @Mock
+    private ClubApplyAnswerRepository clubApplyAnswerRepository;
+
+    @Mock
+    private ClubApplyQueryRepository clubApplyQueryRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BankRepository bankRepository;
+
+    @Mock
+    private ClubPermissionValidator clubPermissionValidator;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private ChatRoomMembershipService chatRoomMembershipService;
+
+    @InjectMocks
+    private ClubApplicationService clubApplicationService;
+
+    @Test
+    @DisplayName("applyClub은 이미 동아리 멤버인 사용자의 지원을 거부한다")
+    void applyClubRejectsAlreadyMember() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyRequest request = new ClubApplyRequest(List.of(), null);
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(true);
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), ALREADY_CLUB_MEMBER);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 이미 pending 지원서가 있으면 중복 지원을 거부한다")
+    void applyClubRejectsAlreadyApplied() {
+        // given
+        Club club = createClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyRequest request = new ClubApplyRequest(List.of(), null);
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(true);
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), ALREADY_APPLIED_CLUB);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 회비 필수 동아리에서 납부 이미지가 없으면 실패한다")
+    void applyClubRequiresFeePaymentImage() {
+        // given
+        Club club = createFeeRequiredClub(1);
+        User user = createUser(10, "2021136001", "지원자");
+        ClubApplyRequest request = new ClubApplyRequest(List.of(), null);
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(user);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.applyClub(1, 10, request), FEE_PAYMENT_IMAGE_REQUIRED);
+        verify(clubApplyRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("applyClub은 답변을 저장하고 운영진이 있으면 제출 이벤트를 발행한다")
+    void applyClubSavesAnswersAndPublishesSubmittedEvent() {
+        // given
+        Club club = createClubWithFeeInfo(1, "국민은행");
+        User applicant = createUser(10, "2021136001", "지원자");
+        User managerUser = createUser(20, "2021136002", "운영진");
+        ClubMember manager = ClubMemberFixture.createManager(club, managerUser);
+        ClubApplyQuestion question = createQuestion(club, 100, "지원 동기", true, 1, at(2026, 4, 1, 12, 0));
+        ClubApplyRequest request = new ClubApplyRequest(
+            List.of(new ClubApplyRequest.InnerClubQuestionAnswer(100, "백엔드를 공부하고 싶습니다.")),
+            "https://example.com/payment.png"
+        );
+        Bank bank = org.mockito.Mockito.mock(Bank.class);
+        ClubApply savedApply = ClubApply.of(club, applicant, request.feePaymentImageUrl());
+        setId(savedApply, 300);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(userRepository.getById(10)).willReturn(applicant);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyRepository.existsPendingByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(question));
+        given(clubApplyRepository.save(any(ClubApply.class))).willReturn(savedApply);
+        given(clubMemberRepository.findAllByClubIdAndPositionIn(1, gg.agit.konect.domain.club.enums.ClubPosition.MANAGERS))
+            .willReturn(List.of(manager));
+        given(bankRepository.getByName("국민은행")).willReturn(bank);
+        given(bank.getId()).willReturn(7);
+
+        // when
+        ClubFeeInfoResponse response = clubApplicationService.applyClub(1, 10, request);
+
+        // then
+        verify(clubApplyAnswerRepository).saveAll(argThat(answers -> {
+            List<ClubApplyAnswer> savedAnswers = (List<ClubApplyAnswer>)answers;
+            return savedAnswers.size() == 1
+                && savedAnswers.get(0).getQuestion().getId().equals(100)
+                && savedAnswers.get(0).getAnswer().equals("백엔드를 공부하고 싶습니다.");
+        }));
+        verify(applicationEventPublisher).publishEvent(ClubApplicationSubmittedEvent.of(
+            List.of(20),
+            300,
+            1,
+            club.getName(),
+            applicant.getName()
+        ));
+        assertThat(response.bankId()).isEqualTo(7);
+        assertThat(response.bankName()).isEqualTo("국민은행");
+        assertThat(response.accountNumber()).isEqualTo("123-456-7890");
+    }
+
+    @Test
+    @DisplayName("approveClubApplication은 멤버 저장, 채팅 멤버십 추가, 승인 이벤트 발행을 수행한다")
+    void approveClubApplicationAddsMembershipAndPublishesEvent() {
+        // given
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        ClubApply clubApply = ClubApply.of(club, applicant, null);
+        ClubMember savedMember = ClubMemberFixture.createMember(club, applicant);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(clubApply);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
+        given(clubMemberRepository.save(any(ClubMember.class))).willReturn(savedMember);
+
+        // when
+        clubApplicationService.approveClubApplication(1, 100, 99);
+
+        // then
+        assertThat(clubApply.getStatus()).isEqualTo(ClubApplyStatus.APPROVED);
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        verify(chatRoomMembershipService).addClubMember(savedMember);
+        verify(applicationEventPublisher).publishEvent(ClubApplicationApprovedEvent.of(10, 1, club.getName()));
+    }
+
+    @Test
+    @DisplayName("approveClubApplication은 이미 멤버인 사용자를 다시 승인하지 않는다")
+    void approveClubApplicationRejectsExistingMember() {
+        // given
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        ClubApply clubApply = ClubApply.of(club, applicant, null);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(clubApply);
+        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(true);
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.approveClubApplication(1, 100, 99), ALREADY_CLUB_MEMBER);
+        assertThat(clubApply.getStatus()).isEqualTo(ClubApplyStatus.PENDING);
+        verify(chatRoomMembershipService, never()).addClubMember(any());
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("rejectClubApplication은 상태를 거절로 바꾸고 거절 이벤트를 발행한다")
+    void rejectClubApplicationChangesStatusAndPublishesEvent() {
+        // given
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        ClubApply clubApply = ClubApply.of(club, applicant, null);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(clubApply);
+
+        // when
+        clubApplicationService.rejectClubApplication(1, 100, 99);
+
+        // then
+        assertThat(clubApply.getStatus()).isEqualTo(ClubApplyStatus.REJECTED);
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        verify(applicationEventPublisher).publishEvent(ClubApplicationRejectedEvent.of(10, 1, club.getName()));
+    }
+
+    @Test
+    @DisplayName("replaceApplyQuestions는 수정된 질문을 soft delete하고 새 질문을 생성하며 빠진 질문도 soft delete한다")
+    void replaceApplyQuestionsSoftDeletesAndCreatesQuestions() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestion unchangedQuestion = createQuestion(club, 1, "지원 동기", true, 1, at(2026, 4, 1, 10, 0));
+        ClubApplyQuestion changedQuestion = createQuestion(club, 2, "관심 분야", false, 2, at(2026, 4, 1, 10, 0));
+        ClubApplyQuestion removedQuestion = createQuestion(club, 3, "자기소개", true, 3, at(2026, 4, 1, 10, 0));
+        ClubApplyQuestion createdQuestion = createQuestion(club, 4, "새 질문", true, 2, at(2026, 4, 2, 10, 0));
+        ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(2, "관심 기술", false),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(null, "새 질문", true)
+        ));
+        List<ClubApplyQuestion> existingQuestions = List.of(unchangedQuestion, changedQuestion, removedQuestion);
+        ArgumentCaptor<List<ClubApplyQuestion>> questionsCaptor = ArgumentCaptor.forClass(List.class);
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1))
+            .willReturn(existingQuestions)
+            .willReturn(List.of(unchangedQuestion, createdQuestion));
+
+        // when
+        var response = clubApplicationService.replaceApplyQuestions(1, 99, request);
+
+        // then
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        verify(clubApplyQuestionRepository).saveAll(questionsCaptor.capture());
+        List<ClubApplyQuestion> createdQuestions = questionsCaptor.getValue();
+        assertThat(createdQuestions).hasSize(2);
+        assertThat(createdQuestions)
+            .extracting(ClubApplyQuestion::getQuestion)
+            .containsExactly("관심 기술", "새 질문");
+        assertThat(unchangedQuestion.getDisplayOrder()).isEqualTo(1);
+        assertThat(changedQuestion.getDeletedAt()).isNotNull();
+        assertThat(removedQuestion.getDeletedAt()).isNotNull();
+        assertThat(response.questions()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("replaceApplyQuestions는 중복 questionId를 거부한다")
+    void replaceApplyQuestionsRejectsDuplicateQuestionIds() {
+        // given
+        Club club = createClub(1);
+        ClubApplyQuestion existingQuestion = createQuestion(club, 1, "지원 동기", true, 1, at(2026, 4, 1, 10, 0));
+        ClubApplyQuestionsReplaceRequest request = new ClubApplyQuestionsReplaceRequest(List.of(
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기", true),
+            new ClubApplyQuestionsReplaceRequest.ApplyQuestionRequest(1, "지원 동기 수정", true)
+        ));
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQuestionRepository.findAllByClubIdOrderByDisplayOrderAsc(1)).willReturn(List.of(existingQuestion));
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.replaceApplyQuestions(1, 99, request), DUPLICATE_CLUB_APPLY_QUESTION);
+        verify(clubApplyQuestionRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("getApprovedMemberApplicationAnswersList는 승인 지원서가 없으면 빈 응답을 즉시 반환한다")
+    void getApprovedMemberApplicationAnswersListReturnsEmptyImmediately() {
+        // given
+        Page<ClubApply> emptyPage = new PageImpl<>(List.of());
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+        given(clubRepository.getById(1)).willReturn(createClub(1));
+        given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(emptyPage);
+
+        // when
+        ClubMemberApplicationAnswersResponse response =
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+
+        // then
+        assertThat(response.applications()).isEmpty();
+        verify(clubPermissionValidator).validateManagerAccess(1, 99);
+        verify(clubApplyAnswerRepository, never()).findAllByApplyIdsWithQuestion(any());
+        verify(clubApplyQuestionRepository, never()).findAllCandidatesVisibleBetweenApplyTimes(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("getApprovedMemberApplicationAnswersList는 지원 시점에 보이던 질문만 각 지원서에 포함한다")
+    void getApprovedMemberApplicationAnswersListUsesQuestionVisibilityAtApplyTime() {
+        // given
+        Club club = createClub(1);
+        User firstUser = createUser(10, "2021136001", "첫번째");
+        User secondUser = createUser(20, "2021136002", "두번째");
+        LocalDateTime firstAppliedAt = at(2026, 4, 2, 10, 0);
+        LocalDateTime secondAppliedAt = at(2026, 4, 4, 10, 0);
+
+        ClubApply firstApply = createApprovedApply(club, firstUser, 100, firstAppliedAt);
+        ClubApply secondApply = createApprovedApply(club, secondUser, 200, secondAppliedAt);
+        Page<ClubApply> page = new PageImpl<>(List.of(firstApply, secondApply));
+        ClubApplicationCondition condition = new ClubApplicationCondition(1, 10, null, null);
+
+        ClubApplyQuestion oldQuestion = createQuestion(club, 1, "공통 질문", true, 1, at(2026, 4, 1, 9, 0));
+        ClubApplyQuestion deletedQuestion = createQuestion(club, 2, "이전 질문", false, 2, at(2026, 4, 1, 9, 0));
+        deletedQuestion.softDelete(at(2026, 4, 3, 0, 0));
+        ClubApplyQuestion newQuestion = createQuestion(club, 3, "신규 질문", true, 3, at(2026, 4, 3, 12, 0));
+
+        ClubApplyAnswer firstAnswer1 = ClubApplyAnswer.of(firstApply, oldQuestion, "첫번째 공통 답변");
+        ClubApplyAnswer firstAnswer2 = ClubApplyAnswer.of(firstApply, deletedQuestion, "첫번째 이전 답변");
+        ClubApplyAnswer secondAnswer1 = ClubApplyAnswer.of(secondApply, oldQuestion, "두번째 공통 답변");
+        ClubApplyAnswer secondAnswer2 = ClubApplyAnswer.of(secondApply, newQuestion, "두번째 신규 답변");
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyQueryRepository.findApprovedMemberApplicationsByClubId(1, condition)).willReturn(page);
+        given(clubApplyAnswerRepository.findAllByApplyIdsWithQuestion(List.of(100, 200)))
+            .willReturn(List.of(firstAnswer1, firstAnswer2, secondAnswer1, secondAnswer2));
+        given(clubApplyQuestionRepository.findAllCandidatesVisibleBetweenApplyTimes(1, firstAppliedAt, secondAppliedAt))
+            .willReturn(List.of(oldQuestion, deletedQuestion, newQuestion));
+
+        // when
+        ClubMemberApplicationAnswersResponse response =
+            clubApplicationService.getApprovedMemberApplicationAnswersList(1, 99, condition);
+
+        // then
+        assertThat(response.applications()).hasSize(2);
+
+        ClubApplicationAnswersResponse firstResponse = response.applications().get(0);
+        assertThat(firstResponse.applicationId()).isEqualTo(100);
+        assertThat(firstResponse.answers())
+            .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
+            .containsExactly("공통 질문", "이전 질문");
+
+        ClubApplicationAnswersResponse secondResponse = response.applications().get(1);
+        assertThat(secondResponse.applicationId()).isEqualTo(200);
+        assertThat(secondResponse.answers())
+            .extracting(ClubApplicationAnswersResponse.ClubApplicationAnswerResponse::question)
+            .containsExactly("공통 질문", "신규 질문");
+    }
+
+    private Club createClub(Integer clubId) {
+        return ClubFixture.createWithId(UniversityFixture.createWithId(1), clubId);
+    }
+
+    private Club createFeeRequiredClub(Integer clubId) {
+        Club club = createClub(clubId);
+        club.updateSettings(null, null, true);
+        return club;
+    }
+
+    private Club createClubWithFeeInfo(Integer clubId, String bankName) {
+        Club club = createFeeRequiredClub(clubId);
+        club.replaceFeeInfo("30000", bankName, "123-456-7890", "BCSD");
+        return club;
+    }
+
+    private User createUser(Integer id, String studentNumber, String name) {
+        return UserFixture.createUserWithId(
+            UniversityFixture.createWithId(1),
+            id,
+            name,
+            studentNumber,
+            gg.agit.konect.domain.user.enums.UserRole.USER
+        );
+    }
+
+    private ClubApplyQuestion createQuestion(
+        Club club,
+        Integer id,
+        String question,
+        boolean isRequired,
+        int displayOrder,
+        LocalDateTime createdAt
+    ) {
+        ClubApplyQuestion applyQuestion = ClubApplyQuestion.of(club, question, isRequired, displayOrder);
+        setId(applyQuestion, id);
+        setCreatedAt(applyQuestion, createdAt);
+        return applyQuestion;
+    }
+
+    private ClubApply createApprovedApply(Club club, User user, Integer id, LocalDateTime createdAt) {
+        ClubApply apply = ClubApply.of(club, user, null);
+        setId(apply, id);
+        setCreatedAt(apply, createdAt);
+        apply.approve();
+        return apply;
+    }
+
+    private void setId(Object target, Integer id) {
+        ReflectionTestUtils.setField(target, "id", id);
+    }
+
+    private void setCreatedAt(Object target, LocalDateTime createdAt) {
+        ReflectionTestUtils.setField(target, "createdAt", createdAt);
+        ReflectionTestUtils.setField(target, "updatedAt", createdAt);
+    }
+
+    private LocalDateTime at(int year, int month, int day, int hour, int minute) {
+        return LocalDateTime.of(year, month, day, hour, minute);
+    }
+
+    private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
+        assertThatThrownBy(callable::call)
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(errorCode));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingCallable {
+        void call();
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -638,9 +638,7 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         Club club = createClub(1);
         User applicant = createUser(10, "2021136001", "지원자");
         LocalDateTime appliedAt = at(2026, 4, 2, 10, 0);
-        ClubApply clubApply = ClubApply.of(club, applicant, null);
-        setId(clubApply, 100);
-        setCreatedAt(clubApply, appliedAt);
+        ClubApply clubApply = createPendingApply(club, applicant, 100, appliedAt);
         ClubApplyQuestion question = createQuestion(club, 200, "지원 동기", true, 1, at(2026, 4, 1, 9, 0));
         ClubApplyAnswer answer = ClubApplyAnswer.of(clubApply, question, "성장하고 싶습니다.");
 
@@ -1231,10 +1229,15 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         return applyQuestion;
     }
 
-    private ClubApply createApprovedApply(Club club, User user, Integer id, LocalDateTime createdAt) {
+    private ClubApply createPendingApply(Club club, User user, Integer id, LocalDateTime createdAt) {
         ClubApply apply = ClubApply.of(club, user, null);
         setId(apply, id);
         setCreatedAt(apply, createdAt);
+        return apply;
+    }
+
+    private ClubApply createApprovedApply(Club club, User user, Integer id, LocalDateTime createdAt) {
+        ClubApply apply = createPendingApply(club, user, id, createdAt);
         apply.approve();
         return apply;
     }

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubApplicationServiceTest.java
@@ -4,6 +4,7 @@ import static gg.agit.konect.global.code.ApiResponseCode.ALREADY_APPLIED_CLUB;
 import static gg.agit.konect.global.code.ApiResponseCode.ALREADY_CLUB_MEMBER;
 import static gg.agit.konect.global.code.ApiResponseCode.DUPLICATE_CLUB_APPLY_QUESTION;
 import static gg.agit.konect.global.code.ApiResponseCode.FEE_PAYMENT_IMAGE_REQUIRED;
+import static gg.agit.konect.global.code.ApiResponseCode.ALREADY_PROCESSED_CLUB_APPLY;
 import static gg.agit.konect.global.code.ApiResponseCode.INVALID_REQUEST_BODY;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB_APPLY_QUESTION;
 import static gg.agit.konect.global.code.ApiResponseCode.REQUIRED_CLUB_APPLY_ANSWER_MISSING;
@@ -785,9 +786,9 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
     // ========== US-002: Approve/reject logical state transitions ==========
 
     @Test
-    @DisplayName("approveClubApplication은 이미 승인된 지원서를 재승인하면 ALREADY_CLUB_MEMBER을 던진다")
-    void approveClubApplicationRejectsDoubleApproval() {
-        // given - first approval already happened (member exists)
+    @DisplayName("approveClubApplication은 이미 승인된 지원서를 재승인하면 ALREADY_PROCESSED_CLUB_APPLY를 던진다")
+    void approveClubApplicationRejectsAlreadyApproved() {
+        // given
         Club club = createClub(1);
         User applicant = createUser(10, "2021136001", "지원자");
         ClubApply approvedApply = ClubApply.of(club, applicant, null);
@@ -795,41 +796,33 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(approvedApply);
-        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(true);
 
         // when & then
-        assertErrorCode(() -> clubApplicationService.approveClubApplication(1, 100, 99), ALREADY_CLUB_MEMBER);
+        assertErrorCode(() -> clubApplicationService.approveClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);
         verify(clubMemberRepository, never()).save(any());
     }
 
     @Test
-    @DisplayName("approveClubApplication은 거절된 지원서를 승인할 수 있다")
-    void approveClubApplicationSucceedsAfterRejection() {
+    @DisplayName("approveClubApplication은 이미 거절된 지원서를 승인하면 ALREADY_PROCESSED_CLUB_APPLY를 던진다")
+    void approveClubApplicationRejectsAlreadyRejected() {
         // given
         Club club = createClub(1);
         User applicant = createUser(10, "2021136001", "지원자");
         ClubApply rejectedApply = ClubApply.of(club, applicant, null);
         rejectedApply.reject();
-        ClubMember savedMember = ClubMemberFixture.createMember(club, applicant);
 
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(rejectedApply);
-        given(clubMemberRepository.existsByClubIdAndUserId(1, 10)).willReturn(false);
-        given(clubMemberRepository.save(any(ClubMember.class))).willReturn(savedMember);
 
-        // when
-        clubApplicationService.approveClubApplication(1, 100, 99);
-
-        // then
-        assertThat(rejectedApply.getStatus()).isEqualTo(ClubApplyStatus.APPROVED);
-        verify(chatRoomMembershipService).addClubMember(savedMember);
-        verify(applicationEventPublisher).publishEvent(ClubApplicationApprovedEvent.of(10, 1, club.getName()));
+        // when & then
+        assertErrorCode(() -> clubApplicationService.approveClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);
+        verify(clubMemberRepository, never()).save(any());
     }
 
     @Test
-    @DisplayName("rejectClubApplication은 이미 승인된 지원서도 거절 상태로 변경한다")
-    void rejectClubApplicationChangesStatusAfterApproval() {
-        // given - application was already approved, member already in club
+    @DisplayName("rejectClubApplication은 이미 승인된 지원서를 거절하면 ALREADY_PROCESSED_CLUB_APPLY를 던진다")
+    void rejectClubApplicationRejectsAlreadyApproved() {
+        // given
         Club club = createClub(1);
         User applicant = createUser(10, "2021136001", "지원자");
         ClubApply approvedApply = ClubApply.of(club, applicant, null);
@@ -838,12 +831,25 @@ class ClubApplicationServiceTest extends ServiceTestSupport {
         given(clubRepository.getById(1)).willReturn(club);
         given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(approvedApply);
 
-        // when
-        clubApplicationService.rejectClubApplication(1, 100, 99);
+        // when & then
+        assertErrorCode(() -> clubApplicationService.rejectClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);
+        assertThat(approvedApply.getStatus()).isEqualTo(ClubApplyStatus.APPROVED);
+    }
 
-        // then
-        assertThat(approvedApply.getStatus()).isEqualTo(ClubApplyStatus.REJECTED);
-        verify(applicationEventPublisher).publishEvent(ClubApplicationRejectedEvent.of(10, 1, club.getName()));
+    @Test
+    @DisplayName("rejectClubApplication은 이미 거절된 지원서를 재거절하면 ALREADY_PROCESSED_CLUB_APPLY를 던진다")
+    void rejectClubApplicationRejectsAlreadyRejected() {
+        // given
+        Club club = createClub(1);
+        User applicant = createUser(10, "2021136001", "지원자");
+        ClubApply rejectedApply = ClubApply.of(club, applicant, null);
+        rejectedApply.reject();
+
+        given(clubRepository.getById(1)).willReturn(club);
+        given(clubApplyRepository.getByIdAndClubId(100, 1)).willReturn(rejectedApply);
+
+        // when & then
+        assertErrorCode(() -> clubApplicationService.rejectClubApplication(1, 100, 99), ALREADY_PROCESSED_CLUB_APPLY);
     }
 
     // ========== US-003: replaceApplyQuestions edge cases ==========


### PR DESCRIPTION
### 🔍 개요

- `ClubApplicationService`의 모든 public 메서드에 대한 단위 테스트를 작성하고 엣지케이스를 보강합니다.
- 이미 처리된 지원서(APPROVED/REJECTED)의 상태 전이를 방지하는 가드 로직을 추가합니다.

- close #522 
---

### 🚀 주요 변경 내용

### 서비스 로직 변경
- `approveClubApplication`, `rejectClubApplication` 메서드에 `clubApply.getStatus() != PENDING` 가드 추가
- 이미 처리된 지원서 조작 시 `ALREADY_PROCESSED_CLUB_APPLY`(409 Conflict) 예외 발생
- `ClubApplyStatus` import 추가

### 테스트 추가 (44개)
- **applyClub (14개)**: 중복 지원, 중복 멤버, 회비 검증, 필수 답변 누락, 공백/null 답변, 존재하지 않는 질문, 중복 질문 ID, 운영진 없음/다중 운영진 이벤트, 회비 불필요 성공, 선택 질문 빈 답변
- **approveClubApplication (4개)**: 정상 승인, 이미 멤버, 이미 승인됨, 이미 거절됨
- **rejectClubApplication (3개)**: 정상 거절, 이미 승인됨, 이미 거절됨
- **replaceApplyQuestions (7개)**: soft delete + 생성, 중복 ID, 존재하지 않는 ID, 전체 신규, 전체 삭제, isRequired 기본값, displayOrder만 변경
- **getApprovedMemberApplicationAnswersList (4개)**: 빈 응답, 가시성 필터링, createdAt==appliedAt 경계, deletedAt==appliedAt 경계, 단일 지원서
- **기타 메서드 (12개)**: getClubApplicationAnswers, getApprovedMemberApplicationAnswers, getClubApplications(상시/기간), getApprovedMemberApplications, getApplyQuestions, getAppliedClubs, getFeeInfo, replaceFeeInfo

---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
