### PR TITLE
chore: JVM 메모리 설정 및 Hibernate 쿼리 플랜 캐시 축소

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,13 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
 
-ENTRYPOINT ["java", "-jar", "KONECT_API.jar"]
+ENTRYPOINT ["java", \
+  "-Xms128m", \
+  "-Xmx256m", \
+  "-XX:MaxMetaspaceSize=128m", \
+  "-XX:+UseStringDeduplication", \
+  "-XX:+AlwaysPreTouch", \
+  "-Xlog:gc*:file=/app/gc.log:time,uptime,level,tags:filecount=5,filesize=10m", \
+  "-XX:+HeapDumpOnOutOfMemoryError", \
+  "-XX:HeapDumpPath=/app/heapdump.hprof", \
+  "-jar", "KONECT_API.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ ENTRYPOINT ["java", \
   "-Xmx256m", \
   "-XX:MaxMetaspaceSize=128m", \
   "-XX:+UseStringDeduplication", \
-  "-XX:+AlwaysPreTouch", \
   "-Xlog:gc*:file=/app/gc.log:time,uptime,level,tags:filecount=5,filesize=10m", \
   "-XX:+HeapDumpOnOutOfMemoryError", \
   "-XX:HeapDumpPath=/app/heapdump.hprof", \

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -25,6 +25,9 @@ spring:
           batch_size: 100
         order_inserts: true
         order_updates: true
+        query:
+          plan_cache_max_size: 64
+          plan_parameter_metadata_max_size: 32
     hibernate:
       ddl-auto: validate
     open-in-view: false


### PR DESCRIPTION
### 🔍 개요

* 해당 프로젝트의 서버 메모리 사용량은 약 `500MB`를 차지하는 중 <img width="744" height="38" alt="image" src="https://github.com/user-attachments/assets/ca54e942-5bc6-4f4e-8122-23a4c408d7d7" />

* 프로젝트 규모에 비해 너무 많은 메모리를 사용한다고 판단하여 원인 파악을 시작

* 힙 덤프 분석 결과 실제 힙 사용량은 약 `85MB`로, 원인은 힙이 아닌 다른 영역에 있을 것이라 추측
  <img width="523" height="253" alt="image" src="https://github.com/user-attachments/assets/7ef298b2-9390-49d2-94ee-1d652a099714" />

* 또한 무엇인지 모르는 `ATNConfig`의 힙 사용량이 5%나 차지하는 것을 관측

### 원인
- 힙 덤프 분석 결과 실제 힙 사용량은 약 `85MB`로, 나머지 `415MB`는 `Metaspace`, `Thread Stacks`, `JVM` 내부 메모리 등에서 사용 중

- 원인:
  - `Dockerfile`에 `JVM` 메모리 설정(`-Xmx` 등)이 없어 `JVM`이 기본값으로 과도한 메모리를 예약
    - 기본적으로 컨테이너 단위로 `2GiB`를 차지하는데, 따로 설정이 없으면 `1/4` 크기로 지정됨
  - `Hibernate HQL` 파서(`ANTLR4`)의 `ATNConfig` 객체가 132,873개 누적되어 약 `4.25MB` 점유
  - `Hibernate Query Plan Cache` 기본 크기(2048)가 과대 설정
 
---

### 🚀 주요 변경 내용

### Dockerfile

- `-Xms128m` / `-Xmx256m`: 힙 메모리 상하한 고정하여 과도한 메모리 예약 방지
- `-XX:MaxMetaspaceSize=128m`: Metaspace 상한 설정
- `-XX:+UseStringDeduplication`: 중복 String 인스턴스(210K개) 메모리 절약
- `-XX:+AlwaysPreTouch`: 시작 시 힙을 물리 메모리에 미리 할당하여 런타임 지연 및 OOM 조기 발견
- `-Xlog:gc*:file=/app/gc.log:time,uptime,level,tags:filecount=5,filesize=10m`: GC 로그 순환 저장
- `-XX:+HeapDumpOnOutOfMemoryError` / `-XX:HeapDumpPath=/app/heapdump.hprof`: OOM 발생 시 자동 힙 덤프 생성

### application-db.yml

- `hibernate.query.plan_cache_max_size`: 2048 → 64
  - Hibernate가 HQL/JPQL 쿼리를 실행할 때 ANTLR4로 파싱한 **실행 계획(Query Plan)을 캐시에 저장**하는데, 이 캐시에 유지할 최대 실행 계획 수
  - 기본값 2048은 고유 쿼리가 많지 않은 서비스에서 과도하여, 사용하지 않는 파서 객체(ATNConfig)가 메모리에 누적됨
  - 자주 사용하는 쿼리 64개만 캐시에 유지하고 나머지는 GC가 회수하도록 축소

- `hibernate.query.plan_parameter_metadata_max_size`: 128 → 32
  - 실행 계획과 함께 캐시되는 **파라미터 메타데이터(바인딩 타입, 순서 등)의 최대 보관 수**
  - plan_cache_max_size와 비율을 맞추어 함께 축소


---

### 💬 참고 사항

- **OOM 가능성**: 힙이 256MB로 제한되므로, 트래픽 급증 시 OOM이 발생할 수 있음. 발생 시 `-Xmx` 값 증량 필요


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
