### PR TITLE
feat: 채팅방 멤버 목록 조회 API 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
@@ -16,7 +16,6 @@ import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
-import gg.agit.konect.domain.chat.dto.ChatRoomMemberResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomMembersResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
@@ -26,7 +25,6 @@ import gg.agit.konect.domain.chat.enums.ChatInviteSortBy;
 import gg.agit.konect.global.auth.annotation.UserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -257,11 +255,11 @@ public interface ChatApi {
     @Operation(summary = "그룹 채팅방을 생성한다.", description = """
         ## 설명
         - 여러 유저를 초대하여 그룹 채팅방을 생성합니다.
-
+        
         ## 로직
         - 요청자(방장)를 포함하여 선택된 모든 유저가 참여하는 그룹 채팅방을 생성합니다.
         - 방장은 채팅방을 생성한 사용자입니다.
-
+        
         ## 에러
         - CANNOT_CREATE_CHAT_ROOM_WITH_SELF (400): 자기 자신만으로는 채팅방을 만들 수 없습니다.
         - NOT_FOUND_USER (404): 유저를 찾을 수 없습니다.
@@ -275,12 +273,12 @@ public interface ChatApi {
     @Operation(summary = "채팅방 멤버 목록 조회", description = """
         ## 설명
         - 특정 채팅방의 모든 멤버 목록을 조회합니다.
-
+        
         ## 로직
         - 채팅방에 참여 중인 멤버만 조회할 수 있습니다.
         - 나간 멤버(leftAt이 설정된 멤버)는 목록에 포함되지 않습니다.
         - 각 멤버의 userId, 이름, 프로필 이미지, 방장 여부, 참여 시간을 반환합니다.
-
+        
         ## 에러
         - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다.
         - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다.

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
@@ -16,6 +16,8 @@ import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomMemberResponse;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomsSummaryResponse;
@@ -23,6 +25,8 @@ import gg.agit.konect.domain.chat.dto.ChatSearchResponse;
 import gg.agit.konect.domain.chat.enums.ChatInviteSortBy;
 import gg.agit.konect.global.auth.annotation.UserId;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -253,11 +257,11 @@ public interface ChatApi {
     @Operation(summary = "그룹 채팅방을 생성한다.", description = """
         ## 설명
         - 여러 유저를 초대하여 그룹 채팅방을 생성합니다.
-        
+
         ## 로직
         - 요청자(방장)를 포함하여 선택된 모든 유저가 참여하는 그룹 채팅방을 생성합니다.
         - 방장은 채팅방을 생성한 사용자입니다.
-        
+
         ## 에러
         - CANNOT_CREATE_CHAT_ROOM_WITH_SELF (400): 자기 자신만으로는 채팅방을 만들 수 없습니다.
         - NOT_FOUND_USER (404): 유저를 찾을 수 없습니다.
@@ -265,6 +269,25 @@ public interface ChatApi {
     @PostMapping("/rooms/group")
     ResponseEntity<ChatRoomResponse> createGroupChatRoom(
         @Valid @RequestBody ChatRoomCreateRequest.Group request,
+        @UserId Integer userId
+    );
+
+    @Operation(summary = "채팅방 멤버 목록 조회", description = """
+        ## 설명
+        - 특정 채팅방의 모든 멤버 목록을 조회합니다.
+
+        ## 로직
+        - 채팅방에 참여 중인 멤버만 조회할 수 있습니다.
+        - 나간 멤버(leftAt이 설정된 멤버)는 목록에 포함되지 않습니다.
+        - 각 멤버의 userId, 이름, 프로필 이미지, 방장 여부, 참여 시간을 반환합니다.
+
+        ## 에러
+        - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다.
+        - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다.
+        """)
+    @GetMapping("/rooms/{chatRoomId}/members")
+    ResponseEntity<ChatRoomMembersResponse> getChatRoomMembers(
+        @Parameter(description = "채팅방 ID") @PathVariable Integer chatRoomId,
         @UserId Integer userId
     );
 }

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
@@ -2,6 +2,7 @@ package gg.agit.konect.domain.chat.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,11 +15,13 @@ import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomsSummaryResponse;
 import gg.agit.konect.domain.chat.dto.ChatSearchResponse;
 import gg.agit.konect.domain.chat.enums.ChatInviteSortBy;
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.chat.service.ChatService;
 import gg.agit.konect.global.auth.annotation.UserId;
 import jakarta.validation.Valid;
@@ -31,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class ChatController implements ChatApi {
 
     private final ChatService chatService;
+    private final ChatRoomMembershipService chatRoomMembershipService;
 
     @Override
     public ResponseEntity<ChatRoomResponse> createOrGetChatRoom(
@@ -145,6 +149,15 @@ public class ChatController implements ChatApi {
         @UserId Integer userId
     ) {
         ChatRoomResponse response = chatService.createGroupChatRoom(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/rooms/{chatRoomId}/members")
+    public ResponseEntity<ChatRoomMembersResponse> getChatRoomMembers(
+            @PathVariable Integer chatRoomId,
+            @UserId Integer userId) {
+        ChatRoomMembersResponse response = chatRoomMembershipService.getChatRoomMembers(chatRoomId, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
@@ -155,8 +155,8 @@ public class ChatController implements ChatApi {
     @Override
     @GetMapping("/rooms/{chatRoomId}/members")
     public ResponseEntity<ChatRoomMembersResponse> getChatRoomMembers(
-            @PathVariable Integer chatRoomId,
-            @UserId Integer userId) {
+        @PathVariable Integer chatRoomId,
+        @UserId Integer userId) {
         ChatRoomMembersResponse response = chatRoomMembershipService.getChatRoomMembers(chatRoomId, userId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMemberResponse.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMemberResponse.java
@@ -1,0 +1,12 @@
+package gg.agit.konect.domain.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomMemberResponse(
+    Integer userId,
+    String name,
+    String profileImageUrl,
+    boolean isOwner,
+    LocalDateTime joinedAt
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMembersResponse.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMembersResponse.java
@@ -1,0 +1,8 @@
+package gg.agit.konect.domain.chat.dto;
+
+import java.util.List;
+
+public record ChatRoomMembersResponse(
+    List<ChatRoomMemberResponse> members
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
@@ -120,6 +120,15 @@ public interface ChatRoomMemberRepository extends Repository<ChatRoomMember, Cha
         @Param("userId") Integer userId
     );
 
+    @Query("""
+        SELECT crm
+        FROM ChatRoomMember crm
+        JOIN FETCH crm.user
+        WHERE crm.id.chatRoomId = :chatRoomId
+          AND crm.leftAt IS NULL
+        """)
+    List<ChatRoomMember> findActiveMembersByChatRoomId(@Param("chatRoomId") Integer chatRoomId);
+
     List<ChatRoomMember> saveAll(Iterable<ChatRoomMember> chatRoomMembers);
 
 }

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
@@ -121,6 +121,18 @@ public interface ChatRoomMemberRepository extends Repository<ChatRoomMember, Cha
     );
 
     @Query("""
+        SELECT COUNT(crm) > 0
+        FROM ChatRoomMember crm
+        WHERE crm.id.chatRoomId = :chatRoomId
+          AND crm.id.userId = :userId
+          AND crm.leftAt IS NULL
+        """)
+    boolean existsActiveByChatRoomIdAndUserId(
+        @Param("chatRoomId") Integer chatRoomId,
+        @Param("userId") Integer userId
+    );
+
+    @Query("""
         SELECT crm
         FROM ChatRoomMember crm
         JOIN FETCH crm.user

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -2,6 +2,7 @@ package gg.agit.konect.domain.chat.service;
 
 import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -43,7 +44,10 @@ public class ChatRoomMembershipService {
 
     @Transactional(readOnly = true)
     public ChatRoomMembersResponse getChatRoomMembers(Integer chatRoomId, Integer currentUserId) {
-        validateMembership(chatRoomId, currentUserId);
+        User currentUser = userRepository.findById(currentUserId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_USER));
+
+        validateMembership(chatRoomId, currentUser);
 
         List<ChatRoomMember> members = chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId);
 
@@ -53,8 +57,13 @@ public class ChatRoomMembershipService {
             .toList());
     }
 
-    private void validateMembership(Integer chatRoomId, Integer userId) {
-        if (!chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)) {
+    private void validateMembership(Integer chatRoomId, User currentUser) {
+        // 어드민은 시스템 어드민 방의 멤버를 조회할 수 있음
+        if (currentUser.isAdmin() && isSystemAdminRoom(chatRoomId)) {
+            return;
+        }
+
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUser.getId())) {
             throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
         }
     }

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -43,13 +43,10 @@ public class ChatRoomMembershipService {
 
     @Transactional(readOnly = true)
     public ChatRoomMembersResponse getChatRoomMembers(Integer chatRoomId, Integer currentUserId) {
-        // 1. 현재 사용자가 채팅방 멤버인지 확인 (존재 + 나가지 않음)
         validateMembership(chatRoomId, currentUserId);
 
-        // 2. 활성 멤버 목록 조회 (leftAt IS NULL)
         List<ChatRoomMember> members = chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId);
 
-        // 3. DTO 변환 및 반환
         return new ChatRoomMembersResponse(members.stream()
             .map(this::toMemberResponse)
             .toList());
@@ -65,7 +62,7 @@ public class ChatRoomMembershipService {
         return new ChatRoomMemberResponse(
             member.getUser().getId(),
             member.getUser().getName(),
-            member.getUser().getImageUrl(),  // getProfileImageUrl -> getImageUrl
+            member.getUser().getImageUrl(),
             member.isOwner(),
             member.getCreatedAt()
         );

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.dto.ChatRoomMemberResponse;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersResponse;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
 import gg.agit.konect.domain.club.model.Club;
@@ -38,6 +40,36 @@ public class ChatRoomMembershipService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ClubMemberRepository clubMemberRepository;
     private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public ChatRoomMembersResponse getChatRoomMembers(Integer chatRoomId, Integer currentUserId) {
+        // 1. 현재 사용자가 채팅방 멤버인지 확인 (존재 + 나가지 않음)
+        validateMembership(chatRoomId, currentUserId);
+
+        // 2. 활성 멤버 목록 조회 (leftAt IS NULL)
+        List<ChatRoomMember> members = chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId);
+
+        // 3. DTO 변환 및 반환
+        return new ChatRoomMembersResponse(members.stream()
+            .map(this::toMemberResponse)
+            .toList());
+    }
+
+    private void validateMembership(Integer chatRoomId, Integer userId) {
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)) {
+            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
+        }
+    }
+
+    private ChatRoomMemberResponse toMemberResponse(ChatRoomMember member) {
+        return new ChatRoomMemberResponse(
+            member.getUser().getId(),
+            member.getUser().getName(),
+            member.getUser().getImageUrl(),  // getProfileImageUrl -> getImageUrl
+            member.isOwner(),
+            member.getCreatedAt()
+        );
+    }
 
     @Transactional
     public void addClubMember(ClubMember clubMember) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -48,6 +48,7 @@ public class ChatRoomMembershipService {
         List<ChatRoomMember> members = chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId);
 
         return new ChatRoomMembersResponse(members.stream()
+            .filter(member -> member.getUser().getDeletedAt() == null)
             .map(this::toMemberResponse)
             .toList());
     }

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -47,7 +47,11 @@ public class ChatRoomMembershipService {
         User currentUser = userRepository.findById(currentUserId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_USER));
 
