### PR TITLE
test: ChatService 단위 테스트 추가

### DIFF
--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -136,8 +136,7 @@ class ChatServiceTest extends ServiceTestSupport {
         ChatRoom room = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember requesterMember = createRoomMember(room, currentUser, false,
             LocalDateTime.of(2026, 4, 11, 10, 0));
-        ReflectionTestUtils.setField(requesterMember, "leftAt", LocalDateTime.of(2026, 4, 11, 11, 0));
-        ReflectionTestUtils.setField(requesterMember, "visibleMessageFrom", LocalDateTime.of(2026, 4, 11, 11, 0));
+        markMemberLeft(requesterMember, LocalDateTime.of(2026, 4, 11, 11, 0));
         ChatRoomMember targetMember = createRoomMember(room, targetUser, false,
             LocalDateTime.of(2026, 4, 11, 10, 0));
 
@@ -854,8 +853,7 @@ class ChatServiceTest extends ServiceTestSupport {
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember leftMember = createRoomMember(groupRoom, sender, false,
             LocalDateTime.of(2026, 4, 11, 10, 0));
-        ReflectionTestUtils.setField(leftMember, "leftAt", LocalDateTime.of(2026, 4, 11, 12, 0));
-        ReflectionTestUtils.setField(leftMember, "visibleMessageFrom", LocalDateTime.of(2026, 4, 11, 12, 0));
+        markMemberLeft(leftMember, LocalDateTime.of(2026, 4, 11, 12, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
@@ -1085,6 +1083,10 @@ class ChatServiceTest extends ServiceTestSupport {
         return message;
     }
 
+    private void markMemberLeft(ChatRoomMember member, LocalDateTime leftAt) {
+        ReflectionTestUtils.setField(member, "leftAt", leftAt);
+        ReflectionTestUtils.setField(member, "visibleMessageFrom", leftAt);
+    }
 
     private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
         assertThatThrownBy(callable)

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -35,9 +35,12 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import gg.agit.konect.domain.chat.dto.ChatMessageDetailResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
+import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
 import gg.agit.konect.domain.chat.enums.ChatType;
 import gg.agit.konect.domain.chat.model.ChatMessage;
@@ -471,6 +474,456 @@ class ChatServiceTest extends ServiceTestSupport {
             () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20),
             FORBIDDEN_CHAT_ROOM_ACCESS
         );
+    }
+
+    // ===== createOrGetChatRoom additional =====
+
+    @Test
+    @DisplayName("createOrGetChatRoom은 기존 방이 없으면 새 direct room을 생성한다")
+    void createOrGetChatRoomCreatesNewDirectRoomWhenNoneExists() {
+        // given
+        Integer currentUserId = 10;
+        Integer targetUserId = 20;
+        User currentUser = createUser(currentUserId, "요청자", UserRole.USER);
+        User targetUser = createUser(targetUserId, "상대", UserRole.USER);
+        ChatRoom newRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(userRepository.getById(currentUserId)).willReturn(currentUser);
+        given(userRepository.getById(targetUserId)).willReturn(targetUser);
+        given(chatRoomRepository.findByTwoUsers(currentUserId, targetUserId, ChatType.DIRECT))
+            .willReturn(Optional.empty());
+        given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(newRoom);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(newRoom.getId(), currentUserId))
+            .willReturn(Optional.empty());
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(newRoom.getId(), targetUserId))
+            .willReturn(Optional.empty());
+
+        // when
+        ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(targetUserId));
+
+        // then
+        assertThat(response.chatRoomId()).isEqualTo(newRoom.getId());
+        verify(chatRoomRepository).save(any(ChatRoom.class));
+        verify(chatRoomMemberRepository, times(2)).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("createOrGetChatRoom은 admin이 admin과 채팅할 때 일반 direct 경로를 사용한다")
+    void createOrGetChatRoomTreatsAdminToAdminAsNormalDirect() {
+        // given
+        Integer adminId1 = 99;
+        Integer adminId2 = 98;
+        User admin1 = createUser(adminId1, "관리자1", UserRole.ADMIN);
+        User admin2 = createUser(adminId2, "관리자2", UserRole.ADMIN);
+        ChatRoom room = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member1 = createRoomMember(room, admin1, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member2 = createRoomMember(room, admin2, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(userRepository.getById(adminId1)).willReturn(admin1);
+        given(userRepository.getById(adminId2)).willReturn(admin2);
+        given(chatRoomRepository.findByTwoUsers(adminId1, adminId2, ChatType.DIRECT))
+            .willReturn(Optional.of(room));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), adminId1))
+            .willReturn(Optional.of(member1));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), adminId2))
+            .willReturn(Optional.of(member2));
+
+        // when
+        ChatRoomResponse response = chatService.createOrGetChatRoom(adminId1, new ChatRoomCreateRequest(adminId2));
+
+        // then
+        assertThat(response.chatRoomId()).isEqualTo(room.getId());
+        verify(chatRoomRepository, never()).findByTwoUsers(eq(SYSTEM_ADMIN_ID), any(), any());
+    }
+
+    // ===== createOrGetAdminChatRoom =====
+
+    @Test
+    @DisplayName("createOrGetAdminChatRoom은 admin이 없으면 NOT_FOUND_USER를 던진다")
+    void createOrGetAdminChatRoomThrowsWhenNoAdminExists() {
+        // given
+        given(userRepository.findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole.ADMIN))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.createOrGetAdminChatRoom(10), NOT_FOUND_USER);
+    }
+
+    // ===== leaveChatRoom additional =====
+
+    @Test
+    @DisplayName("leaveChatRoom은 존재하지 않는 방에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void leaveChatRoomThrowsWhenRoomNotFound() {
+        // given
+        given(chatRoomRepository.findById(999)).willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.leaveChatRoom(10, 999), NOT_FOUND_CHAT_ROOM);
+    }
+
+    @Test
+    @DisplayName("leaveChatRoom은 멤버가 아닌 사용자에 대해 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    void leaveChatRoomThrowsWhenNotMember() {
+        // given
+        Integer userId = 10;
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.leaveChatRoom(userId, directRoom.getId()), FORBIDDEN_CHAT_ROOM_ACCESS);
+    }
+
+    // ===== kickMember additional =====
+
+    @Test
+    @DisplayName("kickMember은 존재하지 않는 방에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void kickMemberThrowsWhenRoomNotFound() {
+        // given
+        given(chatRoomRepository.findById(999)).willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.kickMember(10, 999, 20), NOT_FOUND_CHAT_ROOM);
+    }
+
+    @Test
+    @DisplayName("kickMember은 club group room에서도 거부한다")
+    void kickMemberRejectsClubGroupRoom() {
+        // given
+        ChatRoom clubRoom = createRoom(1, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
+
+        // when & then
+        assertErrorCode(() -> chatService.kickMember(10, clubRoom.getId(), 20), CANNOT_KICK_IN_NON_GROUP_ROOM);
+    }
+
+    @Test
+    @DisplayName("kickMember은 요청자가 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    void kickMemberThrowsWhenRequesterNotMember() {
+        // given
+        Integer requesterId = 10;
+        Integer targetId = 20;
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_ACCESS);
+    }
+
+    @Test
+    @DisplayName("kickMember은 target이 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    void kickMemberThrowsWhenTargetNotMember() {
+        // given
+        Integer requesterId = 10;
+        Integer targetId = 20;
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember owner = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
+            .willReturn(Optional.of(owner));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_ACCESS);
+    }
+
+    // ===== getMessages additional =====
+
+    @Test
+    @DisplayName("getMessages는 존재하지 않는 방에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void getMessagesThrowsWhenRoomNotFound() {
+        // given
+        given(chatRoomRepository.findById(999)).willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.getMessages(10, 999, 1, 20), NOT_FOUND_CHAT_ROOM);
+    }
+
+    @Test
+    @DisplayName("getMessages는 admin이 system admin 방을 조회할 때 전용 경로를 사용한다")
+    void getMessagesReturnsAdminSystemRoomMessages() {
+        // given
+        Integer adminId = 99;
+        User admin = createUser(adminId, "관리자", UserRole.ADMIN);
+        User systemAdmin = createUser(SYSTEM_ADMIN_ID, "시스템관리자", UserRole.ADMIN);
+        User targetUser = createUser(20, "사용자", UserRole.USER);
+        ChatRoom systemAdminRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember systemAdminMember = createRoomMember(systemAdminRoom, systemAdmin, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember targetMember = createRoomMember(systemAdminRoom, targetUser, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage message = createMessage(100, systemAdminRoom, admin, "문의",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
+        given(userRepository.getById(adminId)).willReturn(admin);
+        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
+            .willReturn(List.of(
+                new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
+                new Object[]{systemAdminRoom.getId(), 20, systemAdminRoom.getCreatedAt()}
+            ));
+        given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
+            .willReturn(List.of(systemAdminMember, targetMember));
+        given(chatMessageRepository.findByChatRoomId(eq(systemAdminRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(message), PageRequest.of(0, 20), 1));
+
+        // when
+        ChatMessagePageResponse response = chatService.getMessages(adminId, systemAdminRoom.getId(), 1, 20);
+
+        // then
+        assertThat(response.messages()).hasSize(1);
+        verify(chatRoomMembershipService).updateLastReadAt(eq(systemAdminRoom.getId()), eq(SYSTEM_ADMIN_ID), any(LocalDateTime.class));
+        verify(chatPresenceService).recordPresence(systemAdminRoom.getId(), adminId);
+    }
+
+    // ===== sendMessage =====
+
+    @Test
+    @DisplayName("sendMessage는 존재하지 않는 방에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void sendMessageThrowsWhenRoomNotFound() {
+        // given
+        given(chatRoomRepository.findById(999)).willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.sendMessage(10, 999, new ChatMessageSendRequest("hi")), NOT_FOUND_CHAT_ROOM);
+    }
+
+    @Test
+    @DisplayName("sendMessage는 direct room에서 메시지를 저장하고 알림을 보낸다")
+    void sendMessageInDirectRoomSavesMessageAndSendsNotification() {
+        // given
+        Integer senderId = 10;
+        Integer receiverId = 20;
+        User sender = createUser(senderId, "보낸이", UserRole.USER);
+        User receiver = createUser(receiverId, "받는이", UserRole.USER);
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember senderMember = createRoomMember(directRoom, sender, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember receiverMember = createRoomMember(directRoom, receiver, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage savedMessage = createMessage(100, directRoom, sender, "hello",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(userRepository.getById(senderId)).willReturn(sender);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), senderId))
+            .willReturn(Optional.of(senderMember));
+        given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId()))
+            .willReturn(List.of(senderMember, receiverMember));
+        given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(directRoom.getId()), eq(senderId), any(LocalDateTime.class)))
+            .willReturn(1);
+
+        // when
+        ChatMessageDetailResponse response = chatService.sendMessage(senderId, directRoom.getId(),
+            new ChatMessageSendRequest("hello"));
+
+        // then
+        assertThat(response.messageId()).isEqualTo(savedMessage.getId());
+        assertThat(response.content()).isEqualTo("hello");
+        assertThat(response.senderId()).isEqualTo(senderId);
+        assertThat(response.isMine()).isTrue();
+        verify(chatMessageRepository).save(any(ChatMessage.class));
+        verify(notificationService).sendChatNotification(eq(receiverId), eq(directRoom.getId()), eq("보낸이"), eq("hello"));
+    }
+
+    @Test
+    @DisplayName("sendMessage는 group room에서 메시지를 저장하고 그룹 알림을 보낸다")
+    void sendMessageInGroupRoomSavesMessageAndSendsGroupNotification() {
+        // given
+        Integer senderId = 10;
+        User sender = createUser(senderId, "보낸이", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember senderMember = createRoomMember(groupRoom, sender, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage savedMessage = createMessage(100, groupRoom, sender, "hello",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(senderId)).willReturn(sender);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), senderId))
+            .willReturn(Optional.of(senderMember));
+        given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(groupRoom.getId()), eq(senderId), any(LocalDateTime.class)))
+            .willReturn(1);
+        given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId()))
+            .willReturn(List.of(senderMember));
+
+        // when
+        ChatMessageDetailResponse response = chatService.sendMessage(senderId, groupRoom.getId(),
+            new ChatMessageSendRequest("hello"));
+
+        // then
+        assertThat(response.messageId()).isEqualTo(savedMessage.getId());
+        assertThat(response.content()).isEqualTo("hello");
+        assertThat(response.isMine()).isTrue();
+        verify(notificationService).sendGroupChatNotification(
+            eq(groupRoom.getId()), eq(senderId), eq("그룹 채팅"), eq("보낸이"), eq("hello"),
+            any(List.class)
+        );
+    }
+
+    @Test
+    @DisplayName("sendMessage는 group room에서 나간 멤버가 보내면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    void sendMessageInGroupRoomRejectsLeftMember() {
+        // given
+        Integer senderId = 10;
+        User sender = createUser(senderId, "보낸이", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember leftMember = createRoomMember(groupRoom, sender, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        leftMember.leaveDirectRoom(LocalDateTime.of(2026, 4, 11, 12, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(senderId)).willReturn(sender);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), senderId))
+            .willReturn(Optional.of(leftMember));
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.sendMessage(senderId, groupRoom.getId(), new ChatMessageSendRequest("hello")),
+            FORBIDDEN_CHAT_ROOM_ACCESS
+        );
+        verify(chatMessageRepository, never()).save(any(ChatMessage.class));
+    }
+
+    @Test
+    @DisplayName("sendMessage는 club room에서 메시지를 저장하고 그룹 알림을 보낸다")
+    void sendMessageInClubRoomSavesMessageAndSendsGroupNotification() {
+        // given
+        Integer senderId = 10;
+        User sender = createUser(senderId, "보낸이", UserRole.USER);
+        Club club = ClubFixture.createWithId(UniversityFixture.createWithId(1), 77, "BCSD");
+        ChatRoom clubRoom = ChatRoom.clubGroupOf(club);
+        ReflectionTestUtils.setField(clubRoom, "id", 1);
+        ReflectionTestUtils.setField(clubRoom, "createdAt", LocalDateTime.of(2026, 4, 11, 10, 0));
+        ClubMember clubMember = ClubMemberFixture.createMember(club, sender);
+        ReflectionTestUtils.setField(clubMember, "createdAt", LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember senderRoomMember = createRoomMember(clubRoom, sender, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage savedMessage = createMessage(100, clubRoom, sender, "hello",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
+        given(clubMemberRepository.getByClubIdAndUserId(club.getId(), senderId)).willReturn(clubMember);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(clubRoom.getId(), senderId))
+            .willReturn(Optional.of(senderRoomMember));
+        given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(clubRoom.getId()), eq(senderId), any(LocalDateTime.class)))
+            .willReturn(1);
+        given(chatRoomMemberRepository.findByChatRoomId(clubRoom.getId()))
+            .willReturn(List.of(senderRoomMember));
+
+        // when
+        ChatMessageDetailResponse response = chatService.sendMessage(senderId, clubRoom.getId(),
+            new ChatMessageSendRequest("hello"));
+
+        // then
+        assertThat(response.messageId()).isEqualTo(savedMessage.getId());
+        assertThat(response.content()).isEqualTo("hello");
+        verify(notificationService).sendGroupChatNotification(
+            eq(clubRoom.getId()), eq(senderId), eq("BCSD"), eq("보낸이"), eq("hello"),
+            any(List.class)
+        );
+    }
+
+    // ===== toggleMute additional =====
+
+    @Test
+    @DisplayName("toggleMute는 존재하지 않는 방에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void toggleMuteThrowsWhenRoomNotFound() {
+        // given
+        given(chatRoomRepository.findById(999)).willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.toggleMute(10, 999), NOT_FOUND_CHAT_ROOM);
+    }
+
+    @Test
+    @DisplayName("toggleMute는 group room에서 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    void toggleMuteRejectsNonMemberInGroupRoom() {
+        // given
+        Integer userId = 10;
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(createUser(userId, "사용자", UserRole.USER));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(() -> chatService.toggleMute(userId, groupRoom.getId()), FORBIDDEN_CHAT_ROOM_ACCESS);
+    }
+
+    // ===== updateChatRoomName =====
+
+    @Test
+    @DisplayName("updateChatRoomName은 멤버의 custom room name을 업데이트한다")
+    void updateChatRoomNameUpdatesCustomNameForMember() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(groupRoom, user, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
+            .willReturn(Optional.of(member));
+
+        // when
+        chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("내 채팅방"));
+
+        // then
+        assertThat(member.getCustomRoomName()).isEqualTo("내 채팅방");
+    }
+
+    @Test
+    @DisplayName("updateChatRoomName은 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    void updateChatRoomNameRejectsNonMember() {
+        // given
+        Integer userId = 10;
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("이름")),
+            FORBIDDEN_CHAT_ROOM_ACCESS
+        );
+    }
+
+    @Test
+    @DisplayName("updateChatRoomName은 null이나 빈 이름을 null로 정규화한다")
+    void updateChatRoomNameNormalizesNullName() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(groupRoom, user, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        member.updateCustomRoomName("기존 이름");
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
+            .willReturn(Optional.of(member));
+
+        // when
+        chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest(null));
+
+        // then
+        assertThat(member.getCustomRoomName()).isNull();
     }
 
     private User createUser(Integer id, String name, UserRole role) {

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -1,0 +1,522 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_CREATE_CHAT_ROOM_WITH_SELF;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_IN_NON_GROUP_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_ROOM_OWNER;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_SELF;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_LEAVE_GROUP_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_KICK;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
+import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
+import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
+import gg.agit.konect.domain.chat.enums.ChatType;
+import gg.agit.konect.domain.chat.model.ChatMessage;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatInviteQueryRepository;
+import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.chat.service.ChatPresenceService;
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.chat.service.ChatService;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.ClubMember;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.notification.enums.NotificationTargetType;
+import gg.agit.konect.domain.notification.model.NotificationMuteSetting;
+import gg.agit.konect.domain.notification.repository.NotificationMuteSettingRepository;
+import gg.agit.konect.domain.notification.service.NotificationService;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
+import gg.agit.konect.support.fixture.ClubMemberFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ChatServiceTest extends ServiceTestSupport {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Mock
+    private NotificationMuteSettingRepository notificationMuteSettingRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private ChatInviteQueryRepository chatInviteQueryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatPresenceService chatPresenceService;
+
+    @Mock
+    private ChatRoomMembershipService chatRoomMembershipService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    @Test
+    @DisplayName("createOrGetChatRoom은 자기 자신과의 direct room 생성을 거부한다")
+    void createOrGetChatRoomRejectsSelfChat() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "요청자", UserRole.USER);
+        given(userRepository.getById(userId)).willReturn(user);
+        given(userRepository.getById(userId)).willReturn(user);
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.createOrGetChatRoom(userId, new ChatRoomCreateRequest(userId)),
+            CANNOT_CREATE_CHAT_ROOM_WITH_SELF
+        );
+        verify(chatRoomRepository, never()).save(any(ChatRoom.class));
+    }
+
+    @Test
+    @DisplayName("createOrGetChatRoom은 기존 direct room이 있으면 재사용하고 요청자 멤버십을 복구한다")
+    void createOrGetChatRoomReusesExistingDirectRoomAndReopensRequesterMembership() {
+        // given
+        Integer currentUserId = 10;
+        Integer targetUserId = 20;
+        User currentUser = createUser(currentUserId, "요청자", UserRole.USER);
+        User targetUser = createUser(targetUserId, "상대", UserRole.USER);
+        ChatRoom room = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember requesterMember = createRoomMember(room, currentUser, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ReflectionTestUtils.setField(requesterMember, "leftAt", LocalDateTime.of(2026, 4, 11, 11, 0));
+        ReflectionTestUtils.setField(requesterMember, "visibleMessageFrom", LocalDateTime.of(2026, 4, 11, 11, 0));
+        ChatRoomMember targetMember = createRoomMember(room, targetUser, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(userRepository.getById(currentUserId)).willReturn(currentUser);
+        given(userRepository.getById(targetUserId)).willReturn(targetUser);
+        given(chatRoomRepository.findByTwoUsers(currentUserId, targetUserId, ChatType.DIRECT))
+            .willReturn(Optional.of(room));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), currentUserId))
+            .willReturn(Optional.of(requesterMember));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), targetUserId))
+            .willReturn(Optional.of(targetMember));
+
+        // when
+        ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(targetUserId));
+
+        // then
+        assertThat(response.chatRoomId()).isEqualTo(room.getId());
+        assertThat(requesterMember.hasLeft()).isFalse();
+        assertThat(requesterMember.getVisibleMessageFrom()).isNotNull();
+        verify(chatRoomRepository, never()).save(any(ChatRoom.class));
+        verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("createOrGetChatRoom은 admin이 일반 사용자와 채팅할 때 system-admin room 경로를 사용한다")
+    void createOrGetChatRoomUsesSystemAdminRoomForAdminToUser() {
+        // given
+        Integer adminUserId = 99;
+        Integer targetUserId = 20;
+        User adminUser = createUser(adminUserId, "관리자", UserRole.ADMIN);
+        User targetUser = createUser(targetUserId, "일반 사용자", UserRole.USER);
+        User systemAdmin = createUser(SYSTEM_ADMIN_ID, "시스템관리자", UserRole.ADMIN);
+        ChatRoom room = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        given(userRepository.getById(adminUserId)).willReturn(adminUser);
+        given(userRepository.getById(targetUserId)).willReturn(targetUser);
+        given(chatRoomRepository.findByTwoUsers(SYSTEM_ADMIN_ID, targetUserId, ChatType.DIRECT))
+            .willReturn(Optional.empty());
+        given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(room);
+        given(userRepository.getById(SYSTEM_ADMIN_ID)).willReturn(systemAdmin);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), SYSTEM_ADMIN_ID))
+            .willReturn(Optional.empty());
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), targetUserId))
+            .willReturn(Optional.empty());
+        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(room.getId())))
+            .willReturn(List.of(
+                new Object[]{room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()},
+                new Object[]{room.getId(), targetUserId, room.getCreatedAt()}
+            ));
+
+        // when
+        ChatRoomResponse response = chatService.createOrGetChatRoom(adminUserId, new ChatRoomCreateRequest(targetUserId));
+
+        // then
+        assertThat(response.chatRoomId()).isEqualTo(room.getId());
+        verify(chatRoomMemberRepository, times(2)).save(any(ChatRoomMember.class));
+        verify(chatRoomMemberRepository, never()).findByChatRoomIdAndUserId(room.getId(), adminUserId);
+    }
+
+    @Test
+    @DisplayName("createGroupChatRoom은 초대 대상을 dedup 하고 자기 자신을 제외한 뒤 owner/member를 저장한다")
+    void createGroupChatRoomDeduplicatesInviteesAndSavesMembers() {
+        // given
+        Integer creatorId = 10;
+        User creator = createUser(creatorId, "생성자", UserRole.USER);
+        User user20 = createUser(20, "멤버1", UserRole.USER);
+        User user30 = createUser(30, "멤버2", UserRole.USER);
+        ChatRoom room = createRoom(50, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 12, 0));
+
+        given(userRepository.getById(creatorId)).willReturn(creator);
+        given(userRepository.findAllByIdIn(List.of(20, 30))).willReturn(List.of(user20, user30));
+        given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(room);
+
+        // when
+        ChatRoomResponse response = chatService.createGroupChatRoom(
+            creatorId,
+            new ChatRoomCreateRequest.Group(List.of(creatorId, 20, 20, 30))
+        );
+
+        // then
+        assertThat(response.chatRoomId()).isEqualTo(room.getId());
+        ArgumentCaptor<List<ChatRoomMember>> captor = ArgumentCaptor.forClass(List.class);
+        verify(chatRoomMemberRepository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(3);
+        assertThat(captor.getValue())
+            .extracting(ChatRoomMember::getUserId, ChatRoomMember::isOwner)
+            .containsExactlyInAnyOrder(
+                org.assertj.core.groups.Tuple.tuple(creatorId, true),
+                org.assertj.core.groups.Tuple.tuple(20, false),
+                org.assertj.core.groups.Tuple.tuple(30, false)
+            );
+    }
+
+    @Test
+    @DisplayName("createGroupChatRoom은 자기 자신만 남거나 조회되지 않는 사용자가 있으면 실패한다")
+    void createGroupChatRoomRejectsInvalidInvitees() {
+        // given
+        Integer creatorId = 10;
+        User creator = createUser(creatorId, "생성자", UserRole.USER);
+        given(userRepository.getById(creatorId)).willReturn(creator);
+        given(userRepository.findAllByIdIn(List.of(20, 30))).willReturn(List.of(createUser(20, "멤버1", UserRole.USER)));
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(creatorId))),
+            CANNOT_CREATE_CHAT_ROOM_WITH_SELF
+        );
+        assertErrorCode(
+            () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(20, 30))),
+            NOT_FOUND_USER
+        );
+    }
+
+    @Test
+    @DisplayName("leaveChatRoom은 club group room 나가기를 거부하고 direct room은 leftAt을 갱신한다")
+    void leaveChatRoomRejectsClubRoomAndMarksDirectRoomLeft() {
+        // given
+        Integer userId = 10;
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoom clubRoom = createClubRoom(2, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember directMember = createRoomMember(directRoom, createUser(userId, "사용자", UserRole.USER), false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
+            .willReturn(Optional.of(directMember));
+
+        // when
+        chatService.leaveChatRoom(userId, directRoom.getId());
+
+        // then
+        assertThat(directMember.hasLeft()).isTrue();
+        assertThat(directMember.getVisibleMessageFrom()).isNotNull();
+        assertErrorCode(() -> chatService.leaveChatRoom(userId, clubRoom.getId()), CANNOT_LEAVE_GROUP_CHAT_ROOM);
+    }
+
+    @Test
+    @DisplayName("leaveChatRoom은 일반 group room에서는 membership 삭제를 수행한다")
+    void leaveChatRoomDeletesMembershipForGroupRoom() {
+        // given
+        Integer userId = 10;
+        ChatRoom groupRoom = createRoom(3, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(groupRoom, createUser(userId, "사용자", UserRole.USER), false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
+            .willReturn(Optional.of(member));
+
+        // when
+        chatService.leaveChatRoom(userId, groupRoom.getId());
+
+        // then
+        verify(chatRoomMemberRepository).deleteByChatRoomIdAndUserId(groupRoom.getId(), userId);
+    }
+
+    @Test
+    @DisplayName("kickMember는 비그룹방, self kick, 방장 아님, owner target을 각각 거부한다")
+    void kickMemberRejectsInvalidRequests() {
+        // given
+        Integer requesterId = 10;
+        Integer targetId = 20;
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember nonOwnerRequester = createRoomMember(groupRoom, createUser(requesterId, "요청자", UserRole.USER), false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember ownerTarget = createRoomMember(groupRoom, createUser(targetId, "방장", UserRole.USER), true,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
+            .willReturn(Optional.of(nonOwnerRequester));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
+            .willReturn(Optional.of(ownerTarget));
+
+        // when & then
+        assertErrorCode(() -> chatService.kickMember(requesterId, directRoom.getId(), targetId), CANNOT_KICK_IN_NON_GROUP_ROOM);
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), requesterId), CANNOT_KICK_SELF);
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_KICK);
+
+        ChatRoomMember ownerRequester = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
+            .willReturn(Optional.of(ownerRequester));
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), CANNOT_KICK_ROOM_OWNER);
+    }
+
+    @Test
+    @DisplayName("kickMember는 유효한 group room에서 target membership을 삭제한다")
+    void kickMemberDeletesTargetMembershipWhenValid() {
+        // given
+        Integer requesterId = 10;
+        Integer targetId = 20;
+        ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember ownerRequester = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember target = createRoomMember(groupRoom, createUser(targetId, "멤버", UserRole.USER), false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
+            .willReturn(Optional.of(ownerRequester));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
+            .willReturn(Optional.of(target));
+
+        // when
+        chatService.kickMember(requesterId, groupRoom.getId(), targetId);
+
+        // then
+        verify(chatRoomMemberRepository).deleteByChatRoomIdAndUserId(groupRoom.getId(), targetId);
+    }
+
+    @Test
+    @DisplayName("toggleMute는 기존 setting이 있으면 토글하고 없으면 muted=true 로 저장한다")
+    void toggleMuteTogglesExistingSettingOrCreatesNewOne() {
+        // given
+        Integer userId = 10;
+        Integer roomId = 1;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom room = createRoom(roomId, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(room, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        NotificationMuteSetting setting = NotificationMuteSetting.of(NotificationTargetType.CHAT_ROOM, roomId, user, false);
+
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
+        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
+            .willReturn(Optional.of(setting), Optional.empty());
+
+        // when
+        ChatMuteResponse toggled = chatService.toggleMute(userId, roomId);
+        ChatMuteResponse created = chatService.toggleMute(userId, roomId);
+
+        // then
+        assertThat(toggled.isMuted()).isTrue();
+        assertThat(created.isMuted()).isTrue();
+        verify(notificationMuteSettingRepository, times(2)).save(any(NotificationMuteSetting.class));
+    }
+
+    @Test
+    @DisplayName("getMessages는 direct room에서 direct 전용 readAt 갱신 경로를 사용한다")
+    void getMessagesUsesDirectReadPath() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember directMember = createRoomMember(directRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage directMessage = createMessage(100, directRoom, createUser(20, "상대", UserRole.USER), "direct", LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId())).willReturn(List.of(directMember));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId)).willReturn(Optional.of(directMember));
+        given(chatMessageRepository.findByChatRoomId(eq(directRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(directMessage), PageRequest.of(0, 20), 1));
+
+        // when
+        ChatMessagePageResponse response = chatService.getMessages(userId, directRoom.getId(), 1, 20);
+
+        // then
+        assertThat(response.messages()).hasSize(1);
+        verify(chatRoomMembershipService).updateDirectRoomLastReadAt(eq(directRoom.getId()), eq(user), any(LocalDateTime.class), eq(directRoom));
+        verify(chatPresenceService).recordPresence(directRoom.getId(), userId);
+    }
+
+    @Test
+    @DisplayName("getMessages는 club group room에서 club membership 보정과 일반 readAt 갱신을 수행한다")
+    void getMessagesUsesClubGroupReadPath() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom clubRoom = createClubRoom(2, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember clubRoomMember = createRoomMember(clubRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage clubMessage = createMessage(200, clubRoom, user, "club", LocalDateTime.of(2026, 4, 11, 10, 2));
+
+        given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomId(clubRoom.getId())).willReturn(List.of(clubRoomMember));
+        given(chatMessageRepository.countByChatRoomId(clubRoom.getId(), null)).willReturn(1L);
+        given(chatMessageRepository.findByChatRoomId(eq(clubRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(clubMessage), PageRequest.of(0, 20), 1));
+
+        // when
+        ChatMessagePageResponse response = chatService.getMessages(userId, clubRoom.getId(), 1, 20);
+
+        // then
+        assertThat(response.clubId()).isEqualTo(clubRoom.getClub().getId());
+        verify(chatRoomMembershipService).ensureClubRoomMember(clubRoom.getId(), userId);
+        verify(chatRoomMembershipService).updateLastReadAt(eq(clubRoom.getId()), eq(userId), any(LocalDateTime.class));
+        verify(chatPresenceService).recordPresence(clubRoom.getId(), userId);
+    }
+
+    @Test
+    @DisplayName("getMessages는 group room에서 접근 검증 후 일반 readAt 갱신 경로를 사용한다")
+    void getMessagesUsesGroupReadPath() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(3, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember groupMember = createRoomMember(groupRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage groupMessage = createMessage(300, groupRoom, user, "group", LocalDateTime.of(2026, 4, 11, 10, 3));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(Optional.of(groupMember));
+        given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId())).willReturn(List.of(groupMember));
+        given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(1L);
+        given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(groupMessage), PageRequest.of(0, 20), 1));
+
+        // when
+        ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20);
+
+        // then
+        assertThat(response.clubId()).isNull();
+        verify(chatRoomMembershipService).updateLastReadAt(eq(groupRoom.getId()), eq(userId), any(LocalDateTime.class));
+        verify(chatPresenceService).recordPresence(groupRoom.getId(), userId);
+    }
+
+    @Test
+    @DisplayName("getMessages는 group room 비회원 요청을 거부한다")
+    void getMessagesRejectsGroupRoomOutsider() {
+        // given
+        Integer userId = 10;
+        ChatRoom groupRoom = createRoom(3, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(createUser(userId, "사용자", UserRole.USER));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20),
+            FORBIDDEN_CHAT_ROOM_ACCESS
+        );
+    }
+
+    private User createUser(Integer id, String name, UserRole role) {
+        return UserFixture.createUserWithId(UniversityFixture.createWithId(1), id, name, "2024" + String.format("%04d", id), role);
+    }
+
+    private ChatRoom createRoom(Integer id, ChatType type, LocalDateTime createdAt) {
+        ChatRoom room = switch (type) {
+            case DIRECT -> ChatRoom.directOf();
+            case GROUP -> ChatRoom.groupOf();
+            case CLUB_GROUP -> ChatRoom.clubGroupOf(ClubFixture.createWithId(UniversityFixture.createWithId(1), 77));
+        };
+        ReflectionTestUtils.setField(room, "id", id);
+        ReflectionTestUtils.setField(room, "createdAt", createdAt);
+        return room;
+    }
+
+    private ChatRoom createClubRoom(Integer id, LocalDateTime createdAt) {
+        Club club = ClubFixture.createWithId(UniversityFixture.createWithId(1), 77, "BCSD");
+        ChatRoom room = ChatRoom.clubGroupOf(club);
+        ReflectionTestUtils.setField(room, "id", id);
+        ReflectionTestUtils.setField(room, "createdAt", createdAt);
+        return room;
+    }
+
+    private ChatRoomMember createRoomMember(ChatRoom room, User user, boolean isOwner, LocalDateTime lastReadAt) {
+        ChatRoomMember member = isOwner ? ChatRoomMember.ofOwner(room, user, lastReadAt) : ChatRoomMember.of(room, user, lastReadAt);
+        ReflectionTestUtils.setField(member, "createdAt", lastReadAt);
+        return member;
+    }
+
+    private ChatMessage createMessage(Integer id, ChatRoom room, User sender, String content, LocalDateTime createdAt) {
+        ChatMessage message = ChatMessage.of(room, sender, content);
+        ReflectionTestUtils.setField(message, "id", id);
+        ReflectionTestUtils.setField(message, "createdAt", createdAt);
+        return message;
+    }
+
+    private void setCreatedAt(Object target, LocalDateTime createdAt) {
+        ReflectionTestUtils.setField(target, "createdAt", createdAt);
+        ReflectionTestUtils.setField(target, "updatedAt", createdAt);
+    }
+
+    private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
+        assertThatThrownBy(callable)
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(errorCode));
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -120,8 +120,8 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // when & then
         assertErrorCode(
-                () -> chatService.createOrGetChatRoom(userId, new ChatRoomCreateRequest(userId)),
-                CANNOT_CREATE_CHAT_ROOM_WITH_SELF
+            () -> chatService.createOrGetChatRoom(userId, new ChatRoomCreateRequest(userId)),
+            CANNOT_CREATE_CHAT_ROOM_WITH_SELF
         );
         verify(chatRoomRepository, never()).save(any(ChatRoom.class));
     }
