### PR TITLE
feat: 행사 프로그램 조회 기반 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/event/controller/EventApi.java
+++ b/src/main/java/gg/agit/konect/domain/event/controller/EventApi.java
@@ -1,0 +1,29 @@
+package gg.agit.konect.domain.event.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import gg.agit.konect.domain.event.dto.EventProgramsResponse;
+import gg.agit.konect.domain.event.enums.EventProgramType;
+import gg.agit.konect.global.auth.annotation.UserId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+
+@Tag(name = "(Normal) Event: 행사", description = "행사 API")
+@RequestMapping("/events")
+public interface EventApi {
+
+    @Operation(summary = "행사 프로그램 목록을 조회한다.")
+    @GetMapping("/{eventId}/programs")
+    ResponseEntity<EventProgramsResponse> getEventPrograms(
+        @PathVariable Integer eventId,
+        @RequestParam(defaultValue = "ALL") EventProgramType type,
+        @RequestParam(defaultValue = "1") @Min(1) Integer page,
+        @RequestParam(defaultValue = "20") @Min(1) Integer limit,
+        @UserId Integer userId
+    );
+}

--- a/src/main/java/gg/agit/konect/domain/event/controller/EventController.java
+++ b/src/main/java/gg/agit/konect/domain/event/controller/EventController.java
@@ -1,0 +1,25 @@
+package gg.agit.konect.domain.event.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RestController;
+
+import gg.agit.konect.domain.event.dto.EventProgramsResponse;
+import gg.agit.konect.domain.event.enums.EventProgramType;
+import gg.agit.konect.domain.event.service.EventService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+public class EventController implements EventApi {
+
+    private final EventService eventService;
+
+    @Override
+    public ResponseEntity<EventProgramsResponse> getEventPrograms(Integer eventId, EventProgramType type, Integer page,
+        Integer limit,
+        Integer userId) {
+        return ResponseEntity.ok(eventService.getEventPrograms(eventId, type, page, limit, userId));
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/event/dto/EventProgramSummaryResponse.java
+++ b/src/main/java/gg/agit/konect/domain/event/dto/EventProgramSummaryResponse.java
@@ -1,0 +1,12 @@
+package gg.agit.konect.domain.event.dto;
+
+public record EventProgramSummaryResponse(
+    Integer programId,
+    String title,
+    String description,
+    String thumbnailUrl,
+    Integer rewardPoint,
+    String status,
+    boolean participated
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/event/dto/EventProgramsResponse.java
+++ b/src/main/java/gg/agit/konect/domain/event/dto/EventProgramsResponse.java
@@ -1,0 +1,15 @@
+package gg.agit.konect.domain.event.dto;
+
+import java.util.List;
+
+import gg.agit.konect.domain.event.enums.EventProgramType;
+
+public record EventProgramsResponse(
+    Long totalCount,
+    Integer currentCount,
+    Integer totalPage,
+    Integer currentPage,
+    EventProgramType type,
+    List<EventProgramSummaryResponse> programs
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/event/enums/EventProgramType.java
+++ b/src/main/java/gg/agit/konect/domain/event/enums/EventProgramType.java
@@ -1,0 +1,7 @@
+package gg.agit.konect.domain.event.enums;
+
+public enum EventProgramType {
+    ALL,
+    POINT,
+    RESONANCE
+}

--- a/src/main/java/gg/agit/konect/domain/event/enums/EventProgressStatus.java
+++ b/src/main/java/gg/agit/konect/domain/event/enums/EventProgressStatus.java
@@ -1,0 +1,7 @@
+package gg.agit.konect.domain.event.enums;
+
+public enum EventProgressStatus {
+    UPCOMING,
+    ONGOING,
+    ENDED
+}

--- a/src/main/java/gg/agit/konect/domain/event/enums/EventStatus.java
+++ b/src/main/java/gg/agit/konect/domain/event/enums/EventStatus.java
@@ -1,0 +1,7 @@
+package gg.agit.konect.domain.event.enums;
+
+public enum EventStatus {
+    DRAFT,
+    PUBLISHED,
+    ENDED
+}

--- a/src/main/java/gg/agit/konect/domain/event/model/Event.java
+++ b/src/main/java/gg/agit/konect/domain/event/model/Event.java
@@ -1,0 +1,52 @@
+package gg.agit.konect.domain.event.model;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import java.time.LocalDateTime;
+
+import gg.agit.konect.domain.event.enums.EventStatus;
+import gg.agit.konect.global.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event")
+@NoArgsConstructor(access = PROTECTED)
+public class Event extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false, unique = true)
+    private Integer id;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "subtitle", length = 255)
+    private String subtitle;
+
+    @Column(name = "poster_image_url", length = 255)
+    private String posterImageUrl;
+
+    @Column(name = "notice", columnDefinition = "TEXT")
+    private String notice;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EventStatus status;
+}

--- a/src/main/java/gg/agit/konect/domain/event/model/EventProgram.java
+++ b/src/main/java/gg/agit/konect/domain/event/model/EventProgram.java
@@ -1,0 +1,59 @@
+package gg.agit.konect.domain.event.model;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import gg.agit.konect.domain.event.enums.EventProgressStatus;
+import gg.agit.konect.domain.event.enums.EventProgramType;
+import gg.agit.konect.global.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event_program")
+@NoArgsConstructor(access = PROTECTED)
+public class EventProgram extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false, unique = true)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "event_id", nullable = false, updatable = false)
+    private Event event;
+
+    @Enumerated(STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private EventProgramType type;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "description", nullable = false, length = 255)
+    private String description;
+
+    @Column(name = "thumbnail_url", length = 255)
+    private String thumbnailUrl;
+
+    @Column(name = "reward_point")
+    private Integer rewardPoint;
+
+    @Enumerated(STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EventProgressStatus status;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+}

