### PR TITLE
feat: 행사 미니 이벤트 조회 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/event/controller/EventApi.java
+++ b/src/main/java/gg/agit/konect/domain/event/controller/EventApi.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import gg.agit.konect.domain.event.dto.EventBoothMapResponse;
 import gg.agit.konect.domain.event.dto.EventBoothsResponse;
+import gg.agit.konect.domain.event.dto.EventMiniEventsResponse;
 import gg.agit.konect.domain.event.dto.EventProgramsResponse;
 import gg.agit.konect.domain.event.enums.EventProgramType;
 import gg.agit.konect.global.auth.annotation.UserId;
@@ -43,5 +44,14 @@ public interface EventApi {
     @GetMapping("/{eventId}/booth-map")
     ResponseEntity<EventBoothMapResponse> getEventBoothMap(
         @PathVariable Integer eventId
+    );
+
+    @Operation(summary = "행사 미니 이벤트 목록을 조회한다.")
+    @GetMapping("/{eventId}/mini-events")
+    ResponseEntity<EventMiniEventsResponse> getEventMiniEvents(
+        @PathVariable Integer eventId,
+        @RequestParam(defaultValue = "1") @Min(1) Integer page,
+        @RequestParam(defaultValue = "20") @Min(1) Integer limit,
+        @UserId Integer userId
     );
 }

--- a/src/main/java/gg/agit/konect/domain/event/controller/EventController.java
+++ b/src/main/java/gg/agit/konect/domain/event/controller/EventController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import gg.agit.konect.domain.event.dto.EventBoothMapResponse;
 import gg.agit.konect.domain.event.dto.EventBoothsResponse;
+import gg.agit.konect.domain.event.dto.EventMiniEventsResponse;
 import gg.agit.konect.domain.event.dto.EventProgramsResponse;
 import gg.agit.konect.domain.event.enums.EventProgramType;
 import gg.agit.konect.domain.event.service.EventService;
@@ -34,5 +35,11 @@ public class EventController implements EventApi {
     @Override
     public ResponseEntity<EventBoothMapResponse> getEventBoothMap(Integer eventId) {
         return ResponseEntity.ok(eventService.getEventBoothMap(eventId));
+    }
+
+    @Override
+    public ResponseEntity<EventMiniEventsResponse> getEventMiniEvents(Integer eventId, Integer page, Integer limit,
+        Integer userId) {
+        return ResponseEntity.ok(eventService.getEventMiniEvents(eventId, page, limit, userId));
     }
 }

--- a/src/main/java/gg/agit/konect/domain/event/dto/EventMiniEventSummaryResponse.java
+++ b/src/main/java/gg/agit/konect/domain/event/dto/EventMiniEventSummaryResponse.java
@@ -1,0 +1,12 @@
+package gg.agit.konect.domain.event.dto;
+
+public record EventMiniEventSummaryResponse(
+    Integer miniEventId,
+    String title,
+    String thumbnailUrl,
+    String description,
+    String reward,
+    String status,
+    boolean joined
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/event/dto/EventMiniEventsResponse.java
+++ b/src/main/java/gg/agit/konect/domain/event/dto/EventMiniEventsResponse.java
@@ -1,0 +1,12 @@
+package gg.agit.konect.domain.event.dto;
+
+import java.util.List;
+
+public record EventMiniEventsResponse(
+    Long totalCount,
+    Integer currentCount,
+    Integer totalPage,
+    Integer currentPage,
+    List<EventMiniEventSummaryResponse> miniEvents
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/event/model/EventMiniEvent.java
+++ b/src/main/java/gg/agit/konect/domain/event/model/EventMiniEvent.java
@@ -1,0 +1,54 @@
+package gg.agit.konect.domain.event.model;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import gg.agit.konect.domain.event.enums.EventProgressStatus;
+import gg.agit.konect.global.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "event_mini_event")
+@NoArgsConstructor(access = PROTECTED)
+public class EventMiniEvent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false, unique = true)
+    private Integer id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "event_id", nullable = false, updatable = false)
+    private Event event;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "description", nullable = false, length = 255)
+    private String description;
+
+    @Column(name = "thumbnail_url", length = 255)
+    private String thumbnailUrl;
+
+    @Column(name = "reward_label", length = 100)
+    private String rewardLabel;
+
+    @Enumerated(STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private EventProgressStatus status;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+}

--- a/src/main/java/gg/agit/konect/domain/event/repository/EventMiniEventRepository.java
+++ b/src/main/java/gg/agit/konect/domain/event/repository/EventMiniEventRepository.java
@@ -1,0 +1,14 @@
+package gg.agit.konect.domain.event.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.Repository;
+
+import gg.agit.konect.domain.event.model.EventMiniEvent;
+
+public interface EventMiniEventRepository extends Repository<EventMiniEvent, Integer> {
+
+    List<EventMiniEvent> findAllByEventIdOrderByDisplayOrderAscIdAsc(Integer eventId);
+
+    int countByEventId(Integer eventId);
+}

--- a/src/main/java/gg/agit/konect/domain/event/service/EventService.java
+++ b/src/main/java/gg/agit/konect/domain/event/service/EventService.java
@@ -10,16 +10,20 @@ import org.springframework.transaction.annotation.Transactional;
 import gg.agit.konect.domain.event.dto.EventBoothMapResponse;
 import gg.agit.konect.domain.event.dto.EventBoothSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventBoothsResponse;