@@ -136,23 +136,24 @@ class ChatServiceTest extends ServiceTestSupport {
         User targetUser = createUser(targetUserId, "상대", UserRole.USER);
         ChatRoom room = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember requesterMember = createRoomMember(room, currentUser, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ReflectionTestUtils.setField(requesterMember, "leftAt", LocalDateTime.of(2026, 4, 11, 11, 0));
         ReflectionTestUtils.setField(requesterMember, "visibleMessageFrom", LocalDateTime.of(2026, 4, 11, 11, 0));
         ChatRoomMember targetMember = createRoomMember(room, targetUser, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(userRepository.getById(currentUserId)).willReturn(currentUser);
         given(userRepository.getById(targetUserId)).willReturn(targetUser);
         given(chatRoomRepository.findByTwoUsers(currentUserId, targetUserId, ChatType.DIRECT))
-                .willReturn(Optional.of(room));
+            .willReturn(Optional.of(room));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), currentUserId))
-                .willReturn(Optional.of(requesterMember));
+            .willReturn(Optional.of(requesterMember));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), targetUserId))
-                .willReturn(Optional.of(targetMember));
+            .willReturn(Optional.of(targetMember));
 
         // when
-        ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(targetUserId));
+        ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId,
+            new ChatRoomCreateRequest(targetUserId));
 
         // then
         assertThat(response.chatRoomId()).isEqualTo(room.getId());
