### PR TITLE
fix: 완료된 SSE emitter 전송 예외를 정리하도록 처리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/notification/service/NotificationInboxSseService.java
+++ b/src/main/java/gg/agit/konect/domain/notification/service/NotificationInboxSseService.java
@@ -51,7 +51,12 @@ public class NotificationInboxSseService {
             log.warn("SSE send failed: userId={}", userId, e);
             emitters.remove(userId, emitter);
             if (e instanceof IOException ioException) {
-                emitter.completeWithError(ioException);
+                try {
+                    emitter.completeWithError(ioException);
+                } catch (IllegalStateException completeException) {
+                    log.warn("SSE emitter already completed while closing after send failure: userId={}", userId,
+                        completeException);
+                }
             }
         }
     }

--- a/src/main/java/gg/agit/konect/domain/notification/service/NotificationInboxSseService.java
+++ b/src/main/java/gg/agit/konect/domain/notification/service/NotificationInboxSseService.java
@@ -47,10 +47,12 @@ public class NotificationInboxSseService {
         }
         try {
             emitter.send(SseEmitter.event().name("notification").data(notification));
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException e) {
             log.warn("SSE send failed: userId={}", userId, e);
             emitters.remove(userId, emitter);
-            emitter.completeWithError(e);
+            if (e instanceof IOException ioException) {
+                emitter.completeWithError(ioException);
+            }
         }
     }
 }

--- a/src/test/java/gg/agit/konect/unit/domain/notification/service/NotificationInboxSseServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/notification/service/NotificationInboxSseServiceTest.java
@@ -2,6 +2,7 @@ package gg.agit.konect.unit.domain.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -109,20 +110,17 @@ class NotificationInboxSseServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("send는 IOException 발생 시 emitter를 제거한다")
-    void sendRemovesEmitterOnIOException() {
+    @DisplayName("send는 이미 완료된 emitter가 남아 있어도 예외 없이 정리한다")
+    void sendRemovesCompletedEmitterOnIllegalStateException() throws Exception {
         // given
-        notificationInboxSseService.subscribe(1);
+        SseEmitter emitter = notificationInboxSseService.subscribe(1);
+        emitter.complete();
+        emitters().put(1, emitter);
         NotificationInboxResponse response = createMockNotificationResponse();
 
-        // when
-        // emitter가 존재하는 상태에서 전송 시도
-        notificationInboxSseService.send(1, response);
-
-        // then
-        // 메서드가 정상적으로 동작하는지 확인
-        assertThatCode(() -> notificationInboxSseService.send(1, response))
-            .doesNotThrowAnyException();
+        // when & then
+        assertThatNoException().isThrownBy(() -> notificationInboxSseService.send(1, response));
+        assertThat(emitters()).doesNotContainKey(1);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/gg/agit/konect/unit/domain/notification/service/NotificationInboxSseServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/notification/service/NotificationInboxSseServiceTest.java
@@ -113,7 +113,9 @@ class NotificationInboxSseServiceTest extends ServiceTestSupport {
     @DisplayName("send는 이미 완료된 emitter가 남아 있어도 예외 없이 정리한다")
     void sendRemovesCompletedEmitterOnIllegalStateException() throws Exception {
         // given
-        SseEmitter emitter = notificationInboxSseService.subscribe(1);
+        // subscribe의 completion callback에 의존하지 않고,
+        // 이미 종료된 emitter가 맵에 남아 있는 상태를 결정적으로 재현한다.
+        SseEmitter emitter = new SseEmitter();
         emitter.complete();
         emitters().put(1, emitter);
         NotificationInboxResponse response = createMockNotificationResponse();


### PR DESCRIPTION
### 🔍 개요

* 이미 완료되었거나 종료 경쟁 상태에 들어간 SSE emitter 때문에 알림 전송 정리 과정에서 예외가 다시 전파되지 않도록 예외 처리 경로를 보강했습니다.

---

### 🚀 주요 변경 내용

* `NotificationInboxSseService`에서 `IOException`뿐 아니라 완료된 emitter 전송 시 발생하는 `IllegalStateException`도 함께 처리하도록 변경했습니다.
* `IOException` 정리 과정에서 호출하는 `completeWithError`도 별도 `try-catch`로 감싸, emitter가 이미 종료된 경쟁 상황에서도 추가 예외가 전파되지 않도록 했습니다.
* 테스트는 `subscribe()`의 completion callback 부수효과에 기대지 않고, 완료된 `SseEmitter`를 직접 주입해 예외 정리 경로를 결정적으로 재현하도록 바꿨습니다.

---

### 💬 참고 사항

* 대상 테스트: `./gradlew test --tests \"gg.agit.konect.unit.domain.notification.service.NotificationInboxSseServiceTest\"`
* 리뷰 코멘트 반영으로 emitter 종료 race condition 보호와 테스트 안정성을 추가 보완했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---