-        validateMembership(chatRoomId, currentUser);
+        // 채팅방 존재 여부 먼저 확인
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+
+        validateMembership(chatRoom, currentUser);
 
         List<ChatRoomMember> members = chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId);
 
@@ -57,13 +61,13 @@ public class ChatRoomMembershipService {
             .toList());
     }
 
-    private void validateMembership(Integer chatRoomId, User currentUser) {
+    private void validateMembership(ChatRoom chatRoom, User currentUser) {
         // 어드민은 시스템 어드민 방의 멤버를 조회할 수 있음
-        if (currentUser.isAdmin() && isSystemAdminRoom(chatRoomId)) {
+        if (currentUser.isAdmin() && isSystemAdminRoom(chatRoom.getId())) {
             return;
         }
 
-        if (!chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUser.getId())) {
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoom.getId(), currentUser.getId())) {
             throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
         }
     }

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -67,7 +67,7 @@ public class ChatRoomMembershipService {
             return;
         }
 
-        if (!chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoom.getId(), currentUser.getId())) {
+        if (!chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(chatRoom.getId(), currentUser.getId())) {
             throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
         }
     }

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -73,6 +73,8 @@ class ChatRoomMembershipServiceTest {
 
         given(userRepository.findById(currentUserId))
             .willReturn(java.util.Optional.of(user1));
+        given(chatRoomRepository.findById(chatRoomId))
+            .willReturn(java.util.Optional.of(chatRoom));
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(true);
         given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))