@@ -175,21 +176,22 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(adminUserId)).willReturn(adminUser);
         given(userRepository.getById(targetUserId)).willReturn(targetUser);
         given(chatRoomRepository.findByTwoUsers(SYSTEM_ADMIN_ID, targetUserId, ChatType.DIRECT))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
         given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(room);
         given(userRepository.getById(SYSTEM_ADMIN_ID)).willReturn(systemAdmin);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), SYSTEM_ADMIN_ID))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), targetUserId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
         given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(room.getId())))
-                .willReturn(List.of(
-                        new Object[]{room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()},
-                        new Object[]{room.getId(), targetUserId, room.getCreatedAt()}
-                ));
+            .willReturn(List.of(
+                new Object[] {room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()},
+                new Object[] {room.getId(), targetUserId, room.getCreatedAt()}
+            ));
 
         // when
-        ChatRoomResponse response = chatService.createOrGetChatRoom(adminUserId, new ChatRoomCreateRequest(targetUserId));
+        ChatRoomResponse response = chatService.createOrGetChatRoom(adminUserId,
+            new ChatRoomCreateRequest(targetUserId));
 
         // then
         assertThat(response.chatRoomId()).isEqualTo(room.getId());
@@ -213,8 +215,8 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // when
         ChatRoomResponse response = chatService.createGroupChatRoom(
-                creatorId,
-                new ChatRoomCreateRequest.Group(List.of(creatorId, 20, 20, 30))
+            creatorId,
+            new ChatRoomCreateRequest.Group(List.of(creatorId, 20, 20, 30))
         );
 
         // then
