### PR TITLE
feat: 채팅 메시지 검색 결과에서 특정 메시지 시점으로 페이지 이동 기능 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
@@ -131,7 +131,7 @@ public interface ChatApi {
     @Operation(summary = "채팅방 메시지 리스트를 조회한다.", description = """
         ## 설명
         - 특정 채팅방의 메시지 목록을 페이지네이션으로 조회합니다.
-
+        
         ## 로직
         - 채팅방에 진입하면 읽지 않은 메시지를 자동으로 읽음 처리합니다.
         - 최신 메시지가 먼저 오도록 정렬됩니다 (DESC).
@@ -141,7 +141,7 @@ public interface ChatApi {
         - 어드민은 모든 어드민 채팅방을 조회할 수 있습니다.
         - `messageId`가 제공되면 해당 메시지가 포함된 페이지를 자동으로 계산하여 반환합니다.
           검색 결과에서 특정 메시지 위치로 이동할 때 사용합니다.
-
+        
         ## 에러
         - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다.
         - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다. messageId가 유효하지 않은 경우에도 동일합니다.

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
@@ -131,7 +131,7 @@ public interface ChatApi {
     @Operation(summary = "채팅방 메시지 리스트를 조회한다.", description = """
         ## 설명
         - 특정 채팅방의 메시지 목록을 페이지네이션으로 조회합니다.
-        
+
         ## 로직
         - 채팅방에 진입하면 읽지 않은 메시지를 자동으로 읽음 처리합니다.
         - 최신 메시지가 먼저 오도록 정렬됩니다 (DESC).
@@ -139,9 +139,12 @@ public interface ChatApi {
         - 채팅방 참여자만 메시지를 조회할 수 있습니다.
         - 일반 유저는 자신이 참여한 채팅방만 조회할 수 있습니다.
         - 어드민은 모든 어드민 채팅방을 조회할 수 있습니다.
-        
+        - `messageId`가 제공되면 해당 메시지가 포함된 페이지를 자동으로 계산하여 반환합니다.
+          검색 결과에서 특정 메시지 위치로 이동할 때 사용합니다.
+
         ## 에러
         - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다.
+        - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다. messageId가 유효하지 않은 경우에도 동일합니다.
         """)
     @GetMapping("/rooms/{chatRoomId}")
     ResponseEntity<ChatMessagePageResponse> getChatRoomMessages(
@@ -150,7 +153,8 @@ public interface ChatApi {
         @Min(value = 1, message = "페이지 당 항목 수는 1 이상이어야 합니다.")
         @RequestParam(name = "limit", defaultValue = "20", required = false) Integer limit,
         @PathVariable(value = "chatRoomId") Integer chatRoomId,
-        @UserId Integer userId
+        @UserId Integer userId,
+        @RequestParam(name = "messageId", required = false) Integer messageId
     );
 
     @Operation(summary = "메시지를 전송한다.", description = """

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
@@ -143,8 +143,9 @@ public interface ChatApi {
           검색 결과에서 특정 메시지 위치로 이동할 때 사용합니다.
         
         ## 에러
-        - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다.
-        - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다. messageId가 유효하지 않은 경우에도 동일합니다.
+        - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다 (messageId가 없는 일반 조회 시).
+        - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다.
+          messageId가 제공된 경우, 메시지가 유효하지 않거나 접근 권한이 없거나 가시성 경계를 벗어난 경우에도 모두 404로 통일 응답됩니다.
         """)
     @GetMapping("/rooms/{chatRoomId}")
     ResponseEntity<ChatMessagePageResponse> getChatRoomMessages(

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
@@ -85,9 +85,10 @@ public class ChatController implements ChatApi {
         @RequestParam(name = "page", defaultValue = "1") Integer page,
         @RequestParam(name = "limit", defaultValue = "20", required = false) Integer limit,
         @PathVariable(value = "chatRoomId") Integer chatRoomId,
-        @UserId Integer userId
+        @UserId Integer userId,
+        @RequestParam(name = "messageId", required = false) Integer messageId
     ) {
-        ChatMessagePageResponse response = chatService.getMessages(userId, chatRoomId, page, limit);
+        ChatMessagePageResponse response = chatService.getMessages(userId, chatRoomId, page, limit, messageId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessageMatchResult.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessageMatchResult.java
@@ -29,7 +29,10 @@ public record ChatMessageMatchResult(
 
     @Schema(description = "매칭된 메시지 전송 시간", example = "2025.12.19 23:21", requiredMode = REQUIRED)
     @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
-    LocalDateTime matchedMessageSentAt
+    LocalDateTime matchedMessageSentAt,
+
+    @Schema(description = "검색에 매칭된 메시지 ID", example = "42", requiredMode = REQUIRED)
+    Integer matchedMessageId
 ) {
 
     public static ChatMessageMatchResult from(ChatRoomSummaryResponse room, ChatMessage message) {
@@ -39,7 +42,8 @@ public record ChatMessageMatchResult(
             room.roomName(),
             room.roomImageUrl(),
             message.getContent(),
-            message.getCreatedAt()
+            message.getCreatedAt(),
+            message.getId()
         );
     }
 }

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageRepository.java
@@ -2,6 +2,7 @@ package gg.agit.konect.domain.chat.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,13 +36,15 @@ public interface ChatMessageRepository extends Repository<ChatMessage, Integer> 
         @Param("receiverId") Integer receiverId
     );
 
+    // ORDER BY는 countNewerMessagesByChatRoomId의 WHERE 조건과
+    // 일치해야 함. 페이지 계산 정확도가 두 쿼리의 정렬 일관성에 의존함.
     @Query("""
         SELECT cm
         FROM ChatMessage cm
         JOIN FETCH cm.sender
         WHERE cm.chatRoom.id = :chatRoomId
           AND (:visibleMessageFrom IS NULL OR cm.createdAt > :visibleMessageFrom)
-        ORDER BY cm.createdAt DESC
+        ORDER BY cm.createdAt DESC, cm.id DESC
         """)
     Page<ChatMessage> findByChatRoomId(
         @Param("chatRoomId") Integer chatRoomId,
@@ -138,6 +141,25 @@ public interface ChatMessageRepository extends Repository<ChatMessage, Integer> 
     List<ChatMessage> searchLatestMatchingMessagesByChatRoomIds(
         @Param("roomIds") List<Integer> roomIds,
         @Param("keyword") String keyword
+    );
+
+    @Query("SELECT cm FROM ChatMessage cm JOIN FETCH cm.chatRoom WHERE cm.id = :messageId")
+    Optional<ChatMessage> findByIdWithChatRoom(@Param("messageId") Integer messageId);
+
+    // ORDER BY 기준이 findByChatRoomId와 일치해야 함 (createdAt DESC, id DESC).
+    // 페이지 계산 정확도가 두 쿼리의 정렬 일관성에 의존함.
+    @Query("""
+        SELECT COUNT(m)
+        FROM ChatMessage m
+        WHERE m.chatRoom.id = :chatRoomId
+          AND (m.createdAt > :createdAt OR (m.createdAt = :createdAt AND m.id > :messageId))
+          AND (:visibleMessageFrom IS NULL OR m.createdAt > :visibleMessageFrom)
+        """)
+    long countNewerMessagesByChatRoomId(
+        @Param("chatRoomId") Integer chatRoomId,
+        @Param("messageId") Integer messageId,
+        @Param("createdAt") LocalDateTime createdAt,
+        @Param("visibleMessageFrom") LocalDateTime visibleMessageFrom
     );
 
     @Query("""

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1478,6 +1478,10 @@ public class ChatService {
     private int resolvePageForMessage(
         Integer roomId, Integer messageId, ChatRoom room, User user, int limit
     ) {
+        if (limit <= 0) {
+            throw new IllegalArgumentException("limit must be positive");
+        }
+
         ChatMessage targetMessage = chatMessageRepository.findByIdWithChatRoom(messageId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1478,10 +1478,6 @@ public class ChatService {
     private int resolvePageForMessage(
         Integer roomId, Integer messageId, ChatRoom room, User user, int limit
     ) {
-        if (limit <= 0) {
-            throw new IllegalArgumentException("limit must be positive");
-        }
-
         ChatMessage targetMessage = chatMessageRepository.findByIdWithChatRoom(messageId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -406,23 +406,7 @@ public class ChatService {
         }
 
         LocalDateTime readAt = LocalDateTime.now();
-        ChatMessagePageResponse response = fetchMessagesByRoomType(
-            room, user, userId, roomId, page, limit, readAt);
 
-        // 동시 삽입으로 타겟 메시지가 응답에서 빠진 경우 페이지 재계산 후 1회 재시도
-        if (messageId != null && response.messages().stream()
-            .noneMatch(m -> m.messageId().equals(messageId))) {
-            page = resolvePageForMessage(roomId, messageId, room, user, limit);
-            response = fetchMessagesByRoomType(
-                room, user, userId, roomId, page, limit, readAt);
-        }
-
-        return response;
-    }
-
-    private ChatMessagePageResponse fetchMessagesByRoomType(
-        ChatRoom room, User user, Integer userId, Integer roomId, int page, int limit, LocalDateTime readAt
-    ) {
         if (room.isDirectRoom()) {
             boolean isAdminViewingSystemRoom = user.isAdmin() && isSystemAdminRoom(room);
             if (isAdminViewingSystemRoom) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1458,7 +1458,11 @@ public class ChatService {
             try {
                 clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), userId);
             } catch (CustomException e) {
-                throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+                // 동아리 멤버십 없음만 404로 변환, 다른 예외는 그대로 전파
+                if (e.getErrorCode() == NOT_FOUND_CLUB_MEMBER) {
+                    throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+                }
+                throw e;
             }
         } else {
             chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), userId)

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -389,9 +389,21 @@ public class ChatService {
 
     @Transactional(readOnly = true)
     public ChatMessagePageResponse getMessages(Integer userId, Integer roomId, Integer page, Integer limit) {
+        return getMessages(userId, roomId, page, limit, null);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatMessagePageResponse getMessages(
+        Integer userId, Integer roomId, Integer page, Integer limit, Integer messageId
+    ) {
         ChatRoom room = chatRoomRepository.findById(roomId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
         User user = userRepository.getById(userId);
+
+        if (messageId != null) {
+            ensureMessageLookupAccess(room, user, userId);
+            page = resolvePageForMessage(roomId, messageId, room, user, limit);
+        }
 
         LocalDateTime readAt = LocalDateTime.now();
 
@@ -1427,6 +1439,81 @@ public class ChatService {
             .toList();
 
         return userIds.contains(SYSTEM_ADMIN_ID);
+    }
+
+    /**
+     * messageId 조회 전 방 접근 권한을 검증한다.
+     * 권한 없음과 메시지 미존재를 구분할 수 없게 NOT_FOUND_CHAT_ROOM으로 통일하여
+     * 메시지 존재 여부 오라클을 방지한다.
+     */
+    private void ensureMessageLookupAccess(ChatRoom room, User user, Integer userId) {
+        if (room.isDirectRoom()) {
+            boolean isMember = chatRoomMemberRepository
+                .findByChatRoomIdAndUserId(room.getId(), userId)
+                .isPresent();
+            if (!isMember && !(user.isAdmin() && isSystemAdminRoom(room))) {
+                throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+            }
+        } else if (room.isClubGroupRoom()) {
+            try {
+                clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), userId);
+            } catch (CustomException e) {
+                throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+            }
+        } else {
+            chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), userId)
+                .filter(member -> !member.hasLeft())
+                .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+        }
+    }
+
+    /**
+     * messageId가 가리키는 메시지가 포함된 페이지 번호를 계산한다.
+     * 가시성 검증 및 정보 누출 방지를 위해 동일한 에러 코드를 사용한다.
+     */
+    private int resolvePageForMessage(
+        Integer roomId, Integer messageId, ChatRoom room, User user, int limit
+    ) {
+        ChatMessage targetMessage = chatMessageRepository.findByIdWithChatRoom(messageId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+
+        // 정보 누출 방지를 위해 동일한 에러 코드 사용
+        if (!targetMessage.getChatRoom().getId().equals(roomId)) {
+            throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+        }
+
+        LocalDateTime visibleMessageFrom = resolveVisibleMessageFromPure(room, user);
+
+        if (visibleMessageFrom != null && !targetMessage.getCreatedAt().isAfter(visibleMessageFrom)) {
+            throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+        }
+
+        // NOTE: count와 fetch 사이에 새 메시지가 삽입될 수 있으나,
+        // 검색 메시지 이동 UX에서 1페이지 오차는 허용 가능함
+        long newerCount = chatMessageRepository.countNewerMessagesByChatRoomId(
+            roomId, messageId, targetMessage.getCreatedAt(), visibleMessageFrom
+        );
+        return (int)(newerCount / limit) + 1;
+    }
+
+    /**
+     * 채팅방 타입에 따른 메시지 가시성 기준 시간을 조회한다.
+     * 기존 getMessages() 흐름의 가시성 로직과 동일한 값을 반환하되,
+     * 방 복원 등 부수효과는 발생시키지 않는다.
+     */
+    private LocalDateTime resolveVisibleMessageFromPure(ChatRoom room, User user) {
+        if (!room.isDirectRoom()) {
+            return null;
+        }
+
+        if (user.isAdmin() && isSystemAdminRoom(room)) {
+            List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(room.getId());
+            return resolveAdminSystemRoomVisibleMessageFrom(members);
+        }
+
+        return chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+            .map(ChatRoomMember::getVisibleMessageFrom)
+            .orElse(null);
     }
 
     private boolean shouldDisplayAsOwnMessage(

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -406,7 +406,23 @@ public class ChatService {
         }
 
         LocalDateTime readAt = LocalDateTime.now();
+        ChatMessagePageResponse response = fetchMessagesByRoomType(
+            room, user, userId, roomId, page, limit, readAt);
 
+        // 동시 삽입으로 타겟 메시지가 응답에서 빠진 경우 페이지 재계산 후 1회 재시도
+        if (messageId != null && response.messages().stream()
+            .noneMatch(m -> m.messageId().equals(messageId))) {
+            page = resolvePageForMessage(roomId, messageId, room, user, limit);
+            response = fetchMessagesByRoomType(
+                room, user, userId, roomId, page, limit, readAt);
+        }
+
+        return response;
+    }
+
+    private ChatMessagePageResponse fetchMessagesByRoomType(
+        ChatRoom room, User user, Integer userId, Integer roomId, int page, int limit, LocalDateTime readAt
+    ) {
         if (room.isDirectRoom()) {
             boolean isAdminViewingSystemRoom = user.isAdmin() && isSystemAdminRoom(room);
             if (isAdminViewingSystemRoom) {
@@ -1493,7 +1509,7 @@ public class ChatService {
         }
 
         // NOTE: count와 fetch 사이에 새 메시지가 삽입될 수 있으나,
-        // 검색 메시지 이동 UX에서 1페이지 오차는 허용 가능함
+        // 호출부(getMessages)에서 응답에 타겟 메시지가 없으면 1회 재계산함
         long newerCount = chatMessageRepository.countNewerMessagesByChatRoomId(
             roomId, messageId, targetMessage.getCreatedAt(), visibleMessageFrom
         );

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -1270,13 +1270,9 @@ class ChatServiceTest extends ServiceTestSupport {
     void getMessagesWithMessageIdRejectsNonMemberWithNotFound() {
         // given
         Integer nonMemberId = 99;
-        Integer memberId = 10;
         User nonMember = createUser(nonMemberId, "비회원", UserRole.USER);
         ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
-        User sender = createUser(memberId, "멤버", UserRole.USER);
-        ChatMessage message = createMessage(50, groupRoom, sender, "메시지",
-            LocalDateTime.of(2026, 4, 11, 10, 1));
-
+        // messageId=50에 해당하는 메시지가 존재하더라도 비회원이므로 404
         given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
         given(userRepository.getById(nonMemberId)).willReturn(nonMember);
         // 비회원은 멤버십이 없음

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -1191,7 +1191,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(100L);
         given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class),
             eq(PageRequest.of(1, 20))))  // page=2이므로 offset=20
-            .willReturn(new PageImpl<>(List.of(page2Message), PageRequest.of(1, 20), 100L));
+            .willReturn(new PageImpl<>(List.of(targetMessage, page2Message), PageRequest.of(1, 20), 100L));
 
         // when — page=1을 보내도 서버가 page=2로 덮어씀
         ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20, 50);

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -1191,7 +1191,7 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(100L);
         given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class),
             eq(PageRequest.of(1, 20))))  // page=2이므로 offset=20
-            .willReturn(new PageImpl<>(List.of(targetMessage, page2Message), PageRequest.of(1, 20), 100L));
+            .willReturn(new PageImpl<>(List.of(page2Message), PageRequest.of(1, 20), 100L));
 
         // when — page=1을 보내도 서버가 page=2로 덮어씀
         ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20, 50);

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -1081,6 +1081,246 @@ class ChatServiceTest extends ServiceTestSupport {
         assertThat(member.getCustomRoomName()).isNull();
     }
 
+    // ===== getMessages with messageId (US-003) =====
+
+    @Test
+    @DisplayName("getMessages는 messageId가 null이면 기존 동작과 동일하게 동작한다")
+    void getMessagesWithNullMessageIdBehavesIdentically() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(3, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember groupMember = createRoomMember(groupRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage groupMessage = createMessage(300, groupRoom, user, "group", LocalDateTime.of(2026, 4, 11, 10, 3));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(
+            Optional.of(groupMember));
+        given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId())).willReturn(List.of(groupMember));
+        given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(1L);
+        given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class),
+            eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(groupMessage), PageRequest.of(0, 20), 1));
+
+        // when — 기존 4-arg 오버로드 호출
+        ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20);
+
+        // then
+        assertThat(response.messages()).hasSize(1);
+        verify(chatMessageRepository, never()).findByIdWithChatRoom(any());
+        verify(chatMessageRepository, never()).countNewerMessagesByChatRoomId(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("getMessages는 존재하지 않는 messageId에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void getMessagesWithMessageIdThrowsWhenMessageNotFound() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember groupMember = createRoomMember(groupRoom, user, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
+            .willReturn(Optional.of(groupMember));
+        given(chatMessageRepository.findByIdWithChatRoom(999)).willReturn(Optional.empty());
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20, 999),
+            NOT_FOUND_CHAT_ROOM
+        );
+    }
+
+    @Test
+    @DisplayName("getMessages는 다른 채팅방의 messageId에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void getMessagesWithMessageIdThrowsWhenMessageBelongsToOtherRoom() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoom otherRoom = createRoom(2, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember groupMember = createRoomMember(groupRoom, user, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        User sender = createUser(20, "작성자", UserRole.USER);
+        ChatMessage otherRoomMessage = createMessage(100, otherRoom, sender, "다른 방 메시지",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId))
+            .willReturn(Optional.of(groupMember));
+        given(chatMessageRepository.findByIdWithChatRoom(100)).willReturn(Optional.of(otherRoomMessage));
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.getMessages(userId, groupRoom.getId(), 1, 20, 100),
+            NOT_FOUND_CHAT_ROOM
+        );
+    }
+
+    @Test
+    @DisplayName("getMessages는 group room에서 올바른 messageId 제공 시 계산된 페이지를 반환한다")
+    void getMessagesWithMessageIdCalculatesCorrectPageInGroupRoom() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember groupMember = createRoomMember(groupRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        // 타겟 메시지: roomId=1, id=50, createdAt=14:00
+        ChatMessage targetMessage = createMessage(50, groupRoom, user, "찾는 메시지",
+            LocalDateTime.of(2026, 4, 11, 14, 0));
+
+        // 타겟 메시지보다 최신인 메시지가 25개 → page = 25/20 + 1 = 2
+        ChatMessage page2Message = createMessage(30, groupRoom, user, "페이지2 메시지",
+            LocalDateTime.of(2026, 4, 11, 13, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatMessageRepository.findByIdWithChatRoom(50)).willReturn(Optional.of(targetMessage));
+        given(chatMessageRepository.countNewerMessagesByChatRoomId(
+            groupRoom.getId(), 50, targetMessage.getCreatedAt(), null))
+            .willReturn(25L);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(
+            Optional.of(groupMember));
+        given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId())).willReturn(List.of(groupMember));
+        given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(100L);
+        given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class),
+            eq(PageRequest.of(1, 20))))  // page=2이므로 offset=20
+            .willReturn(new PageImpl<>(List.of(page2Message), PageRequest.of(1, 20), 100L));
+
+        // when — page=1을 보내도 서버가 page=2로 덮어씀
+        ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20, 50);
+
+        // then
+        assertThat(response.currentPage()).isEqualTo(2);
+        verify(chatMessageRepository).countNewerMessagesByChatRoomId(
+            groupRoom.getId(), 50, targetMessage.getCreatedAt(), null);
+    }
+
+    @Test
+    @DisplayName("getMessages는 visibleMessageFrom 범위 밖 messageId에 대해 NOT_FOUND_CHAT_ROOM을 던진다")
+    void getMessagesWithMessageIdThrowsWhenMessageBeforeVisibleMessageFrom() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(directRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+        // 사용자가 나갔다가 돌아옴 → visibleMessageFrom이 설정됨
+        markMemberLeft(member, LocalDateTime.of(2026, 4, 11, 12, 0));
+
+        // 타겟 메시지가 visibleMessageFrom(12:00)보다 이전(10:30)에 작성됨
+        User partner = createUser(20, "상대", UserRole.USER);
+        ChatMessage oldMessage = createMessage(50, directRoom, partner, "오래된 메시지",
+            LocalDateTime.of(2026, 4, 11, 10, 30));
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatMessageRepository.findByIdWithChatRoom(50)).willReturn(Optional.of(oldMessage));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
+            .willReturn(Optional.of(member));
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.getMessages(userId, directRoom.getId(), 1, 20, 50),
+            NOT_FOUND_CHAT_ROOM
+        );
+    }
+
+    @Test
+    @DisplayName("getMessages는 messageId가 최신 메시지면 page=1을 계산한다")
+    void getMessagesWithMessageIdReturnsPage1ForNewestMessage() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember groupMember = createRoomMember(groupRoom, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        ChatMessage newestMessage = createMessage(100, groupRoom, user, "최신 메시지",
+            LocalDateTime.of(2026, 4, 11, 15, 0));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatMessageRepository.findByIdWithChatRoom(100)).willReturn(Optional.of(newestMessage));
+        // 최신 메시지보다 더 최신인 메시지가 0개 → page = 0/20 + 1 = 1
+        given(chatMessageRepository.countNewerMessagesByChatRoomId(
+            groupRoom.getId(), 100, newestMessage.getCreatedAt(), null))
+            .willReturn(0L);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), userId)).willReturn(
+            Optional.of(groupMember));
+        given(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId())).willReturn(List.of(groupMember));
+        given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(50L);
+        given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class),
+            eq(PageRequest.of(0, 20))))
+            .willReturn(new PageImpl<>(List.of(newestMessage), PageRequest.of(0, 20), 50L));
+
+        // when
+        ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20, 100);
+
+        // then
+        assertThat(response.currentPage()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("getMessages는 비회원이 messageId로 조회하면 NOT_FOUND_CHAT_ROOM을 던진다 (오라클 방지)")
+    void getMessagesWithMessageIdRejectsNonMemberWithNotFound() {
+        // given
+        Integer nonMemberId = 99;
+        Integer memberId = 10;
+        User nonMember = createUser(nonMemberId, "비회원", UserRole.USER);
+        ChatRoom groupRoom = createRoom(1, ChatType.GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        User sender = createUser(memberId, "멤버", UserRole.USER);
+        ChatMessage message = createMessage(50, groupRoom, sender, "메시지",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(groupRoom.getId())).willReturn(Optional.of(groupRoom));
+        given(userRepository.getById(nonMemberId)).willReturn(nonMember);
+        // 비회원은 멤버십이 없음
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), nonMemberId))
+            .willReturn(Optional.empty());
+
+        // when & then — 유효한 messageId여도 접근 권한 없음과 동일한 404
+        assertErrorCode(
+            () -> chatService.getMessages(nonMemberId, groupRoom.getId(), 1, 20, 50),
+            NOT_FOUND_CHAT_ROOM
+        );
+        // messageId 조회 자체가 실행되지 않아야 함
+        verify(chatMessageRepository, never()).findByIdWithChatRoom(any());
+    }
+
+    @Test
+    @DisplayName("getMessages는 visibleMessageFrom과 동일 시각의 messageId를 거부한다 (경계 조건)")
+    void getMessagesWithMessageIdRejectsMessageAtExactVisibleMessageFromBoundary() {
+        // given
+        Integer userId = 10;
+        User user = createUser(userId, "사용자", UserRole.USER);
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember member = createRoomMember(directRoom, user, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        LocalDateTime leftAt = LocalDateTime.of(2026, 4, 11, 12, 0);
+        markMemberLeft(member, leftAt);
+
+        // 메시지가 visibleMessageFrom과 정확히 같은 시각
+        User partner = createUser(20, "상대", UserRole.USER);
+        ChatMessage boundaryMessage = createMessage(50, directRoom, partner, "경계 메시지", leftAt);
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(userRepository.getById(userId)).willReturn(user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), userId))
+            .willReturn(Optional.of(member));
+        given(chatMessageRepository.findByIdWithChatRoom(50)).willReturn(Optional.of(boundaryMessage));
+
+        // when & then
+        assertErrorCode(
+            () -> chatService.getMessages(userId, directRoom.getId(), 1, 20, 50),
+            NOT_FOUND_CHAT_ROOM
+        );
+    }
+
     private User createUser(Integer id, String name, UserRole role) {
         return UserFixture.createUserWithId(UniversityFixture.createWithId(1), id, name,
             "2024" + String.format("%04d", id), role);

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -1191,13 +1191,14 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatMessageRepository.countByChatRoomId(groupRoom.getId(), null)).willReturn(100L);
         given(chatMessageRepository.findByChatRoomId(eq(groupRoom.getId()), nullable(LocalDateTime.class),
             eq(PageRequest.of(1, 20))))  // page=2이므로 offset=20
