### PR TITLE
feat: 행사 부스맵 조회 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/event/dto/EventBoothMapResponse.java
+++ b/src/main/java/gg/agit/konect/domain/event/dto/EventBoothMapResponse.java
@@ -1,0 +1,28 @@
+package gg.agit.konect.domain.event.dto;
+
+import java.util.List;
+
+public record EventBoothMapResponse(
+    String mapImageUrl,
+    List<ZoneResponse> zones,
+    List<BoothMapItemResponse> booths
+) {
+
+    public record ZoneResponse(
+        String code,
+        String label
+    ) {
+    }
+
+    public record BoothMapItemResponse(
+        Integer boothId,
+        String name,
+        String zone,
+        Integer x,
+        Integer y,
+        Integer width,
+        Integer height,
+        String status
+    ) {
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/event/enums/EventBoothMapItemStatus.java
+++ b/src/main/java/gg/agit/konect/domain/event/enums/EventBoothMapItemStatus.java
@@ -1,0 +1,7 @@
+package gg.agit.konect.domain.event.enums;
+
+public enum EventBoothMapItemStatus {
+    OPEN,
+    CLOSED,
+    HIDDEN
+}

--- a/src/main/java/gg/agit/konect/domain/event/model/EventBoothMap.java
+++ b/src/main/java/gg/agit/konect/domain/event/model/EventBoothMap.java
@@ -1,0 +1,41 @@
+package gg.agit.konect.domain.event.model;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import gg.agit.konect.global.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event_booth_map")
+@NoArgsConstructor(access = PROTECTED)
+public class EventBoothMap extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false, unique = true)
+    private Integer id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "event_id", nullable = false, updatable = false)
+    private Event event;
+
+    @Column(name = "map_image_url", length = 255)
+    private String mapImageUrl;
+
+    @Column(name = "width")
+    private Integer width;
+
+    @Column(name = "height")
+    private Integer height;
+}

--- a/src/main/java/gg/agit/konect/domain/event/model/EventBoothMapItem.java
+++ b/src/main/java/gg/agit/konect/domain/event/model/EventBoothMapItem.java
@@ -1,0 +1,56 @@
+package gg.agit.konect.domain.event.model;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import gg.agit.konect.domain.event.enums.EventBoothMapItemStatus;
+import gg.agit.konect.global.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event_booth_map_item")
+@NoArgsConstructor(access = PROTECTED)
+public class EventBoothMapItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false, unique = true)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "event_booth_map_id", nullable = false, updatable = false)
+    private EventBoothMap eventBoothMap;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "event_booth_id", nullable = false, updatable = false)
+    private EventBooth eventBooth;
+
+    @Column(name = "x", nullable = false)
+    private Integer x;
+
+    @Column(name = "y", nullable = false)
+    private Integer y;
+
+    @Column(name = "width", nullable = false)
+    private Integer width;
+
+    @Column(name = "height", nullable = false)
+    private Integer height;
+
+    @Enumerated(STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EventBoothMapItemStatus status;
+}

--- a/src/main/java/gg/agit/konect/domain/event/repository/EventBoothMapItemRepository.java
+++ b/src/main/java/gg/agit/konect/domain/event/repository/EventBoothMapItemRepository.java
@@ -1,0 +1,12 @@
+package gg.agit.konect.domain.event.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import gg.agit.konect.domain.event.model.EventBoothMapItem;
+
+public interface EventBoothMapItemRepository extends Repository<EventBoothMapItem, Integer> {
+
+    List<EventBoothMapItem> findAllByEventBoothMapIdOrderByIdAsc(Integer eventBoothMapId);
+}

--- a/src/main/java/gg/agit/konect/domain/event/repository/EventBoothMapRepository.java
+++ b/src/main/java/gg/agit/konect/domain/event/repository/EventBoothMapRepository.java
@@ -1,0 +1,12 @@
+package gg.agit.konect.domain.event.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import gg.agit.konect.domain.event.model.EventBoothMap;
+
+public interface EventBoothMapRepository extends Repository<EventBoothMap, Integer> {
+
+    Optional<EventBoothMap> findByEventId(Integer eventId);
+}

--- a/src/main/java/gg/agit/konect/domain/event/service/EventService.java
+++ b/src/main/java/gg/agit/konect/domain/event/service/EventService.java
@@ -7,13 +7,18 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import gg.agit.konect.domain.event.dto.EventBoothMapResponse;
 import gg.agit.konect.domain.event.dto.EventBoothSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventBoothsResponse;
 import gg.agit.konect.domain.event.dto.EventProgramSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventProgramsResponse;
 import gg.agit.konect.domain.event.enums.EventProgramType;
 import gg.agit.konect.domain.event.model.EventBooth;
+import gg.agit.konect.domain.event.model.EventBoothMap;
+import gg.agit.konect.domain.event.model.EventBoothMapItem;
 import gg.agit.konect.domain.event.model.EventProgram;