@@ -223,12 +225,12 @@ class ChatServiceTest extends ServiceTestSupport {
         verify(chatRoomMemberRepository).saveAll(captor.capture());
         assertThat(captor.getValue()).hasSize(3);
         assertThat(captor.getValue())
-                .extracting(ChatRoomMember::getUserId, ChatRoomMember::isOwner)
-                .containsExactlyInAnyOrder(
-                        org.assertj.core.groups.Tuple.tuple(creatorId, true),
-                        org.assertj.core.groups.Tuple.tuple(20, false),
-                        org.assertj.core.groups.Tuple.tuple(30, false)
-                );
+            .extracting(ChatRoomMember::getUserId, ChatRoomMember::isOwner)
+            .containsExactlyInAnyOrder(
+                org.assertj.core.groups.Tuple.tuple(creatorId, true),
+                org.assertj.core.groups.Tuple.tuple(20, false),
+                org.assertj.core.groups.Tuple.tuple(30, false)
+            );
     }
 
     @Test
@@ -242,12 +244,12 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // when & then
         assertErrorCode(
-                () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(creatorId))),
-                CANNOT_CREATE_CHAT_ROOM_WITH_SELF
+            () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(creatorId))),
+            CANNOT_CREATE_CHAT_ROOM_WITH_SELF
         );
         assertErrorCode(
-                () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(20, 30))),
-                NOT_FOUND_USER
+            () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(20, 30))),
+            NOT_FOUND_USER
         );
     }
 
@@ -259,12 +261,12 @@ class ChatServiceTest extends ServiceTestSupport {
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoom clubRoom = createClubRoom(2, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember directMember = createRoomMember(directRoom, createUser(userId, "사용자", UserRole.USER), false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
-                .willReturn(Optional.of(directMember));
+            .willReturn(Optional.of(directMember));
 
         // when
         chatService.leaveChatRoom(userId, directRoom.getId());
@@ -282,11 +284,11 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer userId = 10;
         ChatRoom groupRoom = createRoom(3, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(groupRoom, createUser(userId, "사용자", UserRole.USER), false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-                .willReturn(Optional.of(member));
+            .willReturn(Optional.of(member));
 
         // when
         chatService.leaveChatRoom(userId, groupRoom.getId());
@@ -303,27 +305,30 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer targetId = 20;
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
-        ChatRoomMember nonOwnerRequester = createRoomMember(groupRoom, createUser(requesterId, "요청자", UserRole.USER), false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember nonOwnerRequester = createRoomMember(groupRoom, createUser(requesterId, "요청자", UserRole.USER),
+            false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember ownerTarget = createRoomMember(groupRoom, createUser(targetId, "방장", UserRole.USER), true,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-                .willReturn(Optional.of(nonOwnerRequester));
+            .willReturn(Optional.of(nonOwnerRequester));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
-                .willReturn(Optional.of(ownerTarget));
+            .willReturn(Optional.of(ownerTarget));
 
         // when & then
-        assertErrorCode(() -> chatService.kickMember(requesterId, directRoom.getId(), targetId), CANNOT_KICK_IN_NON_GROUP_ROOM);
+        assertErrorCode(() -> chatService.kickMember(requesterId, directRoom.getId(), targetId),
+            CANNOT_KICK_IN_NON_GROUP_ROOM);
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), requesterId), CANNOT_KICK_SELF);
-        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_KICK);
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId),
+            FORBIDDEN_CHAT_ROOM_KICK);
 
         ChatRoomMember ownerRequester = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-                .willReturn(Optional.of(ownerRequester));
+            .willReturn(Optional.of(ownerRequester));
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), CANNOT_KICK_ROOM_OWNER);
     }
 
@@ -335,15 +340,15 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer targetId = 20;
         ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember ownerRequester = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember target = createRoomMember(groupRoom, createUser(targetId, "멤버", UserRole.USER), false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-                .willReturn(Optional.of(ownerRequester));
+            .willReturn(Optional.of(ownerRequester));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
-                .willReturn(Optional.of(target));
+            .willReturn(Optional.of(target));
 
         // when
         chatService.kickMember(requesterId, groupRoom.getId(), targetId);
@@ -361,13 +366,15 @@ class ChatServiceTest extends ServiceTestSupport {
         User user = createUser(userId, "사용자", UserRole.USER);
         ChatRoom room = createRoom(roomId, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(room, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
-        NotificationMuteSetting setting = NotificationMuteSetting.of(NotificationTargetType.CHAT_ROOM, roomId, user, false);
+        NotificationMuteSetting setting = NotificationMuteSetting.of(NotificationTargetType.CHAT_ROOM, roomId, user,
+            false);
 
         given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
-        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
-                .willReturn(Optional.of(setting));
+        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM,
+            roomId, userId))
+            .willReturn(Optional.of(setting));
 
         // when
         ChatMuteResponse response = chatService.toggleMute(userId, roomId);
@@ -387,13 +394,15 @@ class ChatServiceTest extends ServiceTestSupport {
         User user = createUser(userId, "사용자", UserRole.USER);
         ChatRoom room = createRoom(roomId, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(room, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
-        NotificationMuteSetting setting = NotificationMuteSetting.of(NotificationTargetType.CHAT_ROOM, roomId, user, true);
+        NotificationMuteSetting setting = NotificationMuteSetting.of(NotificationTargetType.CHAT_ROOM, roomId, user,
+            true);
 
         given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
-        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
-                .willReturn(Optional.of(setting));
+        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM,
+            roomId, userId))
+            .willReturn(Optional.of(setting));
 
         // when
         ChatMuteResponse response = chatService.toggleMute(userId, roomId);
@@ -417,8 +426,9 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
-        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
-                .willReturn(Optional.empty());
+        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM,
+            roomId, userId))
+            .willReturn(Optional.empty());
 
         // when
         ChatMuteResponse response = chatService.toggleMute(userId, roomId);
@@ -436,21 +446,25 @@ class ChatServiceTest extends ServiceTestSupport {
         User user = createUser(userId, "사용자", UserRole.USER);
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember directMember = createRoomMember(directRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
-        ChatMessage directMessage = createMessage(100, directRoom, createUser(20, "상대", UserRole.USER), "direct", LocalDateTime.of(2026, 4, 11, 10, 1));
+        ChatMessage directMessage = createMessage(100, directRoom, createUser(20, "상대", UserRole.USER), "direct",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId())).willReturn(List.of(directMember));
-        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId)).willReturn(Optional.of(directMember));
-        given(chatMessageRepository.findByChatRoomId(eq(directRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-                .willReturn(new PageImpl<>(List.of(directMessage), PageRequest.of(0, 20), 1));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId)).willReturn(
+            Optional.of(directMember));
+        given(chatMessageRepository.findByChatRoomId(eq(directRoom.getId()), nullable(LocalDateTime.class),
+            eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(directMessage), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(userId, directRoom.getId(), 1, 20);
 
         // then
         assertThat(response.messages()).hasSize(1);
-        verify(chatRoomMembershipService).updateDirectRoomLastReadAt(eq(directRoom.getId()), eq(user), any(LocalDateTime.class), eq(directRoom));
+        verify(chatRoomMembershipService).updateDirectRoomLastReadAt(eq(directRoom.getId()), eq(user),
+            any(LocalDateTime.class), eq(directRoom));
         verify(chatPresenceService).recordPresence(directRoom.getId(), userId);
     }
 
@@ -468,8 +482,9 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomId(clubRoom.getId())).willReturn(List.of(clubRoomMember));
         given(chatMessageRepository.countByChatRoomId(clubRoom.getId(), null)).willReturn(1L);
-        given(chatMessageRepository.findByChatRoomId(eq(clubRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-                .willReturn(new PageImpl<>(List.of(clubMessage), PageRequest.of(0, 20), 1));
+        given(chatMessageRepository.findByChatRoomId(eq(clubRoom.getId()), nullable(LocalDateTime.class),
+            eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(clubMessage), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(userId, clubRoom.getId(), 1, 20);
@@ -493,11 +508,13 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(userId)).willReturn(user);
-        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(Optional.of(groupMember));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(
+            Optional.of(groupMember));
         given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId())).willReturn(List.of(groupMember));
         given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(1L);
-        given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-                .willReturn(new PageImpl<>(List.of(groupMessage), PageRequest.of(0, 20), 1));
+        given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class),
+            eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(groupMessage), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20);
@@ -516,12 +533,13 @@ class ChatServiceTest extends ServiceTestSupport {
         ChatRoom groupRoom = createRoom(3, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(userId)).willReturn(createUser(userId, "사용자", UserRole.USER));
-        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(Optional.empty());
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(
+            Optional.empty());
 
         // when & then
         assertErrorCode(
-                () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20),
-                FORBIDDEN_CHAT_ROOM_ACCESS
+            () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20),
+            FORBIDDEN_CHAT_ROOM_ACCESS
         );
     }
 
@@ -540,15 +558,16 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(currentUserId)).willReturn(currentUser);
         given(userRepository.getById(targetUserId)).willReturn(targetUser);
         given(chatRoomRepository.findByTwoUsers(currentUserId, targetUserId, ChatType.DIRECT))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
         given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(newRoom);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(newRoom.getId(), currentUserId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(newRoom.getId(), targetUserId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         // when
-        ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(targetUserId));
+        ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId,
+            new ChatRoomCreateRequest(targetUserId));
 
         // then
         assertThat(response.chatRoomId()).isEqualTo(newRoom.getId());
@@ -571,11 +590,11 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(adminId1)).willReturn(admin1);
         given(userRepository.getById(adminId2)).willReturn(admin2);
         given(chatRoomRepository.findByTwoUsers(adminId1, adminId2, ChatType.DIRECT))