-            .willReturn(new PageImpl<>(List.of(page2Message), PageRequest.of(1, 20), 100L));
+            .willReturn(new PageImpl<>(List.of(page2Message, targetMessage), PageRequest.of(1, 20), 100L));
 
         // when — page=1을 보내도 서버가 page=2로 덮어씀
         ChatMessagePageResponse response = chatService.getMessages(userId, groupRoom.getId(), 1, 20, 50);
 
         // then
         assertThat(response.currentPage()).isEqualTo(2);
+        assertThat(response.messages().stream().anyMatch(m -> m.messageId().equals(50))).isTrue();
         verify(chatMessageRepository).countNewerMessagesByChatRoomId(
             groupRoom.getId(), 50, targetMessage.getCreatedAt(), null);
     }
@@ -1263,6 +1264,7 @@ class ChatServiceTest extends ServiceTestSupport {
 
         // then
         assertThat(response.currentPage()).isEqualTo(1);
+        assertThat(response.messages().stream().anyMatch(m -> m.messageId().equals(100))).isTrue();
     }
 
     @Test


### PR DESCRIPTION
### 🔍 개요

- 채팅 메시지 검색 결과에서 특정 메시지를 클릭하면 해당 메시지가 포함된 페이지로 바로 이동하는 기능을 추가