+import gg.agit.konect.domain.event.repository.EventBoothMapItemRepository;
+import gg.agit.konect.domain.event.repository.EventBoothMapRepository;
 import gg.agit.konect.domain.event.repository.EventBoothRepository;
 import gg.agit.konect.domain.event.repository.EventProgramRepository;
 import gg.agit.konect.domain.event.repository.EventRepository;
@@ -28,6 +33,8 @@ public class EventService {
     private final EventRepository eventRepository;
     private final EventProgramRepository eventProgramRepository;
     private final EventBoothRepository eventBoothRepository;
+    private final EventBoothMapRepository eventBoothMapRepository;
+    private final EventBoothMapItemRepository eventBoothMapItemRepository;
 
     public EventProgramsResponse getEventPrograms(Integer eventId, EventProgramType type, Integer page, Integer limit,
         Integer userId) {
@@ -77,6 +84,30 @@ public class EventService {
         );
     }
 
+    public EventBoothMapResponse getEventBoothMap(Integer eventId) {
+        EventBoothMap boothMap = eventBoothMapRepository.findByEventId(eventId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_EVENT));
+
+        List<EventBoothMapItem> boothMapItems = eventBoothMapItemRepository.findAllByEventBoothMapIdOrderByIdAsc(
+            boothMap.getId());
+        List<EventBoothMapResponse.BoothMapItemResponse> booths = boothMapItems.stream()
+            .map(this::toEventBoothMapItemResponse)
+            .toList();
+
+        List<EventBoothMapResponse.ZoneResponse> zones = booths.stream()
+            .map(EventBoothMapResponse.BoothMapItemResponse::zone)
+            .filter(zone -> zone != null && !zone.isBlank())
+            .distinct()
+            .map(zone -> new EventBoothMapResponse.ZoneResponse(zone, zone))
+            .toList();
+
+        return new EventBoothMapResponse(
+            boothMap.getMapImageUrl(),
+            zones,
+            booths
+        );
+    }
+
     private void getEvent(Integer eventId) {
         eventRepository.findById(eventId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_EVENT));
@@ -112,6 +143,21 @@ public class EventService {
             booth.getZone(),
             booth.getThumbnailUrl(),
             Boolean.TRUE.equals(booth.getIsOpen())
+        );
+    }
+
+    private EventBoothMapResponse.BoothMapItemResponse toEventBoothMapItemResponse(EventBoothMapItem boothMapItem) {
+        EventBooth booth = boothMapItem.getEventBooth();
+
+        return new EventBoothMapResponse.BoothMapItemResponse(
+            booth.getId(),
+            booth.getName(),
+            booth.getZone(),
+            boothMapItem.getX(),
+            boothMapItem.getY(),
+            boothMapItem.getWidth(),
+            boothMapItem.getHeight(),
+            boothMapItem.getStatus().name()
         );
     }
 

--- a/src/main/resources/db/migration/V70__add_event_tables.sql
+++ b/src/main/resources/db/migration/V70__add_event_tables.sql
@@ -46,3 +46,35 @@ CREATE TABLE IF NOT EXISTS event_booth
 
     FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS event_booth_map
+(
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    event_id      INT                                                            NOT NULL,
+    map_image_url VARCHAR(255),
+    width         INT,
+    height        INT,
+    created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP                            NOT NULL,
+    updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+
+    FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE,
+    CONSTRAINT uq_event_booth_map_event_id UNIQUE (event_id)
+);
+
+CREATE TABLE IF NOT EXISTS event_booth_map_item
+(
+    id                 INT AUTO_INCREMENT PRIMARY KEY,
+    event_booth_map_id INT                                                            NOT NULL,
+    event_booth_id     INT                                                            NOT NULL,
+    x                  INT                                                            NOT NULL,
+    y                  INT                                                            NOT NULL,
+    width              INT                                                            NOT NULL,
+    height             INT                                                            NOT NULL,
+    status             ENUM ('OPEN', 'CLOSED', 'HIDDEN')                             NOT NULL DEFAULT 'OPEN',
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP                            NOT NULL,
+    updated_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+
+    FOREIGN KEY (event_booth_map_id) REFERENCES event_booth_map (id) ON DELETE CASCADE,
+    FOREIGN KEY (event_booth_id) REFERENCES event_booth (id) ON DELETE CASCADE,
+    CONSTRAINT uq_event_booth_map_item_booth_id UNIQUE (event_booth_id)
+);


### PR DESCRIPTION
### 🔍 개요

* 행사 조회 기능 중 부스 맵 조회를 독립된 stacked PR로 분리합니다.

---

### 🚀 주요 변경 내용

* event_booth_map / event_booth_map_item 테이블과 관련 enum, entity, repository를 추가합니다.
* 부스 맵 조회 endpoint와 service 로직을 추가합니다.
* zone 목록과 부스 좌표 응답을 함께 구성합니다.

---

### 💬 참고 사항

* base PR: `stack/event-booths-map`
* 부스 목록 PR 위에 자연스럽게 이어지는 의존 구조입니다.
* pre-push hook 기준 `checkstyleMain`, `compileJava`를 통과했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)