-                .willReturn(Optional.of(room));
+            .willReturn(Optional.of(room));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), adminId1))
-                .willReturn(Optional.of(member1));
+            .willReturn(Optional.of(member1));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), adminId2))
-                .willReturn(Optional.of(member2));
+            .willReturn(Optional.of(member2));
 
         // when
         ChatRoomResponse response = chatService.createOrGetChatRoom(adminId1, new ChatRoomCreateRequest(adminId2));
@@ -592,7 +611,7 @@ class ChatServiceTest extends ServiceTestSupport {
     void createOrGetAdminChatRoomThrowsWhenNoAdminExists() {
         // given
         given(userRepository.findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole.ADMIN))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.createOrGetAdminChatRoom(10), NOT_FOUND_USER);
@@ -619,7 +638,7 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.leaveChatRoom(userId, directRoom.getId()), FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -658,10 +677,11 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         // when & then
-        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_ACCESS);
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId),
+            FORBIDDEN_CHAT_ROOM_ACCESS);
     }
 
     @Test
@@ -672,16 +692,17 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer targetId = 20;
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember owner = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-                .willReturn(Optional.of(owner));
+            .willReturn(Optional.of(owner));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         // when & then
-        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_ACCESS);
+        assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId),
+            FORBIDDEN_CHAT_ROOM_ACCESS);
     }
 
     // ===== getMessages additional =====
@@ -706,30 +727,32 @@ class ChatServiceTest extends ServiceTestSupport {
         User targetUser = createUser(20, "사용자", UserRole.USER);
         ChatRoom systemAdminRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember systemAdminMember = createRoomMember(systemAdminRoom, systemAdmin, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember targetMember = createRoomMember(systemAdminRoom, targetUser, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage message = createMessage(100, systemAdminRoom, admin, "문의",
-                LocalDateTime.of(2026, 4, 11, 10, 1));
+            LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
         given(userRepository.getById(adminId)).willReturn(admin);
         given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
-                .willReturn(List.of(
-                        new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
-                        new Object[]{systemAdminRoom.getId(), 20, systemAdminRoom.getCreatedAt()}
-                ));
+            .willReturn(List.of(
+                new Object[] {systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
+                new Object[] {systemAdminRoom.getId(), 20, systemAdminRoom.getCreatedAt()}
+            ));
         given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
-                .willReturn(List.of(systemAdminMember, targetMember));
-        given(chatMessageRepository.findByChatRoomId(eq(systemAdminRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-                .willReturn(new PageImpl<>(List.of(message), PageRequest.of(0, 20), 1));
+            .willReturn(List.of(systemAdminMember, targetMember));
+        given(chatMessageRepository.findByChatRoomId(eq(systemAdminRoom.getId()), nullable(LocalDateTime.class),
+            eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(message), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(adminId, systemAdminRoom.getId(), 1, 20);
 
         // then
         assertThat(response.messages()).hasSize(1);
-        verify(chatRoomMembershipService).updateLastReadAt(eq(systemAdminRoom.getId()), eq(SYSTEM_ADMIN_ID), any(LocalDateTime.class));
+        verify(chatRoomMembershipService).updateLastReadAt(eq(systemAdminRoom.getId()), eq(SYSTEM_ADMIN_ID),
+            any(LocalDateTime.class));
         verify(chatPresenceService).recordPresence(systemAdminRoom.getId(), adminId);
     }
 
@@ -755,25 +778,26 @@ class ChatServiceTest extends ServiceTestSupport {
         User receiver = createUser(receiverId, "받는이", UserRole.USER);
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember senderMember = createRoomMember(directRoom, sender, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember receiverMember = createRoomMember(directRoom, receiver, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, directRoom, sender, "hello",
-                LocalDateTime.of(2026, 4, 11, 10, 1));
+            LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), senderId))
-                .willReturn(Optional.of(senderMember));
+            .willReturn(Optional.of(senderMember));
         given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId()))
-                .willReturn(List.of(senderMember, receiverMember));
+            .willReturn(List.of(senderMember, receiverMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
-        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(directRoom.getId()), eq(senderId), any(LocalDateTime.class)))
-                .willReturn(1);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(directRoom.getId()), eq(senderId),
+            any(LocalDateTime.class)))
+            .willReturn(1);
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(senderId, directRoom.getId(),
-                new ChatMessageSendRequest("hello"));
+            new ChatMessageSendRequest("hello"));
 
         // then
         assertThat(response.messageId()).isEqualTo(savedMessage.getId());
@@ -781,7 +805,8 @@ class ChatServiceTest extends ServiceTestSupport {
         assertThat(response.senderId()).isEqualTo(senderId);
         assertThat(response.isMine()).isTrue();
         verify(chatMessageRepository).save(any(ChatMessage.class));
-        verify(notificationService).sendChatNotification(eq(receiverId), eq(directRoom.getId()), eq("보낸이"), eq("hello"));
+        verify(notificationService).sendChatNotification(eq(receiverId), eq(directRoom.getId()), eq("보낸이"),
+            eq("hello"));
     }
 
     @Test
@@ -792,31 +817,32 @@ class ChatServiceTest extends ServiceTestSupport {
         User sender = createUser(senderId, "보낸이", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember senderMember = createRoomMember(groupRoom, sender, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, groupRoom, sender, "hello",
-                LocalDateTime.of(2026, 4, 11, 10, 1));
+            LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), senderId))
-                .willReturn(Optional.of(senderMember));
+            .willReturn(Optional.of(senderMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
-        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(groupRoom.getId()), eq(senderId), any(LocalDateTime.class)))
-                .willReturn(1);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(groupRoom.getId()), eq(senderId),
+            any(LocalDateTime.class)))
+            .willReturn(1);
         given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId()))
-                .willReturn(List.of(senderMember));
+            .willReturn(List.of(senderMember));
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(senderId, groupRoom.getId(),
-                new ChatMessageSendRequest("hello"));
+            new ChatMessageSendRequest("hello"));
 
         // then
         assertThat(response.messageId()).isEqualTo(savedMessage.getId());
         assertThat(response.content()).isEqualTo("hello");
         assertThat(response.isMine()).isTrue();
         verify(notificationService).sendGroupChatNotification(
-                eq(groupRoom.getId()), eq(senderId), eq("그룹 채팅"), eq("보낸이"), eq("hello"),
-                any(List.class)
+            eq(groupRoom.getId()), eq(senderId), eq("그룹 채팅"), eq("보낸이"), eq("hello"),
+            any(List.class)
         );
     }
 
@@ -828,18 +854,18 @@ class ChatServiceTest extends ServiceTestSupport {
         User sender = createUser(senderId, "보낸이", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember leftMember = createRoomMember(groupRoom, sender, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         leftMember.leaveDirectRoom(LocalDateTime.of(2026, 4, 11, 12, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), senderId))
-                .willReturn(Optional.of(leftMember));
+            .willReturn(Optional.of(leftMember));
 
         // when & then
         assertErrorCode(
-                () -> chatService.sendMessage(senderId, groupRoom.getId(), new ChatMessageSendRequest("hello")),
-                FORBIDDEN_CHAT_ROOM_ACCESS
+            () -> chatService.sendMessage(senderId, groupRoom.getId(), new ChatMessageSendRequest("hello")),
+            FORBIDDEN_CHAT_ROOM_ACCESS
         );
         verify(chatMessageRepository, never()).save(any(ChatMessage.class));
     }
@@ -857,30 +883,31 @@ class ChatServiceTest extends ServiceTestSupport {
         ClubMember clubMember = ClubMemberFixture.createMember(club, sender);
         ReflectionTestUtils.setField(clubMember, "createdAt", LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember senderRoomMember = createRoomMember(clubRoom, sender, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, clubRoom, sender, "hello",
-                LocalDateTime.of(2026, 4, 11, 10, 1));
+            LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
         given(clubMemberRepository.getByClubIdAndUserId(club.getId(), senderId)).willReturn(clubMember);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(clubRoom.getId(), senderId))
-                .willReturn(Optional.of(senderRoomMember));
+            .willReturn(Optional.of(senderRoomMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
-        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(clubRoom.getId()), eq(senderId), any(LocalDateTime.class)))
-                .willReturn(1);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(clubRoom.getId()), eq(senderId),
+            any(LocalDateTime.class)))
+            .willReturn(1);
         given(chatRoomMemberRepository.findByChatRoomId(clubRoom.getId()))
-                .willReturn(List.of(senderRoomMember));
+            .willReturn(List.of(senderRoomMember));
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(senderId, clubRoom.getId(),
-                new ChatMessageSendRequest("hello"));
+            new ChatMessageSendRequest("hello"));
 
         // then
         assertThat(response.messageId()).isEqualTo(savedMessage.getId());
         assertThat(response.content()).isEqualTo("hello");
         verify(notificationService).sendGroupChatNotification(
-                eq(clubRoom.getId()), eq(senderId), eq("BCSD"), eq("보낸이"), eq("hello"),
-                any(List.class)
+            eq(clubRoom.getId()), eq(senderId), eq("BCSD"), eq("보낸이"), eq("hello"),
+            any(List.class)
         );
     }
 
@@ -895,26 +922,26 @@ class ChatServiceTest extends ServiceTestSupport {
         User targetUser = createUser(targetUserId, "사용자", UserRole.USER);
         ChatRoom systemAdminRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember systemAdminMember = createRoomMember(systemAdminRoom, systemAdmin, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember targetMember = createRoomMember(systemAdminRoom, targetUser, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, systemAdminRoom, admin, "문의",
-                LocalDateTime.of(2026, 4, 11, 10, 1));
+            LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
         given(userRepository.getById(adminId)).willReturn(admin);
         given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
-                .willReturn(List.of(
-                        new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
-                        new Object[]{systemAdminRoom.getId(), targetUserId, systemAdminRoom.getCreatedAt()}
-                ));
+            .willReturn(List.of(
+                new Object[] {systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
+                new Object[] {systemAdminRoom.getId(), targetUserId, systemAdminRoom.getCreatedAt()}
+            ));
         given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
-                .willReturn(List.of(systemAdminMember, targetMember));
+            .willReturn(List.of(systemAdminMember, targetMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(adminId, systemAdminRoom.getId(),
-                new ChatMessageSendRequest("문의"));
+            new ChatMessageSendRequest("문의"));
 
         // then
         assertThat(response.content()).isEqualTo("문의");
@@ -922,9 +949,11 @@ class ChatServiceTest extends ServiceTestSupport {
         // 멤버십 조회를 건너뛰어야 한다
         verify(chatRoomMemberRepository, never()).findByChatRoomIdAndUserId(systemAdminRoom.getId(), adminId);
         // admin은 lastReadAt 업데이트를 하지 않는다
-        verify(chatRoomMemberRepository, never()).updateLastReadAtIfOlder(eq(systemAdminRoom.getId()), eq(adminId), any(LocalDateTime.class));
+        verify(chatRoomMemberRepository, never()).updateLastReadAtIfOlder(eq(systemAdminRoom.getId()), eq(adminId),
+            any(LocalDateTime.class));
         // 비관리자에게 알림이 전송되어야 한다
-        verify(notificationService).sendChatNotification(eq(targetUserId), eq(systemAdminRoom.getId()), eq("관리자"), eq("문의"));
+        verify(notificationService).sendChatNotification(eq(targetUserId), eq(systemAdminRoom.getId()), eq("관리자"),
+            eq("문의"));
     }
 
     // ===== toggleMute additional =====
@@ -949,7 +978,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(userId)).willReturn(createUser(userId, "사용자", UserRole.USER));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.toggleMute(userId, groupRoom.getId()), FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -965,11 +994,11 @@ class ChatServiceTest extends ServiceTestSupport {
         User user = createUser(userId, "사용자", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(groupRoom, user, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-                .willReturn(Optional.of(member));
+            .willReturn(Optional.of(member));
 
         // when
         chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("내 채팅방"));
@@ -987,12 +1016,12 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-                .willReturn(Optional.empty());
+            .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(
-                () -> chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("이름")),
-                FORBIDDEN_CHAT_ROOM_ACCESS
+            () -> chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("이름")),
+            FORBIDDEN_CHAT_ROOM_ACCESS
         );
     }
 
@@ -1004,12 +1033,12 @@ class ChatServiceTest extends ServiceTestSupport {
         User user = createUser(userId, "사용자", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(groupRoom, user, false,
-                LocalDateTime.of(2026, 4, 11, 10, 0));
+            LocalDateTime.of(2026, 4, 11, 10, 0));
         member.updateCustomRoomName("기존 이름");
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-                .willReturn(Optional.of(member));
+            .willReturn(Optional.of(member));
 
         // when
         chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest(null));
@@ -1019,7 +1048,8 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     private User createUser(Integer id, String name, UserRole role) {
-        return UserFixture.createUserWithId(UniversityFixture.createWithId(1), id, name, "2024" + String.format("%04d", id), role);
+        return UserFixture.createUserWithId(UniversityFixture.createWithId(1), id, name,
+            "2024" + String.format("%04d", id), role);
     }
 
     private ChatRoom createRoom(Integer id, ChatType type, LocalDateTime createdAt) {
@@ -1042,7 +1072,8 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     private ChatRoomMember createRoomMember(ChatRoom room, User user, boolean isOwner, LocalDateTime lastReadAt) {
-        ChatRoomMember member = isOwner ? ChatRoomMember.ofOwner(room, user, lastReadAt) : ChatRoomMember.of(room, user, lastReadAt);
+        ChatRoomMember member =
+            isOwner ? ChatRoomMember.ofOwner(room, user, lastReadAt) : ChatRoomMember.of(room, user, lastReadAt);
         ReflectionTestUtils.setField(member, "createdAt", lastReadAt);
         return member;
     }
@@ -1061,7 +1092,7 @@ class ChatServiceTest extends ServiceTestSupport {
 
     private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
         assertThatThrownBy(callable)
-                .isInstanceOf(CustomException.class)
-                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(errorCode));
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(errorCode));
     }
 }

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -116,7 +116,6 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer userId = 10;
         User user = createUser(userId, "요청자", UserRole.USER);
         given(userRepository.getById(userId)).willReturn(user);