+import gg.agit.konect.domain.event.dto.EventMiniEventSummaryResponse;
+import gg.agit.konect.domain.event.dto.EventMiniEventsResponse;
 import gg.agit.konect.domain.event.dto.EventProgramSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventProgramsResponse;
 import gg.agit.konect.domain.event.enums.EventProgramType;
 import gg.agit.konect.domain.event.model.EventBooth;
 import gg.agit.konect.domain.event.model.EventBoothMap;
 import gg.agit.konect.domain.event.model.EventBoothMapItem;
+import gg.agit.konect.domain.event.model.EventMiniEvent;
 import gg.agit.konect.domain.event.model.EventProgram;
 import gg.agit.konect.domain.event.repository.EventBoothMapItemRepository;
 import gg.agit.konect.domain.event.repository.EventBoothMapRepository;
 import gg.agit.konect.domain.event.repository.EventBoothRepository;
+import gg.agit.konect.domain.event.repository.EventMiniEventRepository;
 import gg.agit.konect.domain.event.repository.EventProgramRepository;
 import gg.agit.konect.domain.event.repository.EventRepository;
 import gg.agit.konect.global.exception.CustomException;
@@ -35,6 +39,7 @@ public class EventService {
     private final EventBoothRepository eventBoothRepository;
     private final EventBoothMapRepository eventBoothMapRepository;
     private final EventBoothMapItemRepository eventBoothMapItemRepository;
+    private final EventMiniEventRepository eventMiniEventRepository;
 
     public EventProgramsResponse getEventPrograms(Integer eventId, EventProgramType type, Integer page, Integer limit,
         Integer userId) {
@@ -108,6 +113,24 @@ public class EventService {
         );
     }
 
+    public EventMiniEventsResponse getEventMiniEvents(Integer eventId, Integer page, Integer limit, Integer userId) {
+        getEvent(eventId);
+
+        List<EventMiniEvent> miniEvents = eventMiniEventRepository.findAllByEventIdOrderByDisplayOrderAscIdAsc(eventId);
+        PagedResult<EventMiniEvent> pagedMiniEvents = paginate(miniEvents, page, limit);
+        List<EventMiniEventSummaryResponse> miniEventResponses = pagedMiniEvents.items().stream()
+            .map(this::toEventMiniEventSummaryResponse)
+            .toList();
+
+        return new EventMiniEventsResponse(
+            (long)pagedMiniEvents.totalCount(),
+            miniEventResponses.size(),
+            pagedMiniEvents.totalPage(),
+            page,
+            miniEventResponses
+        );
+    }
+
     private void getEvent(Integer eventId) {
         eventRepository.findById(eventId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_EVENT));
@@ -158,6 +181,18 @@ public class EventService {
             boothMapItem.getWidth(),
             boothMapItem.getHeight(),
             boothMapItem.getStatus().name()
+        );
+    }
+
+    private EventMiniEventSummaryResponse toEventMiniEventSummaryResponse(EventMiniEvent miniEvent) {
+        return new EventMiniEventSummaryResponse(
+            miniEvent.getId(),
+            miniEvent.getTitle(),
+            miniEvent.getThumbnailUrl(),
+            miniEvent.getDescription(),
+            miniEvent.getRewardLabel(),
+            miniEvent.getStatus().name(),
+            false
         );
     }
 

--- a/src/main/resources/db/migration/V70__add_event_tables.sql
+++ b/src/main/resources/db/migration/V70__add_event_tables.sql
@@ -78,3 +78,19 @@ CREATE TABLE IF NOT EXISTS event_booth_map_item
     FOREIGN KEY (event_booth_id) REFERENCES event_booth (id) ON DELETE CASCADE,
     CONSTRAINT uq_event_booth_map_item_booth_id UNIQUE (event_booth_id)
 );
+
+CREATE TABLE IF NOT EXISTS event_mini_event
+(
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    event_id      INT                                                            NOT NULL,
+    title         VARCHAR(100)                                                   NOT NULL,
+    description   VARCHAR(255)                                                   NOT NULL,
+    thumbnail_url VARCHAR(255),
+    reward_label  VARCHAR(100),
+    status        ENUM ('UPCOMING', 'ONGOING', 'ENDED')                          NOT NULL,
+    display_order INT                                                            NOT NULL DEFAULT 0,
+    created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP                            NOT NULL,
+    updated_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+
+    FOREIGN KEY (event_id) REFERENCES event (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
### 🔍 개요

* 행사 조회 기능 중 미니 이벤트 목록 조회를 별도 stacked PR로 분리합니다.

---

### 🚀 주요 변경 내용

* event_mini_event 테이블과 관련 entity, repository, DTO를 추가합니다.
* 미니 이벤트 목록 조회 endpoint와 service 로직을 추가합니다.
* 페이지 응답 규격을 기존 행사 조회 흐름과 맞춥니다.

---

### 💬 참고 사항

* base PR: `stack/event-booth-map`
* 기능 범위를 작게 유지하기 위해 미니 이벤트만 포함합니다.
* pre-push hook 기준 `checkstyleMain`, `compileJava`를 통과했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)