### PR TITLE
fix: PR 커버리지 워크플로우가 변경 파일을 감지하지 못하는 문제 수정

### DIFF
--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout PR code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up JDK 21


### PR DESCRIPTION
### 🔍 개요

  - pull_request_target에서 ref 미지정 시 base 브랜치를 체크아웃하여 git diff 시 변경 파일이 0개로 나오는 현상 방지
  - github.event.pull_request.head.sha를 명시적으로 체크아웃하도록 수정

---

### 🚀 주요 변경 내용

* 


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