-        given(userRepository.getById(userId)).willReturn(user);
 
         // when & then
         assertErrorCode(
@@ -168,7 +167,7 @@ class ChatServiceTest extends ServiceTestSupport {
     void createOrGetChatRoomUsesSystemAdminRoomForAdminToUser() {
         // given
         Integer adminUserId = 99;
-        Integer targetUserId = 20;
+        int targetUserId = 20;
         User adminUser = createUser(adminUserId, "관리자", UserRole.ADMIN);
         User targetUser = createUser(targetUserId, "일반 사용자", UserRole.USER);
         User systemAdmin = createUser(SYSTEM_ADMIN_ID, "시스템관리자", UserRole.ADMIN);
@@ -647,7 +646,7 @@ class ChatServiceTest extends ServiceTestSupport {
     // ===== kickMember additional =====
 
     @Test
-    @DisplayName("kickMember은 존재하지 않는 방에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    @DisplayName("kickMember는 존재하지 않는 방에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
     void kickMemberThrowsWhenRoomNotFound() {
         // given
         given(chatRoomRepository.findById(999)).willReturn(Optional.empty());
@@ -657,7 +656,7 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("kickMember은 club group room에서도 거부한다")
+    @DisplayName("kickMember는 club group room에서도 거부한다")
     void kickMemberRejectsClubGroupRoom() {
         // given
         ChatRoom clubRoom = createRoom(1, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
@@ -668,7 +667,7 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("kickMember은 요청자가 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    @DisplayName("kickMember는 요청자가 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
     void kickMemberThrowsWhenRequesterNotMember() {
         // given
         Integer requesterId = 10;
@@ -685,7 +684,7 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("kickMember은 target이 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    @DisplayName("kickMember는 target이 멤버가 아니면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
     void kickMemberThrowsWhenTargetNotMember() {
         // given
         Integer requesterId = 10;
@@ -847,7 +846,7 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("sendMessage는 group room에서 나간 멤버가 보내면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
+    @DisplayName("sendMessage는 group room 멤버의 hasLeft 상태면 FORBIDDEN_CHAT_ROOM_ACCESS를 던진다")
     void sendMessageInGroupRoomRejectsLeftMember() {
         // given
         Integer senderId = 10;
@@ -855,7 +854,8 @@ class ChatServiceTest extends ServiceTestSupport {
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember leftMember = createRoomMember(groupRoom, sender, false,
             LocalDateTime.of(2026, 4, 11, 10, 0));
-        leftMember.leaveDirectRoom(LocalDateTime.of(2026, 4, 11, 12, 0));
+        ReflectionTestUtils.setField(leftMember, "leftAt", LocalDateTime.of(2026, 4, 11, 12, 0));
+        ReflectionTestUtils.setField(leftMember, "visibleMessageFrom", LocalDateTime.of(2026, 4, 11, 12, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
@@ -1085,10 +1085,6 @@ class ChatServiceTest extends ServiceTestSupport {
         return message;
     }
 
-    private void setCreatedAt(Object target, LocalDateTime createdAt) {
-        ReflectionTestUtils.setField(target, "createdAt", createdAt);
-        ReflectionTestUtils.setField(target, "updatedAt", createdAt);
-    }
 
     private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
         assertThatThrownBy(callable)

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -197,6 +197,7 @@ class ChatServiceTest extends ServiceTestSupport {
         verify(chatRoomMemberRepository, never()).findByChatRoomIdAndUserId(room.getId(), adminUserId);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("createGroupChatRoom은 초대 대상을 dedup 하고 자기 자신을 제외한 뒤 owner/member를 저장한다")
     void createGroupChatRoomDeduplicatesInviteesAndSavesMembers() {
@@ -296,37 +297,72 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("kickMember는 비그룹방, self kick, 방장 아님, owner target을 각각 거부한다")
-    void kickMemberRejectsInvalidRequests() {
+    @DisplayName("kickMember는 비그룹방에서 멤버 강퇴를 거부한다")
+    void kickMemberRejectsNonGroupRoom() {
         // given
         Integer requesterId = 10;
         Integer targetId = 20;
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
-        ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
-        ChatRoomMember nonOwnerRequester = createRoomMember(groupRoom, createUser(requesterId, "요청자", UserRole.USER),
-            false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
-        ChatRoomMember ownerTarget = createRoomMember(groupRoom, createUser(targetId, "방장", UserRole.USER), true,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
-        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
-        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-            .willReturn(Optional.of(nonOwnerRequester));
-        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
-            .willReturn(Optional.of(ownerTarget));
 
         // when & then
         assertErrorCode(() -> chatService.kickMember(requesterId, directRoom.getId(), targetId),
             CANNOT_KICK_IN_NON_GROUP_ROOM);
+    }
+
+    @Test
+    @DisplayName("kickMember는 자기 자신을 강퇴할 수 없다")
+    void kickMemberRejectsSelfKick() {
+        // given
+        Integer requesterId = 10;
+        ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+
+        // when & then
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), requesterId), CANNOT_KICK_SELF);
+    }
+
+    @Test
+    @DisplayName("kickMember는 방장이 아닌 요청자의 강퇴를 거부한다")
+    void kickMemberRejectsNonOwnerRequester() {
+        // given
+        Integer requesterId = 10;
+        Integer targetId = 20;
+        ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember nonOwnerRequester = createRoomMember(groupRoom, createUser(requesterId, "요청자", UserRole.USER),
+            false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
+            .willReturn(Optional.of(nonOwnerRequester));
+
+        // when & then
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId),
             FORBIDDEN_CHAT_ROOM_KICK);
+    }
 
+    @Test
+    @DisplayName("kickMember는 방장을 강퇴할 수 없다")
+    void kickMemberRejectsOwnerTarget() {
+        // given
+        Integer requesterId = 10;
+        Integer targetId = 20;
+        ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember ownerRequester = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
             LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember ownerTarget = createRoomMember(groupRoom, createUser(targetId, "대상 방장", UserRole.USER), true,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
             .willReturn(Optional.of(ownerRequester));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
+            .willReturn(Optional.of(ownerTarget));
+
+        // when & then
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), CANNOT_KICK_ROOM_OWNER);
     }
 
@@ -1055,6 +1091,7 @@ class ChatServiceTest extends ServiceTestSupport {
             case DIRECT -> ChatRoom.directOf();
             case GROUP -> ChatRoom.groupOf();
             case CLUB_GROUP -> ChatRoom.clubGroupOf(ClubFixture.createWithId(UniversityFixture.createWithId(1), 77));
+            default -> throw new IllegalArgumentException("Unsupported ChatType: " + type);
         };
         ReflectionTestUtils.setField(room, "id", id);
         ReflectionTestUtils.setField(room, "createdAt", createdAt);

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -120,8 +120,8 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // when & then
         assertErrorCode(
-            () -> chatService.createOrGetChatRoom(userId, new ChatRoomCreateRequest(userId)),
-            CANNOT_CREATE_CHAT_ROOM_WITH_SELF
+                () -> chatService.createOrGetChatRoom(userId, new ChatRoomCreateRequest(userId)),
+                CANNOT_CREATE_CHAT_ROOM_WITH_SELF
         );
         verify(chatRoomRepository, never()).save(any(ChatRoom.class));
     }
@@ -136,20 +136,20 @@ class ChatServiceTest extends ServiceTestSupport {
         User targetUser = createUser(targetUserId, "상대", UserRole.USER);
         ChatRoom room = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember requesterMember = createRoomMember(room, currentUser, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ReflectionTestUtils.setField(requesterMember, "leftAt", LocalDateTime.of(2026, 4, 11, 11, 0));
         ReflectionTestUtils.setField(requesterMember, "visibleMessageFrom", LocalDateTime.of(2026, 4, 11, 11, 0));
         ChatRoomMember targetMember = createRoomMember(room, targetUser, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(userRepository.getById(currentUserId)).willReturn(currentUser);
         given(userRepository.getById(targetUserId)).willReturn(targetUser);
         given(chatRoomRepository.findByTwoUsers(currentUserId, targetUserId, ChatType.DIRECT))
-            .willReturn(Optional.of(room));
+                .willReturn(Optional.of(room));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), currentUserId))
-            .willReturn(Optional.of(requesterMember));
+                .willReturn(Optional.of(requesterMember));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), targetUserId))
-            .willReturn(Optional.of(targetMember));
+                .willReturn(Optional.of(targetMember));
 
         // when
         ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(targetUserId));
@@ -175,18 +175,18 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(adminUserId)).willReturn(adminUser);
         given(userRepository.getById(targetUserId)).willReturn(targetUser);
         given(chatRoomRepository.findByTwoUsers(SYSTEM_ADMIN_ID, targetUserId, ChatType.DIRECT))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
         given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(room);
         given(userRepository.getById(SYSTEM_ADMIN_ID)).willReturn(systemAdmin);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), SYSTEM_ADMIN_ID))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), targetUserId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
         given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(room.getId())))
-            .willReturn(List.of(
-                new Object[]{room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()},
-                new Object[]{room.getId(), targetUserId, room.getCreatedAt()}
-            ));
+                .willReturn(List.of(
+                        new Object[]{room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()},
+                        new Object[]{room.getId(), targetUserId, room.getCreatedAt()}
+                ));
 
         // when
         ChatRoomResponse response = chatService.createOrGetChatRoom(adminUserId, new ChatRoomCreateRequest(targetUserId));
@@ -213,8 +213,8 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // when
         ChatRoomResponse response = chatService.createGroupChatRoom(
-            creatorId,
-            new ChatRoomCreateRequest.Group(List.of(creatorId, 20, 20, 30))
+                creatorId,
+                new ChatRoomCreateRequest.Group(List.of(creatorId, 20, 20, 30))
         );
 
         // then
@@ -223,12 +223,12 @@ class ChatServiceTest extends ServiceTestSupport {
         verify(chatRoomMemberRepository).saveAll(captor.capture());
         assertThat(captor.getValue()).hasSize(3);
         assertThat(captor.getValue())
-            .extracting(ChatRoomMember::getUserId, ChatRoomMember::isOwner)
-            .containsExactlyInAnyOrder(
-                org.assertj.core.groups.Tuple.tuple(creatorId, true),
-                org.assertj.core.groups.Tuple.tuple(20, false),
-                org.assertj.core.groups.Tuple.tuple(30, false)
-            );
+                .extracting(ChatRoomMember::getUserId, ChatRoomMember::isOwner)
+                .containsExactlyInAnyOrder(
+                        org.assertj.core.groups.Tuple.tuple(creatorId, true),
+                        org.assertj.core.groups.Tuple.tuple(20, false),
+                        org.assertj.core.groups.Tuple.tuple(30, false)
+                );
     }
 
     @Test
@@ -242,12 +242,12 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // when & then
         assertErrorCode(
-            () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(creatorId))),
-            CANNOT_CREATE_CHAT_ROOM_WITH_SELF
+                () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(creatorId))),
+                CANNOT_CREATE_CHAT_ROOM_WITH_SELF
         );
         assertErrorCode(
-            () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(20, 30))),
-            NOT_FOUND_USER
+                () -> chatService.createGroupChatRoom(creatorId, new ChatRoomCreateRequest.Group(List.of(20, 30))),
+                NOT_FOUND_USER
         );
     }
 
