### PR TITLE
refactor: Lua 스크립트를 Redis GETDEL 네이티브 명령어로 교체

### DIFF
--- a/src/main/java/gg/agit/konect/domain/user/service/SignupTokenService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/SignupTokenService.java
@@ -1,10 +1,8 @@
 package gg.agit.konect.domain.user.service;
 
 import java.time.Duration;
-import java.util.List;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -25,14 +23,6 @@ public class SignupTokenService {
     private static final int INDEX_NAME = 3;
     private static final int EXPECTED_PARTS_WITHOUT_NAME = 3;
     private static final int EXPECTED_PARTS_WITH_NAME = 4;
-
-    private static final DefaultRedisScript<String> GET_DEL_SCRIPT =
-        new DefaultRedisScript<>(
-            "local v = redis.call('GET', KEYS[1]); " +
-                "if v then redis.call('DEL', KEYS[1]); end; " +
-                "return v;",
-            String.class
-        );
 
     private final StringRedisTemplate redis;
     private final SecureTokenGenerator secureTokenGenerator;
@@ -76,7 +66,7 @@ public class SignupTokenService {
             throw CustomException.of(ApiResponseCode.INVALID_SIGNUP_TOKEN);
         }
 
-        String value = redis.execute(GET_DEL_SCRIPT, List.of(key(token)));
+        String value = redis.opsForValue().getAndDelete(key(token));
         SignupClaims claims = deserialize(value);
         if (claims == null) {
             throw CustomException.of(ApiResponseCode.INVALID_SIGNUP_TOKEN);

--- a/src/main/java/gg/agit/konect/global/auth/oauth/NativeSessionBridgeService.java
+++ b/src/main/java/gg/agit/konect/global/auth/oauth/NativeSessionBridgeService.java
@@ -1,11 +1,9 @@
 package gg.agit.konect.global.auth.oauth;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
@@ -18,13 +16,6 @@ public class NativeSessionBridgeService {
 
     private static final String KEY_PREFIX = "native:session-bridge:";
     private static final Duration TTL = Duration.ofSeconds(30);
-    private static final DefaultRedisScript<String> GET_DEL_SCRIPT =
-        new DefaultRedisScript<>(
-            "local v = redis.call('GET', KEYS[1]); " +
-                "if v then redis.call('DEL', KEYS[1]); end; " +
-                "return v;",
-            String.class
-        );
 
     private final StringRedisTemplate redis;
     private final SecureTokenGenerator secureTokenGenerator;
@@ -46,7 +37,7 @@ public class NativeSessionBridgeService {
         }
 
         String key = KEY_PREFIX + token;
-        String value = redis.execute(GET_DEL_SCRIPT, List.of(key));
+        String value = redis.opsForValue().getAndDelete(key);
 
         if (value == null || value.isBlank()) {
             return Optional.empty();

--- a/src/main/java/gg/agit/konect/infrastructure/oauth/GoogleDriveOAuthService.java
+++ b/src/main/java/gg/agit/konect/infrastructure/oauth/GoogleDriveOAuthService.java
@@ -1,11 +1,9 @@
 package gg.agit.konect.infrastructure.oauth;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -41,11 +39,6 @@ public class GoogleDriveOAuthService {
     private static final Duration STATE_TTL = Duration.ofMinutes(10);
     private static final String CALLBACK_PATH = "/auth/oauth/google/drive/callback";
 
-    private static final DefaultRedisScript<String> GET_DEL_SCRIPT = new DefaultRedisScript<>(
-        "local v = redis.call('GET', KEYS[1]); if v then redis.call('DEL', KEYS[1]); end; return v;",
-        String.class
-    );
-
     private final GoogleSheetsProperties googleSheetsProperties;
     private final UserOAuthAccountRepository userOAuthAccountRepository;
     private final RestTemplate restTemplate;
@@ -78,7 +71,7 @@ public class GoogleDriveOAuthService {
         }
 
         String stateKey = STATE_KEY_PREFIX + state;
-        String userIdStr = redis.execute(GET_DEL_SCRIPT, List.of(stateKey));
+        String userIdStr = redis.opsForValue().getAndDelete(stateKey);
 
         if (userIdStr == null || userIdStr.isBlank()) {
             log.warn("Invalid or expired Drive OAuth state. state={}", state);

--- a/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.time.Duration;
 
@@ -126,7 +126,7 @@ class SignupTokenServiceTest extends ServiceTestSupport {
     void consumeOrThrowRejectsBlankTokenWithoutRedisLookup() {
         // when & then
         assertInvalidSignupToken(() -> signupTokenService.consumeOrThrow(" "));
-        verify(redis, never()).opsForValue();
+        verifyNoInteractions(redis);
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
@@ -106,6 +106,7 @@ class SignupTokenServiceTest extends ServiceTestSupport {
         assertThat(claims.provider()).isEqualTo(Provider.KAKAO);
         assertThat(claims.providerId()).isEqualTo("provider-1");
         assertThat(claims.name()).isEqualTo("코넥트");
+        verify(valueOperations).getAndDelete(eq("auth:signup:signup-token"));
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
@@ -2,7 +2,6 @@ package gg.agit.konect.unit.domain.user.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;

--- a/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/user/service/SignupTokenServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
-import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 import gg.agit.konect.domain.user.enums.Provider;
 import gg.agit.konect.domain.user.service.SignupTokenService;
@@ -97,7 +95,8 @@ class SignupTokenServiceTest extends ServiceTestSupport {
     @DisplayName("consumeOrThrow는 토큰을 한 번만 읽고 삭제한다")
     void consumeOrThrowReadsAndDeletesTokenAtomically() {
         // given
-        given(redis.execute(any(DefaultRedisScript.class), eq(List.of("auth:signup:signup-token"))))
+        given(redis.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete("auth:signup:signup-token"))
             .willReturn("user@koreatech.ac.kr|KAKAO|provider-1|코넥트");
 
         // when
@@ -108,7 +107,6 @@ class SignupTokenServiceTest extends ServiceTestSupport {
         assertThat(claims.provider()).isEqualTo(Provider.KAKAO);
         assertThat(claims.providerId()).isEqualTo("provider-1");
         assertThat(claims.name()).isEqualTo("코넥트");
-        verify(redis, never()).opsForValue();
     }
 
     @Test
@@ -128,7 +126,7 @@ class SignupTokenServiceTest extends ServiceTestSupport {
     void consumeOrThrowRejectsBlankTokenWithoutRedisLookup() {
         // when & then
         assertInvalidSignupToken(() -> signupTokenService.consumeOrThrow(" "));
-        verify(redis, never()).execute(any(DefaultRedisScript.class), any());
+        verify(redis, never()).opsForValue();
     }
 
     @Test
@@ -208,7 +206,8 @@ class SignupTokenServiceTest extends ServiceTestSupport {
     @DisplayName("consumeOrThrow는 Redis가 빈 문자열을 반환하면 INVALID_SIGNUP_TOKEN을 던진다")
     void consumeOrThrowRejectsEmptyStringFromRedis() {
         // given
-        given(redis.execute(any(DefaultRedisScript.class), eq(List.of("auth:signup:token"))))
+        given(redis.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete("auth:signup:token"))
             .willReturn("");
 
         // when & then
@@ -265,7 +264,8 @@ class SignupTokenServiceTest extends ServiceTestSupport {
     @DisplayName("consumeOrThrow는 4파라미터 issue로 생성된 토큰에서 name을 복원한다")
     void consumeOrThrowRestoresNameFromFourParameterIssue() {
         // given
-        given(redis.execute(any(DefaultRedisScript.class), eq(List.of("auth:signup:signup-token"))))
+        given(redis.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete("auth:signup:signup-token"))
             .willReturn("user@koreatech.ac.kr|GOOGLE|provider-123|홍길동");
 
         // when


### PR DESCRIPTION
### 🔍 개요

* 조회와 삭제를 원자적으로 연산하기 위해 사용한 `Lua` 스크립트를 네이티브 명령어인 `GETDEL`로 교체

*` Redis 6.2+` 버전부터 지원하는 기능이며, 현재 프로젝트는 레디스 7.0.8 버전을 사용하므로 위 작업을 진행함


---

### 🚀 주요 변경 내용

* 


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