--- a/src/main/java/gg/agit/konect/domain/event/repository/EventProgramRepository.java
+++ b/src/main/java/gg/agit/konect/domain/event/repository/EventProgramRepository.java
@@ -1,0 +1,14 @@
+package gg.agit.konect.domain.event.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import gg.agit.konect.domain.event.model.EventProgram;
+
+public interface EventProgramRepository extends Repository<EventProgram, Integer> {
+
+    List<EventProgram> findAllByEventIdOrderByDisplayOrderAscIdAsc(Integer eventId);
+
+    int countByEventId(Integer eventId);
+}

--- a/src/main/java/gg/agit/konect/domain/event/repository/EventRepository.java
+++ b/src/main/java/gg/agit/konect/domain/event/repository/EventRepository.java
@@ -1,0 +1,14 @@
+package gg.agit.konect.domain.event.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import gg.agit.konect.domain.event.model.Event;
+
+public interface EventRepository extends Repository<Event, Integer> {
+
+    Optional<Event> findById(Integer id);
+
+    Event save(Event event);
+}

--- a/src/main/java/gg/agit/konect/domain/event/service/EventService.java
+++ b/src/main/java/gg/agit/konect/domain/event/service/EventService.java
@@ -1,0 +1,75 @@
+package gg.agit.konect.domain.event.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_EVENT;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.event.dto.EventProgramSummaryResponse;
+import gg.agit.konect.domain.event.dto.EventProgramsResponse;
+import gg.agit.konect.domain.event.enums.EventProgramType;
+import gg.agit.konect.domain.event.model.EventProgram;
+import gg.agit.konect.domain.event.repository.EventProgramRepository;
+import gg.agit.konect.domain.event.repository.EventRepository;
+import gg.agit.konect.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventService {
+
+    private final EventRepository eventRepository;
+    private final EventProgramRepository eventProgramRepository;
+
+    public EventProgramsResponse getEventPrograms(Integer eventId, EventProgramType type, Integer page, Integer limit,
+        Integer userId) {
+        eventRepository.findById(eventId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_EVENT));
+
+        List<EventProgram> filteredPrograms = eventProgramRepository.findAllByEventIdOrderByDisplayOrderAscIdAsc(
+                eventId).stream()
+            .filter(program -> type == EventProgramType.ALL || program.getType() == type)
+            .toList();
+
+        PagedResult<EventProgram> pagedPrograms = paginate(filteredPrograms, page, limit);
+        List<EventProgramSummaryResponse> programs = pagedPrograms.items().stream()
+            .map(this::toEventProgramSummaryResponse)
+            .toList();
+
+        return new EventProgramsResponse(
+            (long)pagedPrograms.totalCount(),
+            programs.size(),
+            pagedPrograms.totalPage(),
+            page,
+            type,
+            programs
+        );
+    }
+
+    private <T> PagedResult<T> paginate(List<T> items, Integer page, Integer limit) {
+        int totalCount = items.size();
+        int fromIndex = Math.max((page - 1) * limit, 0);
+        int toIndex = Math.min(fromIndex + limit, totalCount);
+        List<T> pagedItems = fromIndex >= totalCount ? List.of() : items.subList(fromIndex, toIndex);
+        int totalPage = totalCount == 0 ? 0 : (int)Math.ceil((double)totalCount / limit);
+        return new PagedResult<>(pagedItems, totalCount, totalPage);
+    }
+
+    private EventProgramSummaryResponse toEventProgramSummaryResponse(EventProgram program) {
+        return new EventProgramSummaryResponse(
+            program.getId(),
+            program.getTitle(),
+            program.getDescription(),
+            program.getThumbnailUrl(),
+            program.getRewardPoint(),
+            program.getStatus().name(),
+            false
+        );
+    }
+
+    private record PagedResult<T>(List<T> items, int totalCount, int totalPage) {
+    }
+}