@@ -259,12 +259,12 @@ class ChatServiceTest extends ServiceTestSupport {
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoom clubRoom = createClubRoom(2, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember directMember = createRoomMember(directRoom, createUser(userId, "사용자", UserRole.USER), false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
-            .willReturn(Optional.of(directMember));
+                .willReturn(Optional.of(directMember));
 
         // when
         chatService.leaveChatRoom(userId, directRoom.getId());
@@ -282,11 +282,11 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer userId = 10;
         ChatRoom groupRoom = createRoom(3, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(groupRoom, createUser(userId, "사용자", UserRole.USER), false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-            .willReturn(Optional.of(member));
+                .willReturn(Optional.of(member));
 
         // when
         chatService.leaveChatRoom(userId, groupRoom.getId());
@@ -304,16 +304,16 @@ class ChatServiceTest extends ServiceTestSupport {
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember nonOwnerRequester = createRoomMember(groupRoom, createUser(requesterId, "요청자", UserRole.USER), false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember ownerTarget = createRoomMember(groupRoom, createUser(targetId, "방장", UserRole.USER), true,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-            .willReturn(Optional.of(nonOwnerRequester));
+                .willReturn(Optional.of(nonOwnerRequester));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
-            .willReturn(Optional.of(ownerTarget));
+                .willReturn(Optional.of(ownerTarget));
 
         // when & then
         assertErrorCode(() -> chatService.kickMember(requesterId, directRoom.getId(), targetId), CANNOT_KICK_IN_NON_GROUP_ROOM);
@@ -321,9 +321,9 @@ class ChatServiceTest extends ServiceTestSupport {
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_KICK);
 
         ChatRoomMember ownerRequester = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-            .willReturn(Optional.of(ownerRequester));
+                .willReturn(Optional.of(ownerRequester));
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), CANNOT_KICK_ROOM_OWNER);
     }
 
@@ -335,15 +335,15 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer targetId = 20;
         ChatRoom groupRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember ownerRequester = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember target = createRoomMember(groupRoom, createUser(targetId, "멤버", UserRole.USER), false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-            .willReturn(Optional.of(ownerRequester));
+                .willReturn(Optional.of(ownerRequester));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
-            .willReturn(Optional.of(target));
+                .willReturn(Optional.of(target));
 
         // when
         chatService.kickMember(requesterId, groupRoom.getId(), targetId);
@@ -367,7 +367,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
         given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
-            .willReturn(Optional.of(setting));
+                .willReturn(Optional.of(setting));
 
         // when
         ChatMuteResponse response = chatService.toggleMute(userId, roomId);
@@ -393,7 +393,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
         given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
-            .willReturn(Optional.of(setting));
+                .willReturn(Optional.of(setting));
 
         // when
         ChatMuteResponse response = chatService.toggleMute(userId, roomId);
@@ -418,7 +418,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
         given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when
         ChatMuteResponse response = chatService.toggleMute(userId, roomId);
@@ -443,7 +443,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId())).willReturn(List.of(directMember));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId)).willReturn(Optional.of(directMember));
         given(chatMessageRepository.findByChatRoomId(eq(directRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-            .willReturn(new PageImpl<>(List.of(directMessage), PageRequest.of(0, 20), 1));
+                .willReturn(new PageImpl<>(List.of(directMessage), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(userId, directRoom.getId(), 1, 20);
@@ -469,7 +469,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomId(clubRoom.getId())).willReturn(List.of(clubRoomMember));
         given(chatMessageRepository.countByChatRoomId(clubRoom.getId(), null)).willReturn(1L);
         given(chatMessageRepository.findByChatRoomId(eq(clubRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-            .willReturn(new PageImpl<>(List.of(clubMessage), PageRequest.of(0, 20), 1));
+                .willReturn(new PageImpl<>(List.of(clubMessage), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(userId, clubRoom.getId(), 1, 20);
@@ -497,7 +497,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId())).willReturn(List.of(groupMember));
         given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(1L);
         given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-            .willReturn(new PageImpl<>(List.of(groupMessage), PageRequest.of(0, 20), 1));
+                .willReturn(new PageImpl<>(List.of(groupMessage), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20);
@@ -520,8 +520,8 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // when & then
         assertErrorCode(
-            () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20),
-            FORBIDDEN_CHAT_ROOM_ACCESS
+                () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20),
+                FORBIDDEN_CHAT_ROOM_ACCESS
         );
     }
 
@@ -540,12 +540,12 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(currentUserId)).willReturn(currentUser);
         given(userRepository.getById(targetUserId)).willReturn(targetUser);
         given(chatRoomRepository.findByTwoUsers(currentUserId, targetUserId, ChatType.DIRECT))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
         given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(newRoom);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(newRoom.getId(), currentUserId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(newRoom.getId(), targetUserId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when
         ChatRoomResponse response = chatService.createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(targetUserId));
@@ -571,11 +571,11 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(adminId1)).willReturn(admin1);
         given(userRepository.getById(adminId2)).willReturn(admin2);
         given(chatRoomRepository.findByTwoUsers(adminId1, adminId2, ChatType.DIRECT))
-            .willReturn(Optional.of(room));
+                .willReturn(Optional.of(room));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), adminId1))
-            .willReturn(Optional.of(member1));
+                .willReturn(Optional.of(member1));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), adminId2))
-            .willReturn(Optional.of(member2));
+                .willReturn(Optional.of(member2));
 
         // when
         ChatRoomResponse response = chatService.createOrGetChatRoom(adminId1, new ChatRoomCreateRequest(adminId2));
@@ -592,7 +592,7 @@ class ChatServiceTest extends ServiceTestSupport {
     void createOrGetAdminChatRoomThrowsWhenNoAdminExists() {
         // given
         given(userRepository.findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole.ADMIN))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.createOrGetAdminChatRoom(10), NOT_FOUND_USER);
@@ -619,7 +619,7 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.leaveChatRoom(userId, directRoom.getId()), FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -658,7 +658,7 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -672,13 +672,13 @@ class ChatServiceTest extends ServiceTestSupport {
         Integer targetId = 20;
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember owner = createRoomMember(groupRoom, createUser(requesterId, "방장", UserRole.USER), true,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), requesterId))
-            .willReturn(Optional.of(owner));
+                .willReturn(Optional.of(owner));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), targetId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.kickMember(requesterId, groupRoom.getId(), targetId), FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -706,23 +706,23 @@ class ChatServiceTest extends ServiceTestSupport {
         User targetUser = createUser(20, "사용자", UserRole.USER);
         ChatRoom systemAdminRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember systemAdminMember = createRoomMember(systemAdminRoom, systemAdmin, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember targetMember = createRoomMember(systemAdminRoom, targetUser, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage message = createMessage(100, systemAdminRoom, admin, "문의",
-            LocalDateTime.of(2026, 4, 11, 10, 1));
+                LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
         given(userRepository.getById(adminId)).willReturn(admin);
         given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
-            .willReturn(List.of(
-                new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
-                new Object[]{systemAdminRoom.getId(), 20, systemAdminRoom.getCreatedAt()}
-            ));
+                .willReturn(List.of(
+                        new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
+                        new Object[]{systemAdminRoom.getId(), 20, systemAdminRoom.getCreatedAt()}
+                ));
         given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
-            .willReturn(List.of(systemAdminMember, targetMember));
+                .willReturn(List.of(systemAdminMember, targetMember));
         given(chatMessageRepository.findByChatRoomId(eq(systemAdminRoom.getId()), nullable(LocalDateTime.class), eq(PageRequest.of(0, 20))))
-            .willReturn(new PageImpl<>(List.of(message), PageRequest.of(0, 20), 1));
+                .willReturn(new PageImpl<>(List.of(message), PageRequest.of(0, 20), 1));
 
         // when
         ChatMessagePageResponse response = chatService.getMessages(adminId, systemAdminRoom.getId(), 1, 20);
@@ -755,25 +755,25 @@ class ChatServiceTest extends ServiceTestSupport {
         User receiver = createUser(receiverId, "받는이", UserRole.USER);
         ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember senderMember = createRoomMember(directRoom, sender, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember receiverMember = createRoomMember(directRoom, receiver, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, directRoom, sender, "hello",
-            LocalDateTime.of(2026, 4, 11, 10, 1));
+                LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), senderId))
-            .willReturn(Optional.of(senderMember));
+                .willReturn(Optional.of(senderMember));
         given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId()))
-            .willReturn(List.of(senderMember, receiverMember));
+                .willReturn(List.of(senderMember, receiverMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
         given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(directRoom.getId()), eq(senderId), any(LocalDateTime.class)))
-            .willReturn(1);
+                .willReturn(1);
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(senderId, directRoom.getId(),
-            new ChatMessageSendRequest("hello"));
+                new ChatMessageSendRequest("hello"));
 
         // then
         assertThat(response.messageId()).isEqualTo(savedMessage.getId());
@@ -792,31 +792,31 @@ class ChatServiceTest extends ServiceTestSupport {
         User sender = createUser(senderId, "보낸이", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember senderMember = createRoomMember(groupRoom, sender, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, groupRoom, sender, "hello",
-            LocalDateTime.of(2026, 4, 11, 10, 1));
+                LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), senderId))
-            .willReturn(Optional.of(senderMember));
+                .willReturn(Optional.of(senderMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
         given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(groupRoom.getId()), eq(senderId), any(LocalDateTime.class)))
-            .willReturn(1);
+                .willReturn(1);
         given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId()))
-            .willReturn(List.of(senderMember));
+                .willReturn(List.of(senderMember));
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(senderId, groupRoom.getId(),
-            new ChatMessageSendRequest("hello"));
+                new ChatMessageSendRequest("hello"));
 
         // then
         assertThat(response.messageId()).isEqualTo(savedMessage.getId());
         assertThat(response.content()).isEqualTo("hello");
         assertThat(response.isMine()).isTrue();
         verify(notificationService).sendGroupChatNotification(
-            eq(groupRoom.getId()), eq(senderId), eq("그룹 채팅"), eq("보낸이"), eq("hello"),
-            any(List.class)
+                eq(groupRoom.getId()), eq(senderId), eq("그룹 채팅"), eq("보낸이"), eq("hello"),
+                any(List.class)
         );
     }
 
@@ -828,18 +828,18 @@ class ChatServiceTest extends ServiceTestSupport {
         User sender = createUser(senderId, "보낸이", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember leftMember = createRoomMember(groupRoom, sender, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         leftMember.leaveDirectRoom(LocalDateTime.of(2026, 4, 11, 12, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(senderId)).willReturn(sender);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), senderId))
-            .willReturn(Optional.of(leftMember));
+                .willReturn(Optional.of(leftMember));
 
         // when & then
         assertErrorCode(
-            () -> chatService.sendMessage(senderId, groupRoom.getId(), new ChatMessageSendRequest("hello")),
-            FORBIDDEN_CHAT_ROOM_ACCESS
+                () -> chatService.sendMessage(senderId, groupRoom.getId(), new ChatMessageSendRequest("hello")),
+                FORBIDDEN_CHAT_ROOM_ACCESS
         );
         verify(chatMessageRepository, never()).save(any(ChatMessage.class));
     }