@@ -108,8 +110,14 @@ class ChatRoomMembershipServiceTest {
             .imageUrl("image1.jpg")
             .build();
 
+        ChatRoom chatRoom = ChatRoom.builder()
+            .id(chatRoomId)
+            .build();
+
         given(userRepository.findById(currentUserId))
             .willReturn(java.util.Optional.of(user1));
+        given(chatRoomRepository.findById(chatRoomId))
+            .willReturn(java.util.Optional.of(chatRoom));
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(false);
 
@@ -148,6 +156,8 @@ class ChatRoomMembershipServiceTest {
 
         given(userRepository.findById(currentUserId))
             .willReturn(java.util.Optional.of(user1));
+        given(chatRoomRepository.findById(chatRoomId))
+            .willReturn(java.util.Optional.of(chatRoom));
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(true);
         given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -3,7 +3,6 @@ package gg.agit.konect.unit.domain.chat.service;
 import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDateTime;

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -75,7 +75,7 @@ class ChatRoomMembershipServiceTest {
             .willReturn(java.util.Optional.of(user1));
         given(chatRoomRepository.findById(chatRoomId))
             .willReturn(java.util.Optional.of(chatRoom));
-        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(true);
         given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))
             .willReturn(List.of(member1, member2));
@@ -118,8 +118,38 @@ class ChatRoomMembershipServiceTest {
             .willReturn(java.util.Optional.of(user1));
         given(chatRoomRepository.findById(chatRoomId))
             .willReturn(java.util.Optional.of(chatRoom));
-        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomMembershipService.getChatRoomMembers(chatRoomId, currentUserId))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", FORBIDDEN_CHAT_ROOM_ACCESS);
+    }
+
+    @Test
+    @DisplayName("나간 멤버가 조회 시도 시 FORBIDDEN 예외 발생")
+    void getChatRoomMembers_forbiddenWhenLeftMember() {
+        // given
+        Integer chatRoomId = 1;
+        Integer currentUserId = 100;
+
+        User user1 = User.builder()
+            .id(100)
+            .name("User1")
+            .imageUrl("image1.jpg")
+            .build();
+
+        ChatRoom chatRoom = ChatRoom.builder()
+            .id(chatRoomId)
+            .build();
+
+        given(userRepository.findById(currentUserId))
+            .willReturn(java.util.Optional.of(user1));
+        given(chatRoomRepository.findById(chatRoomId))
+            .willReturn(java.util.Optional.of(chatRoom));
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(chatRoomId, currentUserId))
+            .willReturn(false); // 나간 멤버는 활성 멤버가 아님
 
         // when & then
         assertThatThrownBy(() -> chatRoomMembershipService.getChatRoomMembers(chatRoomId, currentUserId))
