### PR TITLE
test: ChatRoomMembershipService 테스트 커버리지 보강

### DIFF
--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -312,7 +312,7 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
     @DisplayName("updateDirectRoomLastReadAt는 system-admin room에서 admin이 읽으면 시스템 관리자 멤버만 갱신한다")
     void updateDirectRoomLastReadAtUpdatesSystemAdminForAdminReader() {
         // given
-        Integer roomId = 10;
+        int roomId = 10;
         User admin = createUser(99, "관리자", UserRole.ADMIN);
         ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
@@ -332,7 +332,7 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
     @DisplayName("updateDirectRoomLastReadAt는 일반 멤버가 직접 채팅방에 속하면 본인 lastReadAt을 갱신한다")
     void updateDirectRoomLastReadAtUpdatesReaderWhenMemberExists() {
         // given
-        Integer roomId = 10;
+        int roomId = 10;
         User user = createUser(20, "사용자", UserRole.USER);
         ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
@@ -349,7 +349,7 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
     @DisplayName("updateDirectRoomLastReadAt는 일반 사용자가 멤버가 아니면 접근을 거부한다")
     void updateDirectRoomLastReadAtRejectsNonMemberUser() {
         // given
-        Integer roomId = 10;
+        int roomId = 10;
         User user = createUser(20, "사용자", UserRole.USER);
         ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
@@ -367,7 +367,7 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
     @DisplayName("updateDirectRoomLastReadAt는 admin이 system-admin room 비멤버여도 본인 멤버를 생성하지 않는다")
     void updateDirectRoomLastReadAtSkipsAdminMembershipCreationInSystemAdminRoom() {
         // given
-        Integer roomId = 10;
+        int roomId = 10;
         User admin = createUser(99, "관리자", UserRole.ADMIN);
         ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -509,6 +509,6 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
     private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
         assertThatThrownBy(callable)
             .isInstanceOf(CustomException.class)
-            .satisfies(exception -> assertThat(((CustomException) exception).getErrorCode()).isEqualTo(errorCode));
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(errorCode));
     }
 }

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -286,7 +286,8 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
         given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
 
         // when & then
-        assertErrorCode(() -> chatRoomMembershipService.ensureClubRoomMember(directRoom.getId(), 20), NOT_FOUND_CHAT_ROOM);
+        assertErrorCode(() -> chatRoomMembershipService.ensureClubRoomMember(directRoom.getId(), 20),
+            NOT_FOUND_CHAT_ROOM);
         verify(clubMemberRepository, never()).getByClubIdAndUserId(any(), any());
     }
 

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -1,0 +1,410 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gg.agit.konect.domain.chat.enums.ChatType;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.ClubMember;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
+import gg.agit.konect.support.fixture.ClubMemberFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ChatRoomMembershipServiceTest extends ServiceTestSupport {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ChatRoomMembershipService chatRoomMembershipService;
+
+    @Test
+    @DisplayName("addClubMember는 기존 클럽 채팅방이 없으면 생성하고 멤버를 저장한다")
+    void addClubMemberCreatesClubRoomAndSavesMember() {
+        // given
+        Club club = createClub(10);
+        User user = createUser(20, "동아리원", UserRole.USER);
+        ClubMember clubMember = createClubMember(club, user, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoom savedRoom = createRoom(30, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findByClubId(club.getId())).willReturn(Optional.empty());
+        given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(savedRoom);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(savedRoom.getId(), user.getId()))
+            .willReturn(Optional.empty());
+
+        // when
+        chatRoomMembershipService.addClubMember(clubMember);
+
+        // then
+        verify(chatRoomRepository).save(any(ChatRoom.class));
+        verify(chatRoomMemberRepository).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("addClubMember는 채팅방 동시 생성 중복 예외가 나면 재조회한 방에 멤버를 추가한다")
+    void addClubMemberReloadsRoomWhenClubRoomCreationHitsDuplicate() {
+        // given
+        Club club = createClub(10);
+        User user = createUser(20, "동아리원", UserRole.USER);
+        ClubMember clubMember = createClubMember(club, user, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoom existingRoom = createRoom(31, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findByClubId(club.getId()))
+            .willReturn(Optional.empty())
+            .willReturn(Optional.of(existingRoom));
+        given(chatRoomRepository.save(any(ChatRoom.class)))
+            .willThrow(new DuplicateKeyException("duplicate room"));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(existingRoom.getId(), user.getId()))
+            .willReturn(Optional.empty());
+
+        // when
+        chatRoomMembershipService.addClubMember(clubMember);
+
+        // then
+        verify(chatRoomRepository).save(any(ChatRoom.class));
+        verify(chatRoomRepository, times(2)).findByClubId(club.getId());
+        verify(chatRoomMemberRepository).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("addClubMember는 이미 멤버가 있으면 더 최신 createdAt일 때만 lastReadAt을 갱신한다")
+    void addClubMemberUpdatesLastReadAtOnlyWhenBaselineIsNewer() {
+        // given
+        Club club = createClub(10);
+        User user = createUser(20, "동아리원", UserRole.USER);
+        ChatRoom room = createRoom(30, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 9, 0));
+        ClubMember clubMember = createClubMember(club, user, LocalDateTime.of(2026, 4, 11, 11, 0));
+        ChatRoomMember existingMember = createRoomMember(room, user, false, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findByClubId(club.getId())).willReturn(Optional.of(room));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(existingMember));
+
+        // when
+        chatRoomMembershipService.addClubMember(clubMember);
+
+        // then
+        assertThat(existingMember.getLastReadAt()).isEqualTo(clubMember.getCreatedAt());
+        verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("addClubMember는 이미 더 최신 lastReadAt이 있으면 저장하지 않고 유지한다")
+    void addClubMemberKeepsLastReadAtWhenExistingMemberIsNewer() {
+        // given
+        Club club = createClub(10);
+        User user = createUser(20, "동아리원", UserRole.USER);
+        ChatRoom room = createRoom(30, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 9, 0));
+        ClubMember clubMember = createClubMember(club, user, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember existingMember = createRoomMember(room, user, false, LocalDateTime.of(2026, 4, 11, 11, 0));
+
+        given(chatRoomRepository.findByClubId(club.getId())).willReturn(Optional.of(room));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(existingMember));
+
+        // when
+        chatRoomMembershipService.addClubMember(clubMember);
+
+        // then
+        assertThat(existingMember.getLastReadAt()).isEqualTo(LocalDateTime.of(2026, 4, 11, 11, 0));
+        verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("addDirectMembers는 joinedAt이 null이면 즉시 실패한다")
+    void addDirectMembersFailsWhenJoinedAtIsNull() {
+        // given
+        ChatRoom room = createRoom(10, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        User firstUser = createUser(20, "첫번째", UserRole.USER);
+        User secondUser = createUser(30, "두번째", UserRole.USER);
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomMembershipService.addDirectMembers(room, firstUser, secondUser, null))
+            .isInstanceOf(NullPointerException.class);
+        verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("addDirectMembers는 멤버 저장 중 중복 예외가 나면 무시하고 나머지 멤버를 계속 처리한다")
+    void addDirectMembersIgnoresDuplicateMemberSave() {
+        // given
+        ChatRoom room = createRoom(10, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        User firstUser = createUser(20, "첫번째", UserRole.USER);
+        User secondUser = createUser(30, "두번째", UserRole.USER);
+        LocalDateTime joinedAt = LocalDateTime.of(2026, 4, 11, 10, 5);
+
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), firstUser.getId()))
+            .willReturn(Optional.empty());
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), secondUser.getId()))
+            .willReturn(Optional.empty());
+        given(chatRoomMemberRepository.save(any(ChatRoomMember.class)))
+            .willThrow(new DuplicateKeyException("duplicate member"))
+            .willReturn(createRoomMember(room, secondUser, false, joinedAt));
+
+        // when
+        chatRoomMembershipService.addDirectMembers(room, firstUser, secondUser, joinedAt);
+
+        // then
+        verify(chatRoomMemberRepository, times(2)).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("removeClubMember는 클럽 채팅방이 있을 때만 멤버를 삭제한다")
+    void removeClubMemberDeletesOnlyWhenClubRoomExists() {
+        // given
+        ChatRoom room = createRoom(10, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 10, 0));
+        given(chatRoomRepository.findByClubId(1)).willReturn(Optional.of(room));
+
+        // when
+        chatRoomMembershipService.removeClubMember(1, 20);
+
+        // then
+        verify(chatRoomMemberRepository).deleteByChatRoomIdAndUserId(room.getId(), 20);
+    }
+
+    @Test
+    @DisplayName("updateDirectRoomLastReadAt는 system-admin room에서 admin이 읽으면 시스템 관리자 멤버만 갱신한다")
+    void updateDirectRoomLastReadAtUpdatesSystemAdminForAdminReader() {
+        // given
+        Integer roomId = 10;
+        User admin = createUser(99, "관리자", UserRole.ADMIN);
+        ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
+        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(roomId)))
+            .willReturn(List.<Object[]>of(new Object[] {roomId, SYSTEM_ADMIN_ID, readAt}));
+
+        // when
+        chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, admin, readAt, room);
+
+        // then
+        verify(chatRoomMemberRepository).updateLastReadAtIfOlder(roomId, SYSTEM_ADMIN_ID, readAt);
+        verify(chatRoomMemberRepository, never()).existsByChatRoomIdAndUserId(roomId, admin.getId());
+        verify(chatRoomMemberRepository, never()).updateLastReadAtIfOlder(roomId, admin.getId(), readAt);
+    }
+
+    @Test
+    @DisplayName("updateDirectRoomLastReadAt는 일반 멤버가 직접 채팅방에 속하면 본인 lastReadAt을 갱신한다")
+    void updateDirectRoomLastReadAtUpdatesReaderWhenMemberExists() {
+        // given
+        Integer roomId = 10;
+        User user = createUser(20, "사용자", UserRole.USER);
+        ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(roomId, user.getId())).willReturn(true);
+
+        // when
+        chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, user, readAt, room);
+
+        // then
+        verify(chatRoomMemberRepository).updateLastReadAtIfOlder(roomId, user.getId(), readAt);
+    }
+
+    @Test
+    @DisplayName("updateDirectRoomLastReadAt는 일반 사용자가 멤버가 아니면 접근을 거부한다")
+    void updateDirectRoomLastReadAtRejectsNonMemberUser() {
+        // given
+        Integer roomId = 10;
+        User user = createUser(20, "사용자", UserRole.USER);
+        ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(roomId, user.getId())).willReturn(false);
+
+        // when & then
+        assertErrorCode(
+            () -> chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, user, readAt, room),
+            FORBIDDEN_CHAT_ROOM_ACCESS
+        );
+        verify(chatRoomMemberRepository, never()).updateLastReadAtIfOlder(roomId, user.getId(), readAt);
+    }
+
+    @Test
+    @DisplayName("updateDirectRoomLastReadAt는 admin이 system-admin room 비멤버여도 본인 멤버를 생성하지 않는다")
+    void updateDirectRoomLastReadAtSkipsAdminMembershipCreationInSystemAdminRoom() {
+        // given
+        Integer roomId = 10;
+        User admin = createUser(99, "관리자", UserRole.ADMIN);
+        ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
+        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(roomId)))
+            .willReturn(List.<Object[]>of(new Object[] {roomId, SYSTEM_ADMIN_ID, readAt}));
+
+        // when
+        chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, admin, readAt, room);
+
+        // then
+        verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("ensureClubRoomMember는 group room이 아니거나 club이 없으면 채팅방을 찾을 수 없다고 본다")
+    void ensureClubRoomMemberRejectsNonClubGroupRoom() {
+        // given
+        ChatRoom directRoom = createRoom(10, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+
+        // when & then
+        assertErrorCode(() -> chatRoomMembershipService.ensureClubRoomMember(directRoom.getId(), 20), NOT_FOUND_CHAT_ROOM);
+        verify(clubMemberRepository, never()).getByClubIdAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("ensureClubRoomMember는 club 멤버 createdAt 기준으로 채팅방 멤버를 보장한다")
+    void ensureClubRoomMemberCreatesOrUpdatesMemberFromClubMemberBaseline() {
+        // given
+        Club club = createClub(10);
+        ChatRoom room = createRoom(30, ChatType.CLUB_GROUP, LocalDateTime.of(2026, 4, 11, 9, 0));
+        ReflectionTestUtils.setField(room, "club", club);
+        User user = createUser(20, "동아리원", UserRole.USER);
+        ClubMember clubMember = createClubMember(club, user, LocalDateTime.of(2026, 4, 11, 10, 0));
+
+        given(chatRoomRepository.findById(room.getId())).willReturn(Optional.of(room));
+        given(clubMemberRepository.getByClubIdAndUserId(club.getId(), user.getId())).willReturn(clubMember);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.empty());
+
+        // when
+        chatRoomMembershipService.ensureClubRoomMember(room.getId(), user.getId());
+
+        // then
+        verify(chatRoomMemberRepository).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("updateLastReadAt는 저장된 값이 더 오래된 경우에만 갱신 쿼리를 위임한다")
+    void updateLastReadAtDelegatesConditionalUpdate() {
+        // when
+        LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 0);
+        chatRoomMembershipService.updateLastReadAt(10, 20, readAt);
+
+        // then
+        verify(chatRoomMemberRepository).updateLastReadAtIfOlder(10, 20, readAt);
+    }
+
+    @Test
+    @DisplayName("중복이 아닌 DataIntegrityViolationException은 삼키지 않고 다시 던진다")
+    void addClubMemberRethrowsNonDuplicateIntegrityViolation() {
+        // given
+        Club club = createClub(10);
+        User user = createUser(20, "동아리원", UserRole.USER);
+        ClubMember clubMember = createClubMember(club, user, LocalDateTime.of(2026, 4, 11, 10, 0));
+        DataIntegrityViolationException exception = new DataIntegrityViolationException("other constraint");
+
+        given(chatRoomRepository.findByClubId(club.getId())).willReturn(Optional.empty());
+        given(chatRoomRepository.save(any(ChatRoom.class))).willThrow(exception);
+
+        // when & then
+        assertThatThrownBy(() -> chatRoomMembershipService.addClubMember(clubMember))
+            .isSameAs(exception);
+    }
+
+    @Test
+    @DisplayName("root cause 메시지에 duplicate key가 있으면 채팅방 멤버 저장 중복도 무시한다")
+    void addDirectMembersIgnoresDuplicateByRootCauseMessage() {
+        // given
+        ChatRoom room = createRoom(10, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        User firstUser = createUser(20, "첫번째", UserRole.USER);
+        User secondUser = createUser(30, "두번째", UserRole.USER);
+        LocalDateTime joinedAt = LocalDateTime.of(2026, 4, 11, 10, 5);
+        DataIntegrityViolationException duplicateLikeException = new DataIntegrityViolationException(
+            "constraint violated",
+            new RuntimeException("duplicate key value violates unique constraint")
+        );
+
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), firstUser.getId()))
+            .willReturn(Optional.empty());
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), secondUser.getId()))
+            .willReturn(Optional.empty());
+        given(chatRoomMemberRepository.save(any(ChatRoomMember.class)))
+            .willThrow(duplicateLikeException)
+            .willReturn(createRoomMember(room, secondUser, false, joinedAt));
+
+        // when
+        chatRoomMembershipService.addDirectMembers(room, firstUser, secondUser, joinedAt);
+
+        // then
+        verify(chatRoomMemberRepository, times(2)).save(any(ChatRoomMember.class));
+    }
+
+    private Club createClub(Integer clubId) {
+        return ClubFixture.createWithId(UniversityFixture.createWithId(1), clubId, "BCSD");
+    }
+
+    private User createUser(Integer userId, String name, UserRole role) {
+        return UserFixture.createUserWithId(userId, name, role);
+    }
+
+    private ClubMember createClubMember(Club club, User user, LocalDateTime createdAt) {
+        ClubMember clubMember = ClubMemberFixture.createMember(club, user);
+        ReflectionTestUtils.setField(clubMember, "createdAt", createdAt);
+        return clubMember;
+    }
+
+    private ChatRoom createRoom(Integer id, ChatType type, LocalDateTime createdAt) {
+        ChatRoom room = switch (type) {
+            case DIRECT -> ChatRoom.directOf();
+            case GROUP -> ChatRoom.groupOf();
+            case CLUB_GROUP -> ChatRoom.clubGroupOf(createClub(77));
+            default -> throw new IllegalArgumentException("Unsupported ChatType: " + type);
+        };
+        ReflectionTestUtils.setField(room, "id", id);
+        ReflectionTestUtils.setField(room, "createdAt", createdAt);
+        return room;
+    }
+
+    private ChatRoomMember createRoomMember(ChatRoom room, User user, boolean isOwner, LocalDateTime lastReadAt) {
+        ChatRoomMember member = isOwner
+            ? ChatRoomMember.ofOwner(room, user, lastReadAt)
+            : ChatRoomMember.of(room, user, lastReadAt);
+        ReflectionTestUtils.setField(member, "createdAt", lastReadAt);
+        return member;
+    }
+
+    private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
+        assertThatThrownBy(callable)
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(errorCode));
+    }
+}


