### PR TITLE
chore: 롤링 로그 gzip 압축 적용

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -17,7 +17,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_PATH}/konect-backend.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/konect-backend.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_PATH}/konect-backend.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
             <maxHistory>30</maxHistory>
             <totalSizeCap>3GB</totalSizeCap>
         </rollingPolicy>
@@ -29,7 +29,7 @@
     <appender name="SCHEDULER_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_PATH}/scheduler.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/scheduler.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_PATH}/scheduler.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
             <maxHistory>7</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>


### PR DESCRIPTION
### 🔍 개요

* Logback 롤링 로그가 생성 직후 gzip으로 압축되도록 설정을 변경했습니다.

---

### 🚀 주요 변경 내용

* `src/main/resources/logback-spring.xml`의 backend 로그 롤링 파일 패턴을 `.log.gz`로 변경
* `src/main/resources/logback-spring.xml`의 scheduler 로그 롤링 파일 패턴을 `.log.gz`로 변경
* 이후 생성되는 일별 로그가 개별 gzip 파일로 바로 보관되도록 정리

---

### 💬 참고 사항

* 기존에 이미 생성된 `.log` 롤링 파일은 자동으로 재압축되지 않고, 이번 설정은 새로 롤링되는 파일부터 적용됩니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)