@@ -158,7 +188,7 @@ class ChatRoomMembershipServiceTest {
             .willReturn(java.util.Optional.of(user1));
         given(chatRoomRepository.findById(chatRoomId))
             .willReturn(java.util.Optional.of(chatRoom));
-        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(true);
         given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))
             .willReturn(List.of(member1)); // 나간 멤버는 조회되지 않음

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -71,6 +71,8 @@ class ChatRoomMembershipServiceTest {
         ChatRoomMember member1 = ChatRoomMember.ofOwner(chatRoom, user1, LocalDateTime.now());
         ChatRoomMember member2 = ChatRoomMember.of(chatRoom, user2, LocalDateTime.now());
 
+        given(userRepository.findById(currentUserId))
+            .willReturn(java.util.Optional.of(user1));
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(true);
         given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))
@@ -100,6 +102,14 @@ class ChatRoomMembershipServiceTest {
         Integer chatRoomId = 1;
         Integer currentUserId = 100;
 
+        User user1 = User.builder()
+            .id(100)
+            .name("User1")
+            .imageUrl("image1.jpg")
+            .build();
+
+        given(userRepository.findById(currentUserId))
+            .willReturn(java.util.Optional.of(user1));
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(false);
 
@@ -136,6 +146,8 @@ class ChatRoomMembershipServiceTest {
         ChatRoomMember member2 = ChatRoomMember.of(chatRoom, user2, LocalDateTime.now());
         member2.leaveDirectRoom(LocalDateTime.now()); // member2는 나간 상태
 
+        given(userRepository.findById(currentUserId))
+            .willReturn(java.util.Optional.of(user1));
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
             .willReturn(true);
         given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -1,0 +1,152 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import gg.agit.konect.domain.chat.dto.ChatRoomMemberResponse;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersResponse;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.exception.CustomException;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomMembershipServiceTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ChatRoomMembershipService chatRoomMembershipService;
+
+    @Test
+    @DisplayName("채팅방 멤버 목록 조회 성공")
+    void getChatRoomMembers_success() {
+        // given
+        Integer chatRoomId = 1;
+        Integer currentUserId = 100;
+
+        User user1 = User.builder()
+            .id(100)
+            .name("User1")
+            .imageUrl("image1.jpg")
+            .build();
+
+        User user2 = User.builder()
+            .id(200)
+            .name("User2")
+            .imageUrl("image2.jpg")
+            .build();
+
+        ChatRoom chatRoom = ChatRoom.builder()
+            .id(chatRoomId)
+            .build();
+
+        ChatRoomMember member1 = ChatRoomMember.ofOwner(chatRoom, user1, LocalDateTime.now());
+        ChatRoomMember member2 = ChatRoomMember.of(chatRoom, user2, LocalDateTime.now());
+
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
+            .willReturn(true);
+        given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))
+            .willReturn(List.of(member1, member2));
+
+        // when
+        ChatRoomMembersResponse response = chatRoomMembershipService.getChatRoomMembers(chatRoomId, currentUserId);
+
+        // then
+        assertThat(response.members()).hasSize(2);
+
+        ChatRoomMemberResponse firstMember = response.members().get(0);
+        assertThat(firstMember.userId()).isEqualTo(100);
+        assertThat(firstMember.name()).isEqualTo("User1");
+        assertThat(firstMember.isOwner()).isTrue();
+
+        ChatRoomMemberResponse secondMember = response.members().get(1);
+        assertThat(secondMember.userId()).isEqualTo(200);
+        assertThat(secondMember.name()).isEqualTo("User2");
+        assertThat(secondMember.isOwner()).isFalse();
+    }
+
+    @Test
+    @DisplayName("비멤버가 조회 시도 시 FORBIDDEN 예외 발생")
+    void getChatRoomMembers_forbiddenWhenNotMember() {
+        // given
+        Integer chatRoomId = 1;
+        Integer currentUserId = 100;
+
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
+            .willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomMembershipService.getChatRoomMembers(chatRoomId, currentUserId))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", FORBIDDEN_CHAT_ROOM_ACCESS);
+    }
+
+    @Test
+    @DisplayName("나간 멤버는 조회되지 않음")
+    void getChatRoomMembers_excludesLeftMembers() {
+        // given
+        Integer chatRoomId = 1;
+        Integer currentUserId = 100;
+
+        User user1 = User.builder()
+            .id(100)
+            .name("User1")
+            .imageUrl("image1.jpg")
+            .build();
+
+        User user2 = User.builder()
+            .id(200)
+            .name("User2")
+            .imageUrl("image2.jpg")
+            .build();
+
+        ChatRoom chatRoom = ChatRoom.builder()
+            .id(chatRoomId)
+            .build();
+
+        ChatRoomMember member1 = ChatRoomMember.of(chatRoom, user1, LocalDateTime.now());
+        ChatRoomMember member2 = ChatRoomMember.of(chatRoom, user2, LocalDateTime.now());
+        member2.leaveDirectRoom(LocalDateTime.now()); // member2는 나간 상태
+
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, currentUserId))
+            .willReturn(true);
+        given(chatRoomMemberRepository.findActiveMembersByChatRoomId(chatRoomId))
+            .willReturn(List.of(member1)); // 나간 멤버는 조회되지 않음
+
+        // when
+        ChatRoomMembersResponse response = chatRoomMembershipService.getChatRoomMembers(chatRoomId, currentUserId);
+
+        // then
+        assertThat(response.members()).hasSize(1);
+        assertThat(response.members().get(0).userId()).isEqualTo(100);
+    }
+}