- 검색 응답에 `matchedMessageId` 필드를 추가하고, 메시지 조회 API에 `messageId` 옵션 파라미터를 추가하여 클라에서 검색 결과 → 메시지 위치로 직접 이동 가능


---

### 🚀 주요 변경 내용

- **ChatMessageMatchResult**: `matchedMessageId` 필드 추가, `from()`에서 `message.getId()` 매핑

- **ChatMessageRepository**:
  - `findByIdWithChatRoom(messageId)` — 메시지 + 채팅방 JOIN FETCH 조회
  - `countNewerMessagesByChatRoomId(...)` — 타겟 메시지 이후 메시지 개수 카운트 (페이지 계산용)
  - `findByChatRoomId` ORDER BY에 `cm.id DESC` tie-breaker 추가 (동일 createdAt 메시지 결정론적 정렬)

- **ChatService**:
  - 5-인수 `getMessages(userId, roomId, page, limit, messageId)` 오버로드 추가
  - `messageId` 제공 시 `page = newerCount / limit + 1`으로 자동 페이지 계산
  - `resolvePageForMessage` — 페이지 계산 로직을 별도 메서드로 추출
  - `resolveVisibleMessageFromPure` — 부수효과 없는 가시성 조회 (기존 `resolveAdminSystemRoomVisibleMessageFrom`에 위임)
  - `ensureMessageLookupAccess` — messageId resolution 전 접근 권한 사전 검증

---

### 💬 참고 사항

- `GET /chats/rooms/{chatRoomId}?messageId=42` 호출 시 해당 메시지가 포함된 페이지 번호를 자동 계산하여 반환

- `messageId` 미제공 시 기존 동작과 완전 동일 (하위 호환)

- 존재하지 않는 messageId, 다른 채팅방의 messageId → `404 NOT_FOUND_CHAT_ROOM`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