### PR DESCRIPTION
### 🔍 개요

* ChatRoomMembershipService의 public 메서드를 대상으로 정상 흐름과 예외 흐름을 분리해 단위 테스트를 보강했습니다.
* 멤버십 생성, 중복 저장, 접근 권한, system-admin 예외 처리처럼 회귀가 나기 쉬운 경계 조건을 테스트로 고정했습니다.

---

### 🚀 주요 변경 내용

* `src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java`를 추가했습니다.
* `addClubMember`의 채팅방 생성, 동시성 중복 예외 fallback, 기존 멤버의 `lastReadAt` 갱신/유지 분기를 검증했습니다.
* `addDirectMembers`의 `joinedAt` null, 멤버 저장 중복 예외, root cause 기반 duplicate 판별 경로를 검증했습니다.
* `updateDirectRoomLastReadAt`의 일반 멤버 갱신, 비멤버 접근 거부, admin의 system-admin room 처리 예외를 검증했습니다.
* `ensureClubRoomMember`, `removeClubMember`, `updateLastReadAt`의 위임 및 예외 분기를 검증했습니다.

---

### 💬 참고 사항

* 브랜치에는 테스트 추가 커밋과 포맷 정리 커밋이 함께 포함되며, 실질적인 변경은 ChatRoomMembershipService 테스트 보강입니다.
* 실행 검증은 `./gradlew test --tests gg.agit.konect.unit.domain.chat.service.ChatRoomMembershipServiceTest`로 완료했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---