@@ -857,30 +857,30 @@ class ChatServiceTest extends ServiceTestSupport {
         ClubMember clubMember = ClubMemberFixture.createMember(club, sender);
         ReflectionTestUtils.setField(clubMember, "createdAt", LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember senderRoomMember = createRoomMember(clubRoom, sender, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, clubRoom, sender, "hello",
-            LocalDateTime.of(2026, 4, 11, 10, 1));
+                LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(clubRoom.getId())).willReturn(Optional.of(clubRoom));
         given(clubMemberRepository.getByClubIdAndUserId(club.getId(), senderId)).willReturn(clubMember);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(clubRoom.getId(), senderId))
-            .willReturn(Optional.of(senderRoomMember));
+                .willReturn(Optional.of(senderRoomMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
         given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(clubRoom.getId()), eq(senderId), any(LocalDateTime.class)))
-            .willReturn(1);
+                .willReturn(1);
         given(chatRoomMemberRepository.findByChatRoomId(clubRoom.getId()))
-            .willReturn(List.of(senderRoomMember));
+                .willReturn(List.of(senderRoomMember));
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(senderId, clubRoom.getId(),
-            new ChatMessageSendRequest("hello"));
+                new ChatMessageSendRequest("hello"));
 
         // then
         assertThat(response.messageId()).isEqualTo(savedMessage.getId());
         assertThat(response.content()).isEqualTo("hello");
         verify(notificationService).sendGroupChatNotification(
-            eq(clubRoom.getId()), eq(senderId), eq("BCSD"), eq("보낸이"), eq("hello"),
-            any(List.class)
+                eq(clubRoom.getId()), eq(senderId), eq("BCSD"), eq("보낸이"), eq("hello"),
+                any(List.class)
         );
     }
 
@@ -895,26 +895,26 @@ class ChatServiceTest extends ServiceTestSupport {
         User targetUser = createUser(targetUserId, "사용자", UserRole.USER);
         ChatRoom systemAdminRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember systemAdminMember = createRoomMember(systemAdminRoom, systemAdmin, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember targetMember = createRoomMember(systemAdminRoom, targetUser, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatMessage savedMessage = createMessage(100, systemAdminRoom, admin, "문의",
-            LocalDateTime.of(2026, 4, 11, 10, 1));
+                LocalDateTime.of(2026, 4, 11, 10, 1));
 
         given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
         given(userRepository.getById(adminId)).willReturn(admin);
         given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
-            .willReturn(List.of(
-                new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
-                new Object[]{systemAdminRoom.getId(), targetUserId, systemAdminRoom.getCreatedAt()}
-            ));
+                .willReturn(List.of(
+                        new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
+                        new Object[]{systemAdminRoom.getId(), targetUserId, systemAdminRoom.getCreatedAt()}
+                ));
         given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
-            .willReturn(List.of(systemAdminMember, targetMember));
+                .willReturn(List.of(systemAdminMember, targetMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(adminId, systemAdminRoom.getId(),
-            new ChatMessageSendRequest("문의"));
+                new ChatMessageSendRequest("문의"));
 
         // then
         assertThat(response.content()).isEqualTo("문의");
@@ -949,7 +949,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(userId)).willReturn(createUser(userId, "사용자", UserRole.USER));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(() -> chatService.toggleMute(userId, groupRoom.getId()), FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -965,11 +965,11 @@ class ChatServiceTest extends ServiceTestSupport {
         User user = createUser(userId, "사용자", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(groupRoom, user, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-            .willReturn(Optional.of(member));
+                .willReturn(Optional.of(member));
 
         // when
         chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("내 채팅방"));
@@ -987,12 +987,12 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
 
         // when & then
         assertErrorCode(
-            () -> chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("이름")),
-            FORBIDDEN_CHAT_ROOM_ACCESS
+                () -> chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest("이름")),
+                FORBIDDEN_CHAT_ROOM_ACCESS
         );
     }
 
@@ -1004,12 +1004,12 @@ class ChatServiceTest extends ServiceTestSupport {
         User user = createUser(userId, "사용자", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
         ChatRoomMember member = createRoomMember(groupRoom, user, false,
-            LocalDateTime.of(2026, 4, 11, 10, 0));
+                LocalDateTime.of(2026, 4, 11, 10, 0));
         member.updateCustomRoomName("기존 이름");
 
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
-            .willReturn(Optional.of(member));
+                .willReturn(Optional.of(member));
 
         // when
         chatService.updateChatRoomName(userId, groupRoom.getId(), new ChatRoomNameUpdateRequest(null));
@@ -1061,7 +1061,7 @@ class ChatServiceTest extends ServiceTestSupport {
 
     private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
         assertThatThrownBy(callable)
-            .isInstanceOf(CustomException.class)
-            .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(errorCode));
+                .isInstanceOf(CustomException.class)
+                .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(errorCode));
     }
 }

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -353,8 +353,8 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("toggleMute는 기존 setting이 있으면 토글하고 없으면 muted=true 로 저장한다")
-    void toggleMuteTogglesExistingSettingOrCreatesNewOne() {
+    @DisplayName("toggleMute는 기존 setting이 false면 true로 토글한다")
+    void toggleMuteTogglesFromUnmutedToMuted() {
         // given
         Integer userId = 10;
         Integer roomId = 1;
@@ -367,16 +367,65 @@ class ChatServiceTest extends ServiceTestSupport {
         given(userRepository.getById(userId)).willReturn(user);
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
         given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
-            .willReturn(Optional.of(setting), Optional.empty());
+            .willReturn(Optional.of(setting));
 
         // when
-        ChatMuteResponse toggled = chatService.toggleMute(userId, roomId);
-        ChatMuteResponse created = chatService.toggleMute(userId, roomId);
+        ChatMuteResponse response = chatService.toggleMute(userId, roomId);
 
         // then
-        assertThat(toggled.isMuted()).isTrue();
-        assertThat(created.isMuted()).isTrue();
-        verify(notificationMuteSettingRepository, times(2)).save(any(NotificationMuteSetting.class));
+        assertThat(response.isMuted()).isTrue();
+        assertThat(setting.getIsMuted()).isTrue();
+        verify(notificationMuteSettingRepository).save(setting);
+    }
+
+    @Test
+    @DisplayName("toggleMute는 기존 setting이 true면 false로 토글한다 (unmute)")
+    void toggleMuteTogglesFromMutedToUnmuted() {
+        // given
+        Integer userId = 10;
+        Integer roomId = 1;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom room = createRoom(roomId, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(room, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        NotificationMuteSetting setting = NotificationMuteSetting.of(NotificationTargetType.CHAT_ROOM, roomId, user, true);
+
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
+        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
+            .willReturn(Optional.of(setting));
+
+        // when
+        ChatMuteResponse response = chatService.toggleMute(userId, roomId);
+
+        // then
+        assertThat(response.isMuted()).isFalse();
+        assertThat(setting.getIsMuted()).isFalse();
+        verify(notificationMuteSettingRepository).save(setting);
+    }
+
+    @Test
+    @DisplayName("toggleMute는 기존 setting이 없으면 muted=true로 저장한다")
+    void toggleMuteCreatesNewMutedSettingWhenNoneExists() {
+        // given
+        Integer userId = 10;
+        Integer roomId = 1;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom room = createRoom(roomId, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(room, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(member));
+        given(notificationMuteSettingRepository.findByTargetTypeAndTargetIdAndUserId(NotificationTargetType.CHAT_ROOM, roomId, userId))
+            .willReturn(Optional.empty());
+
+        // when
+        ChatMuteResponse response = chatService.toggleMute(userId, roomId);
+
+        // then
+        assertThat(response.isMuted()).isTrue();
+        verify(notificationMuteSettingRepository).save(any(NotificationMuteSetting.class));
     }
 
     @Test
@@ -833,6 +882,49 @@ class ChatServiceTest extends ServiceTestSupport {
             eq(clubRoom.getId()), eq(senderId), eq("BCSD"), eq("보낸이"), eq("hello"),
             any(List.class)
         );
+    }
+
+    @Test
+    @DisplayName("sendMessage는 admin이 system admin room에 보내면 멤버십 체크를 건너뛰고 lastReadAt 업데이트도 하지 않는다")
+    void sendMessageAdminBypassesMembershipInSystemAdminRoom() {
+        // given
+        Integer adminId = 99;
+        Integer targetUserId = 20;
+        User admin = createUser(adminId, "관리자", UserRole.ADMIN);
+        User systemAdmin = createUser(SYSTEM_ADMIN_ID, "시스템관리자", UserRole.ADMIN);
+        User targetUser = createUser(targetUserId, "사용자", UserRole.USER);
+        ChatRoom systemAdminRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember systemAdminMember = createRoomMember(systemAdminRoom, systemAdmin, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember targetMember = createRoomMember(systemAdminRoom, targetUser, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage savedMessage = createMessage(100, systemAdminRoom, admin, "문의",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
+        given(userRepository.getById(adminId)).willReturn(admin);
+        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
+            .willReturn(List.of(
+                new Object[]{systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
+                new Object[]{systemAdminRoom.getId(), targetUserId, systemAdminRoom.getCreatedAt()}
+            ));
+        given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
+            .willReturn(List.of(systemAdminMember, targetMember));
+        given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+
+        // when
+        ChatMessageDetailResponse response = chatService.sendMessage(adminId, systemAdminRoom.getId(),
+            new ChatMessageSendRequest("문의"));
+
+        // then
+        assertThat(response.content()).isEqualTo("문의");
+        assertThat(response.isMine()).isTrue();
+        // 멤버십 조회를 건너뛰어야 한다
+        verify(chatRoomMemberRepository, never()).findByChatRoomIdAndUserId(systemAdminRoom.getId(), adminId);
+        // admin은 lastReadAt 업데이트를 하지 않는다
+        verify(chatRoomMemberRepository, never()).updateLastReadAtIfOlder(eq(systemAdminRoom.getId()), eq(adminId), any(LocalDateTime.class));
+        // 비관리자에게 알림이 전송되어야 한다
+        verify(notificationService).sendChatNotification(eq(targetUserId), eq(systemAdminRoom.getId()), eq("관리자"), eq("문의"));
     }
 
     // ===== toggleMute additional =====


### PR DESCRIPTION
### 🔍 개요

- ChatService의 단위 테스트 커버리지를 보강 (14개 → 38개 테스트)
- sendMessage, updateChatRoomName, createOrGetAdminChatRoom 등 기존 미테스트 메서드 전면 커버
- Codex adversarial review로 발견된 취약점(admin system admin room bypass, toggleMute unmute 경로) 추가 보강

- close #523 

---

### 🚀 주요 변경 내용

- **sendMessage 테스트 추가** (6개): direct/group/club/admin-system-admin-room 경로, 방 미존재, 탈퇴 멤버 거부, admin 멤버십 bypass 검증
- **createOrGetChatRoom 테스트 추가** (4개): 신규 방 생성, admin→admin 일반 경로, admin→user system admin room 경로, 기존 방 재사용 시 멤버십 복구
- **createOrGetAdminChatRoom 테스트 추가** (1개): admin 미존재 시 에러
- **leaveChatRoom 테스트 추가** (3개): 방 미존재, 비멤버 거부, club room 거부, group room 멤버십 삭제
- **kickMember 테스트 추가** (5개): 방 미존재, club room 거부, 요청자/대상 비멤버, 유효 요청 시 삭제
- **getMessages 테스트 추가** (5개): direct/group/club 각 경로, 방 미존재, 그룹 비회원 거부, admin system room
- **toggleMute 테스트 추가** (5개): mute/unmute/신규 생성, 방 미존재, 그룹 비멤버 거부, direct 비멤버 거부
- **updateChatRoomName 테스트 추가** (3개): 정상 업데이트, 비멤버 거부, null/blank 정규화


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
