### PR TITLE
feat: 행사 홈 조회 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/event/controller/EventApi.java
+++ b/src/main/java/gg/agit/konect/domain/event/controller/EventApi.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import gg.agit.konect.domain.event.dto.EventBoothMapResponse;
 import gg.agit.konect.domain.event.dto.EventBoothsResponse;
 import gg.agit.konect.domain.event.dto.EventContentsResponse;
+import gg.agit.konect.domain.event.dto.EventHomeResponse;
 import gg.agit.konect.domain.event.dto.EventMiniEventsResponse;
 import gg.agit.konect.domain.event.dto.EventProgramsResponse;
 import gg.agit.konect.domain.event.enums.EventProgramType;
@@ -20,6 +21,13 @@ import jakarta.validation.constraints.Min;
 @Tag(name = "(Normal) Event: 행사", description = "행사 API")
 @RequestMapping("/events")
 public interface EventApi {
+
+    @Operation(summary = "행사 홈 정보를 조회한다.")
+    @GetMapping("/{eventId}/home")
+    ResponseEntity<EventHomeResponse> getEventHome(
+        @PathVariable Integer eventId,
+        @UserId Integer userId
+    );
 
     @Operation(summary = "행사 프로그램 목록을 조회한다.")
     @GetMapping("/{eventId}/programs")

--- a/src/main/java/gg/agit/konect/domain/event/controller/EventController.java
+++ b/src/main/java/gg/agit/konect/domain/event/controller/EventController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 import gg.agit.konect.domain.event.dto.EventBoothMapResponse;
 import gg.agit.konect.domain.event.dto.EventBoothsResponse;
 import gg.agit.konect.domain.event.dto.EventContentsResponse;
+import gg.agit.konect.domain.event.dto.EventHomeResponse;
 import gg.agit.konect.domain.event.dto.EventMiniEventsResponse;
 import gg.agit.konect.domain.event.dto.EventProgramsResponse;
 import gg.agit.konect.domain.event.enums.EventProgramType;
@@ -19,6 +20,11 @@ import lombok.RequiredArgsConstructor;
 public class EventController implements EventApi {
 
     private final EventService eventService;
+
+    @Override
+    public ResponseEntity<EventHomeResponse> getEventHome(Integer eventId, Integer userId) {
+        return ResponseEntity.ok(eventService.getEventHome(eventId, userId));
+    }
 
     @Override
     public ResponseEntity<EventProgramsResponse> getEventPrograms(Integer eventId, EventProgramType type, Integer page,

--- a/src/main/java/gg/agit/konect/domain/event/dto/EventHomeResponse.java
+++ b/src/main/java/gg/agit/konect/domain/event/dto/EventHomeResponse.java
@@ -1,0 +1,30 @@
+package gg.agit.konect.domain.event.dto;
+
+import java.time.LocalDateTime;
+
+public record EventHomeResponse(
+    Integer eventId,
+    String title,
+    String subtitle,
+    String posterImageUrl,
+    LocalDateTime startAt,
+    LocalDateTime endAt,
+    String notice,
+    Summary summary,
+    UserStatus userStatus
+) {
+
+    public record Summary(
+        Integer programCount,
+        Integer boothCount,
+        Integer eventCount,
+        Integer contentCount
+    ) {
+    }
+
+    public record UserStatus(
+        Integer point,
+        Integer participatedEventCount
+    ) {
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/event/service/EventService.java
+++ b/src/main/java/gg/agit/konect/domain/event/service/EventService.java
@@ -12,11 +12,13 @@ import gg.agit.konect.domain.event.dto.EventBoothSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventBoothsResponse;
 import gg.agit.konect.domain.event.dto.EventContentSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventContentsResponse;
+import gg.agit.konect.domain.event.dto.EventHomeResponse;
 import gg.agit.konect.domain.event.dto.EventMiniEventSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventMiniEventsResponse;
 import gg.agit.konect.domain.event.dto.EventProgramSummaryResponse;
 import gg.agit.konect.domain.event.dto.EventProgramsResponse;
 import gg.agit.konect.domain.event.enums.EventProgramType;
+import gg.agit.konect.domain.event.model.Event;
 import gg.agit.konect.domain.event.model.EventBooth;
 import gg.agit.konect.domain.event.model.EventBoothMap;
 import gg.agit.konect.domain.event.model.EventBoothMapItem;
@@ -45,6 +47,27 @@ public class EventService {
     private final EventBoothMapItemRepository eventBoothMapItemRepository;
     private final EventMiniEventRepository eventMiniEventRepository;
     private final EventContentRepository eventContentRepository;
+
+    public EventHomeResponse getEventHome(Integer eventId, Integer userId) {
+        Event event = getEvent(eventId);
+
+        return new EventHomeResponse(
+            event.getId(),
+            event.getTitle(),
+            event.getSubtitle(),
+            event.getPosterImageUrl(),
+            event.getStartAt(),
+            event.getEndAt(),
+            event.getNotice(),
+            new EventHomeResponse.Summary(
+                eventProgramRepository.countByEventId(eventId),
+                eventBoothRepository.countByEventId(eventId),
+                eventMiniEventRepository.countByEventId(eventId),
+                eventContentRepository.countByEventId(eventId)
+            ),
+            new EventHomeResponse.UserStatus(0, 0)
+        );
+    }
 
     public EventProgramsResponse getEventPrograms(Integer eventId, EventProgramType type, Integer page, Integer limit,
         Integer userId) {
@@ -162,8 +185,8 @@ public class EventService {
         );
     }
 
-    private void getEvent(Integer eventId) {
-        eventRepository.findById(eventId)
+    private Event getEvent(Integer eventId) {
+        return eventRepository.findById(eventId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_EVENT));
     }
 


### PR DESCRIPTION
### 🔍 개요

* 행사 조회 기능 중 홈 응답을 별도 stacked PR로 추가합니다.

---

### 🚀 주요 변경 내용

* 행사 홈 응답 DTO를 추가합니다.
* 홈 조회 endpoint와 service 로직을 추가합니다.
* 프로그램, 부스, 미니 이벤트, 콘텐츠 요약 카운트를 집계합니다.

---

### 💬 참고 사항

* base PR: `stack/event-contents`
* 이후 테스트 PR들이 이 홈 응답 구현을 기준으로 쌓입니다.
* pre-push hook 기준 `checkstyleMain`, `compileJava`를 통과했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)