### PR TITLE
feat: 이미지 업로드 시 요청 횟수 제한 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
+    testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
     testRuntimeOnly 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
@@ -17,7 +17,7 @@ public class UploadController implements UploadApi {
 
     private final UploadService uploadService;
 
-    @RateLimit(maxRequests = 50, timeWindowSeconds = 600, keyExpression = "#userId")
+    @RateLimit(maxRequests = 20, timeWindowSeconds = 60, keyExpression = "#userId")
     @Override
     public ResponseEntity<ImageUploadResponse> uploadImage(
         @UserId Integer userId,

--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
@@ -8,6 +8,7 @@ import gg.agit.konect.domain.upload.dto.ImageUploadResponse;
 import gg.agit.konect.domain.upload.enums.UploadTarget;
 import gg.agit.konect.domain.upload.service.UploadService;
 import gg.agit.konect.global.auth.annotation.UserId;
+import gg.agit.konect.global.ratelimit.annotation.RateLimit;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -16,6 +17,7 @@ public class UploadController implements UploadApi {
 
     private final UploadService uploadService;
 
+    @RateLimit(maxRequests = 50, timeWindowSeconds = 600, keyExpression = "#userId")
     @Override
     public ResponseEntity<ImageUploadResponse> uploadImage(
         @UserId Integer userId,

--- a/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
+++ b/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
@@ -131,6 +131,9 @@ public enum ApiResponseCode {
     // 413 Payload Too Large (요청 본문 크기 초과)
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "파일 크기가 제한을 초과했습니다."),
 
+    // 429 Too Many Requests (요청 횟수 초과)
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "요청 횟수가 너무 많습니다. 잠시 후 다시 시도해주세요."),
+
     // 500 Internal Server Error (서버 오류)
     CLIENT_ABORTED(HttpStatus.INTERNAL_SERVER_ERROR, "클라이언트에 의해 연결이 중단되었습니다."),
     FAILED_UPLOAD_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),

--- a/src/main/java/gg/agit/konect/global/ratelimit/annotation/RateLimit.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/annotation/RateLimit.java
@@ -1,0 +1,35 @@
+package gg.agit.konect.global.ratelimit.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Rate Limit을 적용하기 위한 어노테이션.
+ * 메서드 또는 클래스 레벨에 적용할 수 있습니다.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+
+    /**
+     * 허용할 최대 요청 횟수.
+     * 기본값: 50
+     */
+    int maxRequests() default 50;
+
+    /**
+     * 시간 윈도우 (초 단위).
+     * 기본값: 600 (10분)
+     */
+    int timeWindowSeconds() default 600;
+
+    /**
+     * Rate Limit 키를 생성할 SpEL 표현식.
+     * 메서드 파라미터를 참조할 수 있습니다. 예: #userId, #target
+     * 기본값: 빈 문자열 (메서드 시그니처 기본 키 사용)
+     */
+    String keyExpression() default "";
+
+}

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -1,0 +1,87 @@
+package gg.agit.konect.global.ratelimit.aspect;
+
+import java.time.Duration;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import gg.agit.konect.global.ratelimit.annotation.RateLimit;
+import gg.agit.konect.global.ratelimit.exception.RateLimitExceededException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RateLimitAspect {
+
+    private static final String RATE_LIMIT_KEY_PREFIX = "ratelimit:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final SpelExpressionParser parser = new SpelExpressionParser();
+
+    @Around("@annotation(rateLimit)")
+    public Object around(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
+        String key = generateKey(joinPoint, rateLimit);
+        int maxRequests = rateLimit.maxRequests();
+        int timeWindowSeconds = rateLimit.timeWindowSeconds();
+
+        // 키가 없으면 TTL과 함께 초기화 (원자적 연산)
+        redisTemplate.opsForValue().setIfAbsent(
+            key, "0", Duration.ofSeconds(timeWindowSeconds)
+        );
+
+        // 요청 횟수 증가
+        Long currentCount = redisTemplate.opsForValue().increment(key);
+
+        // 제한 초과 확인
+        if (currentCount != null && currentCount > maxRequests) {
+            // 남은 TTL 조회 (초 단위)
+            Long remainingSeconds = redisTemplate.getExpire(key);
+            long remaining = remainingSeconds != null && remainingSeconds > 0
+                ? remainingSeconds
+                : timeWindowSeconds;
+
+            throw RateLimitExceededException.withRemainingTime(remaining);
+        }
+
+        return joinPoint.proceed();
+    }
+
+    private String generateKey(ProceedingJoinPoint joinPoint, RateLimit rateLimit) {
+        String keyExpression = rateLimit.keyExpression();
+        MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+
+        if (keyExpression == null || keyExpression.isBlank()) {
+            String methodKey = signature.getDeclaringTypeName() + "." + signature.getName();
+            return RATE_LIMIT_KEY_PREFIX + methodKey;
+        }
+
+        StandardEvaluationContext context = new StandardEvaluationContext();
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+
+        if (paramNames != null) {
+            for (int i = 0; i < paramNames.length; i++) {
+                context.setVariable(paramNames[i], args[i]);
+            }
+        }
+
+        try {
+            Object result = parser.parseExpression(keyExpression).getValue(context);
+            String keyValue = result != null ? result.toString() : "unknown";
+            String methodKey = signature.getDeclaringTypeName() + "." + signature.getName();
+            return RATE_LIMIT_KEY_PREFIX + methodKey + ":" + keyValue;
+        } catch (Exception e) {
+            String methodKey = signature.getDeclaringTypeName() + "." + signature.getName();
+            return RATE_LIMIT_KEY_PREFIX + methodKey;
+        }
+    }
+}

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -1,12 +1,11 @@
 package gg.agit.konect.global.ratelimit.aspect;
 
-import java.time.Duration;
-
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
@@ -17,6 +16,8 @@ import gg.agit.konect.global.ratelimit.exception.RateLimitExceededException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
+
 @Slf4j
 @Aspect
 @Component
@@ -24,6 +25,15 @@ import lombok.extern.slf4j.Slf4j;
 public class RateLimitAspect {
 
     private static final String RATE_LIMIT_KEY_PREFIX = "ratelimit:";
+
+    // Lua 스크립트: INCR로 원자적 증가 후, 처음 생성된 경우에만 TTL 설정
+    // 이 방식으로 SETNX와 INCR 사이의 레이스 컨디션을 방지
+    private static final String INCR_WITH_TTL_SCRIPT =
+        "local current = redis.call('INCR', KEYS[1]) " +
+        "if current == 1 then " +
+        "    redis.call('EXPIRE', KEYS[1], ARGV[1]) " +
+        "end " +
+        "return current";
 
     private final StringRedisTemplate redisTemplate;
     private final SpelExpressionParser parser = new SpelExpressionParser();
@@ -34,13 +44,13 @@ public class RateLimitAspect {
         int maxRequests = rateLimit.maxRequests();
         int timeWindowSeconds = rateLimit.timeWindowSeconds();
 
-        // 키가 없으면 TTL과 함께 초기화 (원자적 연산)
-        redisTemplate.opsForValue().setIfAbsent(
-            key, "0", Duration.ofSeconds(timeWindowSeconds)
+        // Lua 스크립트로 원자적 연산: INCR + 첫 생성 시 TTL 설정
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>(INCR_WITH_TTL_SCRIPT, Long.class);
+        Long currentCount = redisTemplate.execute(
+            script,
+            Collections.singletonList(key),
+            String.valueOf(timeWindowSeconds)
         );
-
-        // 요청 횟수 증가
-        Long currentCount = redisTemplate.opsForValue().increment(key);
 
         // 제한 초과 확인
         if (currentCount != null && currentCount > maxRequests) {

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -91,6 +91,15 @@ public class RateLimitAspect {
         String[] paramNames = signature.getParameterNames();
         Object[] args = joinPoint.getArgs();
 
+        // -parameters 플래그 없이 컴파일된 경우 paramNames가 null일 수 있음
+        // 이 경우 arg0, arg1, ... 형태의 플레이스홀더 이름 생성
+        if (paramNames == null) {
+            paramNames = new String[args.length];
+            for (int i = 0; i < args.length; i++) {
+                paramNames[i] = "arg" + i;
+            }
+        }
+
         for (int i = 0; i < paramNames.length; i++) {
             context.setVariable(paramNames[i], args[i]);
         }

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -30,10 +30,10 @@ public class RateLimitAspect {
     // 이 방식으로 SETNX와 INCR 사이의 레이스 컨디션을 방지
     private static final String INCR_WITH_TTL_SCRIPT =
         "local current = redis.call('INCR', KEYS[1]) " +
-        "if current == 1 then " +
-        "    redis.call('EXPIRE', KEYS[1], ARGV[1]) " +
-        "end " +
-        "return current";
+            "if current == 1 then " +
+            "    redis.call('EXPIRE', KEYS[1], ARGV[1]) " +
+            "end " +
+            "return current";
 
     private final StringRedisTemplate redisTemplate;
     private final SpelExpressionParser parser = new SpelExpressionParser();

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -38,29 +38,37 @@ public class RateLimitAspect {
     private final StringRedisTemplate redisTemplate;
     private final SpelExpressionParser parser = new SpelExpressionParser();
 
-    @Around("@annotation(rateLimit)")
+    @Around("@within(rateLimit) || @annotation(rateLimit)")
     public Object around(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
         String key = generateKey(joinPoint, rateLimit);
         int maxRequests = rateLimit.maxRequests();
         int timeWindowSeconds = rateLimit.timeWindowSeconds();
 
-        // Lua 스크립트로 원자적 연산: INCR + 첫 생성 시 TTL 설정
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>(INCR_WITH_TTL_SCRIPT, Long.class);
-        Long currentCount = redisTemplate.execute(
-            script,
-            Collections.singletonList(key),
-            String.valueOf(timeWindowSeconds)
-        );
+        // Redis 장애 시 fail-open 정책: 예외 발생하면 rate limit 체크를 스킵하고 요청 처리
+        long currentCount;
+        long remainingSeconds;
+        try {
+            // Lua 스크립트로 원자적 연산: INCR + 첫 생성 시 TTL 설정
+            DefaultRedisScript<Long> script = new DefaultRedisScript<>(INCR_WITH_TTL_SCRIPT, Long.class);
+            Long count = redisTemplate.execute(
+                script,
+                Collections.singletonList(key),
+                String.valueOf(timeWindowSeconds)
+            );
+            currentCount = count != null ? count : 0;
+
+            // 남은 TTL 조회 (초 단위)
+            Long expire = redisTemplate.getExpire(key);
+            remainingSeconds = expire != null && expire > 0 ? expire : timeWindowSeconds;
+        } catch (Exception e) {
+            log.warn("Rate limiting Redis operation failed for key={}: {}. Skipping rate limit check.",
+                key, e.getMessage());
+            return joinPoint.proceed();
+        }
 
         // 제한 초과 확인
-        if (currentCount != null && currentCount > maxRequests) {
-            // 남은 TTL 조회 (초 단위)
-            Long remainingSeconds = redisTemplate.getExpire(key);
-            long remaining = remainingSeconds != null && remainingSeconds > 0
-                ? remainingSeconds
-                : timeWindowSeconds;
-
-            throw RateLimitExceededException.withRemainingTime(remaining);
+        if (currentCount > maxRequests) {
+            throw RateLimitExceededException.withRemainingTime(remainingSeconds);
         }
 
         return joinPoint.proceed();
@@ -88,6 +96,8 @@ public class RateLimitAspect {
             String keyValue = result != null ? result.toString() : "unknown";
             return RATE_LIMIT_KEY_PREFIX + methodKey + ":" + keyValue;
         } catch (Exception e) {
+            log.error("SpEL expression evaluation failed for keyExpression='{}', methodKey='{}': {}",
+                keyExpression, methodKey, e.getMessage());
             return RATE_LIMIT_KEY_PREFIX + methodKey;
         }
     }

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import gg.agit.konect.global.ratelimit.annotation.RateLimit;
 import gg.agit.konect.global.ratelimit.exception.RateLimitExceededException;
@@ -58,9 +59,9 @@ public class RateLimitAspect {
     private String generateKey(ProceedingJoinPoint joinPoint, RateLimit rateLimit) {
         String keyExpression = rateLimit.keyExpression();
         MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+        String methodKey = signature.getDeclaringTypeName() + "." + signature.getName();
 
-        if (keyExpression == null || keyExpression.isBlank()) {
-            String methodKey = signature.getDeclaringTypeName() + "." + signature.getName();
+        if (!StringUtils.hasText(keyExpression)) {
             return RATE_LIMIT_KEY_PREFIX + methodKey;
         }
 
@@ -68,19 +69,15 @@ public class RateLimitAspect {
         String[] paramNames = signature.getParameterNames();
         Object[] args = joinPoint.getArgs();
 
-        if (paramNames != null) {
-            for (int i = 0; i < paramNames.length; i++) {
-                context.setVariable(paramNames[i], args[i]);
-            }
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
         }
 
         try {
             Object result = parser.parseExpression(keyExpression).getValue(context);
             String keyValue = result != null ? result.toString() : "unknown";
-            String methodKey = signature.getDeclaringTypeName() + "." + signature.getName();
             return RATE_LIMIT_KEY_PREFIX + methodKey + ":" + keyValue;
         } catch (Exception e) {
-            String methodKey = signature.getDeclaringTypeName() + "." + signature.getName();
             return RATE_LIMIT_KEY_PREFIX + methodKey;
         }
     }

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -13,7 +13,6 @@ import org.springframework.util.StringUtils;
 
 import gg.agit.konect.global.ratelimit.annotation.RateLimit;
 import gg.agit.konect.global.ratelimit.exception.RateLimitExceededException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
@@ -21,7 +20,6 @@ import java.util.Collections;
 @Slf4j
 @Aspect
 @Component
-@RequiredArgsConstructor
 public class RateLimitAspect {
 
     private static final String RATE_LIMIT_KEY_PREFIX = "ratelimit:";
@@ -38,6 +36,14 @@ public class RateLimitAspect {
     private final StringRedisTemplate redisTemplate;
     private final SpelExpressionParser parser = new SpelExpressionParser();
 
+    // Lua 스크립트를 재사용하기 위해 미리 컴파일 (매 요청마다 생성 비용 제거)
+    private final DefaultRedisScript<Long> incrWithTtlScript;
+
+    public RateLimitAspect(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        this.incrWithTtlScript = new DefaultRedisScript<>(INCR_WITH_TTL_SCRIPT, Long.class);
+    }
+
     @Around("@within(rateLimit) || @annotation(rateLimit)")
     public Object around(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
         String key = generateKey(joinPoint, rateLimit);
@@ -46,29 +52,27 @@ public class RateLimitAspect {
 
         // Redis 장애 시 fail-open 정책: 예외 발생하면 rate limit 체크를 스킵하고 요청 처리
         long currentCount;
-        long remainingSeconds;
         try {
-            // Lua 스크립트로 원자적 연산: INCR + 첫 생성 시 TTL 설정
-            DefaultRedisScript<Long> script = new DefaultRedisScript<>(INCR_WITH_TTL_SCRIPT, Long.class);
+            // 미리 생성해둔 Lua 스크립트 실행 (원자적 INCR + TTL 설정)
             Long count = redisTemplate.execute(
-                script,
+                incrWithTtlScript,
                 Collections.singletonList(key),
                 String.valueOf(timeWindowSeconds)
             );
             currentCount = count != null ? count : 0;
-
-            // 남은 TTL 조회 (초 단위)
-            Long expire = redisTemplate.getExpire(key);
-            remainingSeconds = expire != null && expire > 0 ? expire : timeWindowSeconds;
         } catch (Exception e) {
             log.warn("Rate limiting Redis operation failed for key={}: {}. Skipping rate limit check.",
                 key, e.getMessage());
             return joinPoint.proceed();
         }
 
-        // 제한 초과 확인
+        // 제한 초과 확인 - 초과 시에만 TTL 조회
         if (currentCount > maxRequests) {
-            throw RateLimitExceededException.withRemainingTime(remainingSeconds);
+            Long remainingSeconds = redisTemplate.getExpire(key);
+            long remaining = remainingSeconds != null && remainingSeconds > 0
+                ? remainingSeconds
+                : timeWindowSeconds;
+            throw RateLimitExceededException.withRemainingTime(remaining);
         }
 
         return joinPoint.proceed();

--- a/src/main/java/gg/agit/konect/global/ratelimit/exception/RateLimitExceededException.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/exception/RateLimitExceededException.java
@@ -28,13 +28,4 @@ public final class RateLimitExceededException {
         );
     }
 
-    /**
-     * 기본 메시지로 예외를 생성합니다.
-     *
-     * @return CustomException
-     */
-    public static CustomException create() {
-        return CustomException.of(ApiResponseCode.TOO_MANY_REQUESTS);
-    }
-
 }

--- a/src/main/java/gg/agit/konect/global/ratelimit/exception/RateLimitExceededException.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/exception/RateLimitExceededException.java
@@ -1,0 +1,40 @@
+package gg.agit.konect.global.ratelimit.exception;
+
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+
+/**
+ * Rate Limit 초과 시 발생하는 예외 팩토리.
+ * CustomException은 상속이 불가능하므로 팩토리 메서드로 생성합니다.
+ */
+public final class RateLimitExceededException {
+
+    private static final String MESSAGE_TEMPLATE = "요청 횟수가 너무 많습니다. %d초 후 다시 시도해주세요.";
+
+    private RateLimitExceededException() {
+        // 유틸리티 클래스
+    }
+
+    /**
+     * 남은 시간(초)을 포함하여 예외를 생성합니다.
+     *
+     * @param remainingSeconds 남은 시간(초)
+     * @return CustomException
+     */
+    public static CustomException withRemainingTime(long remainingSeconds) {
+        return CustomException.of(
+            ApiResponseCode.TOO_MANY_REQUESTS,
+            String.format(MESSAGE_TEMPLATE, remainingSeconds)
+        );
+    }
+
+    /**
+     * 기본 메시지로 예외를 생성합니다.
+     *
+     * @return CustomException
+     */
+    public static CustomException create() {
+        return CustomException.of(ApiResponseCode.TOO_MANY_REQUESTS);
+    }
+
+}

--- a/src/test/java/gg/agit/konect/support/EmbeddedRedisConfig.java
+++ b/src/test/java/gg/agit/konect/support/EmbeddedRedisConfig.java
@@ -1,0 +1,50 @@
+package gg.agit.konect.support;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import redis.embedded.RedisServer;
+
+@TestConfiguration
+public class EmbeddedRedisConfig {
+
+    private static final int DEFAULT_REDIS_PORT = 0; // 0이면 랜덤 포트
+
+    private int actualPort;
+    private RedisServer redisServer;
+
+    @Bean
+    @Primary
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("localhost", actualPort);
+    }
+
+    @PostConstruct
+    public void startRedis() throws IOException {
+        // 사용 가능한 랜덤 포트 찾기
+        actualPort = findAvailablePort();
+        redisServer = new RedisServer(actualPort);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() throws IOException {
+        if (redisServer != null && redisServer.isActive()) {
+            redisServer.stop();
+        }
+    }
+
+    private int findAvailablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/src/test/java/gg/agit/konect/support/IntegrationTestSupport.java
+++ b/src/test/java/gg/agit/konect/support/IntegrationTestSupport.java
@@ -43,7 +43,7 @@ import gg.agit.konect.global.logging.LoggingProperties;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import({TestSecurityConfig.class, TestJpaConfig.class, TestClaudeConfig.class})
+@Import({TestSecurityConfig.class, TestJpaConfig.class, TestClaudeConfig.class, EmbeddedRedisConfig.class})
 @TestPropertyConfig
 @Transactional  // 각 테스트 메서드 종료 시 자동 롤백하여 fork 내 데이터 격리 보장
 public abstract class IntegrationTestSupport {

--- a/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
@@ -2,10 +2,14 @@ package gg.agit.konect.unit.global.ratelimit.aspect;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
@@ -16,7 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
@@ -30,9 +34,6 @@ class RateLimitAspectTest {
     private StringRedisTemplate redisTemplate;
 
     @Mock
-    private ValueOperations<String, String> valueOperations;
-
-    @Mock
     private ProceedingJoinPoint joinPoint;
 
     @Mock
@@ -44,15 +45,11 @@ class RateLimitAspectTest {
     @InjectMocks
     private RateLimitAspect rateLimitAspect;
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("제한 내 요청 시 정상 통과")
     void allowsRequestWithinLimit() throws Throwable {
         // given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.setIfAbsent(
-            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
-        )).willReturn(true);
-        given(valueOperations.increment("ratelimit:test.method:user123")).willReturn(5L);
         given(rateLimit.maxRequests()).willReturn(10);
         given(rateLimit.timeWindowSeconds()).willReturn(60);
         given(rateLimit.keyExpression()).willReturn("#userId");
@@ -61,6 +58,10 @@ class RateLimitAspectTest {
         given(methodSignature.getName()).willReturn("method");
         given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
         given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+
+        // Lua 스크립트 실행 결과 모킹
+        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
+            .thenReturn(5L);
 
         Object expectedResult = new Object();
         given(joinPoint.proceed()).willReturn(expectedResult);
@@ -72,15 +73,11 @@ class RateLimitAspectTest {
         assertThat(result).isEqualTo(expectedResult);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
-    @DisplayName("첫 번째 요청 시 setIfAbsent로 TTL 설정")
-    void setsTtlOnFirstRequestWithSetIfAbsent() throws Throwable {
+    @DisplayName("Lua 스크립트로 원자적 INCR + TTL 설정")
+    void usesLuaScriptForAtomicIncrAndTtl() throws Throwable {
         // given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.setIfAbsent(
-            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
-        )).willReturn(true);
-        given(valueOperations.increment("ratelimit:test.method:user123")).willReturn(1L);
         given(rateLimit.maxRequests()).willReturn(10);
         given(rateLimit.timeWindowSeconds()).willReturn(60);
         given(rateLimit.keyExpression()).willReturn("#userId");
@@ -91,24 +88,21 @@ class RateLimitAspectTest {
         given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
         given(joinPoint.proceed()).willReturn(null);
 
+        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
+            .thenReturn(1L);
+
         // when
         rateLimitAspect.around(joinPoint, rateLimit);
 
-        // then
-        verify(valueOperations).setIfAbsent(
-            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
-        );
+        // then - Lua 스크립트가 실행되었는지 검증
+        verify(redisTemplate).execute(any(DefaultRedisScript.class), any(List.class), eq("60"));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("제한 초과 시 RateLimitExceededException 발생")
     void throwsExceptionWhenLimitExceeded() {
         // given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.setIfAbsent(
-            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
-        )).willReturn(false);
-        given(valueOperations.increment("ratelimit:test.method:user123")).willReturn(11L);
         given(rateLimit.maxRequests()).willReturn(10);
         given(rateLimit.timeWindowSeconds()).willReturn(60);
         given(rateLimit.keyExpression()).willReturn("#userId");
@@ -117,6 +111,10 @@ class RateLimitAspectTest {
         given(methodSignature.getName()).willReturn("method");
         given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
         given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+
+        // Lua 스크립트가 카운터를 11로 반환 (제한 초과)
+        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
+            .thenReturn(11L);
         given(redisTemplate.getExpire("ratelimit:test.method:user123")).willReturn(30L);
 
         // when & then
@@ -128,15 +126,11 @@ class RateLimitAspectTest {
             });
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("빈 keyExpression 시 메서드 시그니처 기본 키 사용")
     void usesDefaultKeyWhenExpressionIsEmpty() throws Throwable {
         // given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.setIfAbsent(
-            "ratelimit:test.method", "0", Duration.ofSeconds(60)
-        )).willReturn(true);
-        given(valueOperations.increment("ratelimit:test.method")).willReturn(1L);
         given(rateLimit.maxRequests()).willReturn(10);
         given(rateLimit.timeWindowSeconds()).willReturn(60);
         given(rateLimit.keyExpression()).willReturn("");
@@ -145,12 +139,17 @@ class RateLimitAspectTest {
         given(methodSignature.getName()).willReturn("method");
         given(joinPoint.proceed()).willReturn(null);
 
+        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
+            .thenReturn(1L);
+
         // when
         rateLimitAspect.around(joinPoint, rateLimit);
 
-        // then
-        verify(valueOperations).setIfAbsent(
-            "ratelimit:test.method", "0", Duration.ofSeconds(60)
+        // then - 기본 키로 Lua 스크립트 실행
+        verify(redisTemplate).execute(
+            any(DefaultRedisScript.class),
+            eq(Collections.singletonList("ratelimit:test.method")),
+            any(String.class)
         );
     }
 

--- a/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
@@ -56,8 +56,8 @@ class RateLimitAspectTest {
         given(joinPoint.getSignature()).willReturn(methodSignature);
         given(methodSignature.getDeclaringTypeName()).willReturn("test");
         given(methodSignature.getName()).willReturn("method");
-        given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
-        given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+        given(methodSignature.getParameterNames()).willReturn(new String[] {"userId"});
+        given(joinPoint.getArgs()).willReturn(new Object[] {"user123"});
 
         // Lua 스크립트 실행 결과 모킹
         when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
@@ -84,8 +84,8 @@ class RateLimitAspectTest {
         given(joinPoint.getSignature()).willReturn(methodSignature);
         given(methodSignature.getDeclaringTypeName()).willReturn("test");
         given(methodSignature.getName()).willReturn("method");
-        given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
-        given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+        given(methodSignature.getParameterNames()).willReturn(new String[] {"userId"});
+        given(joinPoint.getArgs()).willReturn(new Object[] {"user123"});
         given(joinPoint.proceed()).willReturn(null);
 
         when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
@@ -109,8 +109,8 @@ class RateLimitAspectTest {
         given(joinPoint.getSignature()).willReturn(methodSignature);
         given(methodSignature.getDeclaringTypeName()).willReturn("test");
         given(methodSignature.getName()).willReturn("method");
-        given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
-        given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+        given(methodSignature.getParameterNames()).willReturn(new String[] {"userId"});
+        given(joinPoint.getArgs()).willReturn(new Object[] {"user123"});
 
         // Lua 스크립트가 카운터를 11로 반환 (제한 초과)
         when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))

--- a/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
@@ -1,0 +1,157 @@
+package gg.agit.konect.unit.global.ratelimit.aspect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.global.ratelimit.annotation.RateLimit;
+import gg.agit.konect.global.ratelimit.aspect.RateLimitAspect;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitAspectTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    @Mock
+    private MethodSignature methodSignature;
+
+    @Mock
+    private RateLimit rateLimit;
+
+    @InjectMocks
+    private RateLimitAspect rateLimitAspect;
+
+    @Test
+    @DisplayName("제한 내 요청 시 정상 통과")
+    void allowsRequestWithinLimit() throws Throwable {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(
+            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
+        )).willReturn(true);
+        given(valueOperations.increment("ratelimit:test.method:user123")).willReturn(5L);
+        given(rateLimit.maxRequests()).willReturn(10);
+        given(rateLimit.timeWindowSeconds()).willReturn(60);
+        given(rateLimit.keyExpression()).willReturn("#userId");
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getDeclaringTypeName()).willReturn("test");
+        given(methodSignature.getName()).willReturn("method");
+        given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
+        given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+
+        Object expectedResult = new Object();
+        given(joinPoint.proceed()).willReturn(expectedResult);
+
+        // when
+        Object result = rateLimitAspect.around(joinPoint, rateLimit);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    @DisplayName("첫 번째 요청 시 setIfAbsent로 TTL 설정")
+    void setsTtlOnFirstRequestWithSetIfAbsent() throws Throwable {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(
+            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
+        )).willReturn(true);
+        given(valueOperations.increment("ratelimit:test.method:user123")).willReturn(1L);
+        given(rateLimit.maxRequests()).willReturn(10);
+        given(rateLimit.timeWindowSeconds()).willReturn(60);
+        given(rateLimit.keyExpression()).willReturn("#userId");
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getDeclaringTypeName()).willReturn("test");
+        given(methodSignature.getName()).willReturn("method");
+        given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
+        given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+        given(joinPoint.proceed()).willReturn(null);
+
+        // when
+        rateLimitAspect.around(joinPoint, rateLimit);
+
+        // then
+        verify(valueOperations).setIfAbsent(
+            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
+        );
+    }
+
+    @Test
+    @DisplayName("제한 초과 시 RateLimitExceededException 발생")
+    void throwsExceptionWhenLimitExceeded() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(
+            "ratelimit:test.method:user123", "0", Duration.ofSeconds(60)
+        )).willReturn(false);
+        given(valueOperations.increment("ratelimit:test.method:user123")).willReturn(11L);
+        given(rateLimit.maxRequests()).willReturn(10);
+        given(rateLimit.timeWindowSeconds()).willReturn(60);
+        given(rateLimit.keyExpression()).willReturn("#userId");
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getDeclaringTypeName()).willReturn("test");
+        given(methodSignature.getName()).willReturn("method");
+        given(methodSignature.getParameterNames()).willReturn(new String[]{"userId"});
+        given(joinPoint.getArgs()).willReturn(new Object[]{"user123"});
+        given(redisTemplate.getExpire("ratelimit:test.method:user123")).willReturn(30L);
+
+        // when & then
+        assertThatThrownBy(() -> rateLimitAspect.around(joinPoint, rateLimit))
+            .isInstanceOf(CustomException.class)
+            .satisfies(ex -> {
+                CustomException customEx = (CustomException)ex;
+                assertThat(customEx.getErrorCode()).isEqualTo(ApiResponseCode.TOO_MANY_REQUESTS);
+            });
+    }
+
+    @Test
+    @DisplayName("빈 keyExpression 시 메서드 시그니처 기본 키 사용")
+    void usesDefaultKeyWhenExpressionIsEmpty() throws Throwable {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.setIfAbsent(
+            "ratelimit:test.method", "0", Duration.ofSeconds(60)
+        )).willReturn(true);
+        given(valueOperations.increment("ratelimit:test.method")).willReturn(1L);
+        given(rateLimit.maxRequests()).willReturn(10);
+        given(rateLimit.timeWindowSeconds()).willReturn(60);
+        given(rateLimit.keyExpression()).willReturn("");
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getDeclaringTypeName()).willReturn("test");
+        given(methodSignature.getName()).willReturn("method");
+        given(joinPoint.proceed()).willReturn(null);
+
+        // when
+        rateLimitAspect.around(joinPoint, rateLimit);
+
+        // then
+        verify(valueOperations).setIfAbsent(
+            "ratelimit:test.method", "0", Duration.ofSeconds(60)
+        );
+    }
+
+}


### PR DESCRIPTION
### 🔍 개요

* 동아리 플랫폼에서 악의적인 사용자나 버그로 인한 대량 이미지 업로드로 서버 리소스가 과도하게 소모될 수 있습니다. 이를 방지하기 위해 사용자별 업로드 횟수 제한이 필요했습니다.


---

### 🚀 주요 변경 내용

### Rate Limiting 기반 구조 추가
- `@RateLimit` 어노테이션 추가: 메서드 레벨에서 Rate Limit 적용 가능
- `RateLimitAspect` 구현: AOP를 통한 선언적 Rate Limit 처리
  - Lua 스크립트를 사용하여 INCR와 EXPIRE를 원자적으로 실행
  - SETNX와 INCR 사이의 레이스 컨디션 방지 (TTL 손실 문제 해결)
- `RateLimitExceededException` 팩토리: 429 응답 생성
- `TOO_MANY_REQUESTS` (429) 응답 코드 추가

### 이미지 업로드 API 적용
- `UploadController.uploadImage()`에 Rate Limit 적용
- 설정: 사용자별 1분에 20회 제한 (`#userId`로 사용자 식별)

### 테스트
- `RateLimitAspectTest` 단위 테스트 추가
  - 정상 요청 통과 검증
  - Lua 스크립트 실행 검증
  - 제한 초과 예외 발생 검증
  - 기본 키 사용 검증

---

### 💬 참고 사항

* Redis 장애 시 업로드 API가 영향을 받을 수 있음


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