--- a/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
+++ b/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
@@ -104,6 +104,7 @@ public enum ApiResponseCode {
     NOT_FOUND_NOTIFICATION_TOKEN(HttpStatus.NOT_FOUND, "알림 토큰을 찾을 수 없습니다."),
     NOT_FOUND_NOTIFICATION_INBOX(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
     NOT_FOUND_ADVERTISEMENT(HttpStatus.NOT_FOUND, "광고를 찾을 수 없습니다."),
+    NOT_FOUND_EVENT(HttpStatus.NOT_FOUND, "행사를 찾을 수 없습니다."),
     NOT_FOUND_CLUB_SHEET_ID(HttpStatus.NOT_FOUND, "등록된 스프레드시트 ID가 없습니다. 먼저 스프레드시트 ID를 등록해 주세요."),
     NOT_FOUND_GOOGLE_DRIVE_AUTH(HttpStatus.NOT_FOUND, "Google Drive 권한이 연결되지 않았습니다. 먼저 Drive 권한을 연결해 주세요."),
 

--- a/src/main/resources/db/migration/V70__add_event_tables.sql
+++ b/src/main/resources/db/migration/V70__add_event_tables.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS event
+(
+    id               INT AUTO_INCREMENT PRIMARY KEY,
+    title            VARCHAR(100)                                                   NOT NULL,
+    subtitle         VARCHAR(255),
+    poster_image_url VARCHAR(255),
+    notice           TEXT,
+    start_at         TIMESTAMP                                                      NOT NULL,
+    end_at           TIMESTAMP                                                      NOT NULL,
+    status           ENUM ('DRAFT', 'PUBLISHED', 'ENDED')                           NOT NULL,
+    created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP                            NOT NULL,
+    updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS event_program
+(
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    event_id      INT                                                            NOT NULL,
+    type          ENUM ('POINT', 'RESONANCE')                                    NOT NULL,
+    title         VARCHAR(100)                                                   NOT NULL,
+    description   VARCHAR(255)                                                   NOT NULL,
+    thumbnail_url VARCHAR(255),
+    reward_point  INT,
+    status        ENUM ('UPCOMING', 'ONGOING', 'ENDED')                          NOT NULL,
+    display_order INT                                                            NOT NULL DEFAULT 0,
+    created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP                            NOT NULL,
+    updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+
+    FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
### 🔍 개요

* 행사 도메인과 프로그램 조회 API의 최소 기반을 첫 stacked PR로 분리합니다.

---

### 🚀 주요 변경 내용

* event / event_program 테이블과 관련 enum, entity, repository를 추가합니다.
* 행사 프로그램 목록 조회 endpoint, service, DTO를 추가합니다.
* 행사 조회에서 사용하는 `NOT_FOUND_EVENT` 응답 코드를 함께 복구합니다.

---

### 💬 참고 사항

* stacked PR의 시작점입니다.
* 이후 PR들은 이 브랜치를 base로 순차적으로 쌓입니다.
* pre-push hook 기준 `checkstyleMain`, `compileJava`를 통과했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)