### PR TITLE
fix: 메시지 검색 결과에 unreadCount, isMuted 필드 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessageMatchResult.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatMessageMatchResult.java
@@ -32,7 +32,13 @@ public record ChatMessageMatchResult(
     LocalDateTime matchedMessageSentAt,
 
     @Schema(description = "검색에 매칭된 메시지 ID", example = "42", requiredMode = REQUIRED)
-    Integer matchedMessageId
+    Integer matchedMessageId,
+
+    @Schema(description = "읽지 않은 메시지 수", example = "3", requiredMode = REQUIRED)
+    Integer unreadCount,
+
+    @Schema(description = "채팅방 알림 뮤트 여부", example = "false", requiredMode = REQUIRED)
+    Boolean isMuted
 ) {
 
     public static ChatMessageMatchResult from(ChatRoomSummaryResponse room, ChatMessage message) {
@@ -43,7 +49,9 @@ public record ChatMessageMatchResult(
             room.roomImageUrl(),
             message.getContent(),
             message.getCreatedAt(),
-            message.getId()
+            message.getId(),
+            room.unreadCount(),
+            room.isMuted()
         );
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 


---

### 🚀 주요 변경 내용

* roomMatches와 동일하게 messageMatches 응답에도 읽지 않은 메시지 수와 알림 뮤트 여부를 포함하도록 수정


---

### 💬 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