### PR DESCRIPTION
### 🔍 개요

채팅방에 접속했을 때 해당 채팅방에 속한 유저의 목록을 조회할 수 있는 API를 추가합니다.

---

### 🚀 주요 변경 내용

* **DTO 추가**: `ChatRoomMemberResponse`, `ChatRoomMembersResponse`
  * 멤버 정보: userId, name, profileImageUrl, isOwner, joinedAt

* **Repository**: `findActiveMembersByChatRoomId` 메서드 추가
  * JOIN FETCH로 User 정보 한 번에 로딩 (N+1 방지)
  * `leftAt IS NULL` 조건으로 나간 멤버 필터링

* **Service**: `getChatRoomMembers` 메서드 구현
  * 채팅방 존재 여부 확인 (404)
  * 멤버십 권한 검증 (403)
  * 탈퇴한 유저 필터링
  * 어드민은 시스템 어드민 방 멤버 조회 가능

* **Controller**: `GET /chats/rooms/{chatRoomId}/members` 엔드포인트 추가
  * Swagger 문서화 완료

* **테스트**: `ChatRoomMembershipServiceTest` 단위 테스트 추가
  * 멤버 조회 성공
  * 비멤버 접근 시 403
  * 나간 멤버 필터링

---

### 💬 참고 사항

* 예외 처리 순서: 채팅방 없음(404) → 비멤버 접근(403)
* `joinedAt`은 `ChatRoomMember.createdAt`을 사용
* Integer 타입으로 기존 코드와 일관성 유지

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)