### PR TITLE
fix: 채팅방 마지막 메시지 메타데이터 동기화

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
@@ -5,6 +5,7 @@ import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +19,19 @@ import gg.agit.konect.global.exception.CustomException;
 public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
 
     ChatRoom save(ChatRoom chatRoom);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE ChatRoom cr
+        SET cr.lastMessageContent = :content,
+            cr.lastMessageSentAt = :sentAt
+        WHERE cr.id = :roomId
+        """)
+    int updateLastMessage(
+        @Param("roomId") Integer roomId,
+        @Param("content") String content,
+        @Param("sentAt") java.time.LocalDateTime sentAt
+    );
 
     @Query("""
         SELECT DISTINCT cr

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
@@ -21,15 +21,25 @@ public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
 
     ChatRoom save(ChatRoom chatRoom);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(flushAutomatically = true)
     @Query("""
         UPDATE ChatRoom cr
         SET cr.lastMessageContent = :content,
             cr.lastMessageSentAt = :sentAt
         WHERE cr.id = :roomId
+          AND NOT EXISTS (
+              SELECT 1
+              FROM ChatMessage cm
+              WHERE cm.chatRoom.id = :roomId
+                AND (
+                    cm.createdAt > :sentAt
+                    OR (cm.createdAt = :sentAt AND cm.id > :messageId)
+                )
+          )
         """)
-    int updateLastMessage(
+    int updateLastMessageIfLatest(
         @Param("roomId") Integer roomId,
+        @Param("messageId") Integer messageId,
         @Param("content") String content,
         @Param("sentAt") LocalDateTime sentAt
     );

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
@@ -31,6 +31,7 @@ public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
               SELECT 1
               FROM ChatMessage cm
               WHERE cm.chatRoom.id = :roomId
+                AND cm.id <> :messageId
                 AND (
                     cm.createdAt > :sentAt
                     OR (cm.createdAt = :sentAt AND cm.id > :messageId)

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package gg.agit.konect.domain.chat.repository;
 
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,7 +31,7 @@ public interface ChatRoomRepository extends Repository<ChatRoom, Integer> {
     int updateLastMessage(
         @Param("roomId") Integer roomId,
         @Param("content") String content,
-        @Param("sentAt") java.time.LocalDateTime sentAt
+        @Param("sentAt") LocalDateTime sentAt
     );
 
     @Query("""

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -433,7 +433,7 @@ public class ChatService {
         return getGroupMessagesByRoomId(roomId, userId, page, limit);
     }
 
-    @Transactional(readOnly = false)
+    @Transactional
     public ChatMessageDetailResponse sendMessage(Integer userId, Integer roomId, ChatMessageSendRequest request) {
         ChatRoom room = chatRoomRepository.findById(roomId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1211,9 +1211,17 @@ public class ChatService {
     }
 
     private void syncLastMessage(ChatRoom room, ChatMessage message) {
-        room.updateLastMessage(message.getContent(), message.getCreatedAt());
-        // 채팅방 목록은 chat_room.last_message_*를 직접 조회하므로 메시지 저장과 메타데이터 갱신을 같은 경로에서 고정한다.
-        chatRoomRepository.updateLastMessage(room.getId(), message.getContent(), message.getCreatedAt());
+        // 채팅방 목록은 chat_room.last_message_*를 직접 조회하므로
+        // 동시 전송에서도 가장 최신 메시지만 메타데이터를 덮어쓰도록 DB 조건을 같이 건다.
+        int updated = chatRoomRepository.updateLastMessageIfLatest(
+            room.getId(),
+            message.getId(),
+            message.getContent(),
+            message.getCreatedAt()
+        );
+        if (updated > 0) {
+            room.updateLastMessage(message.getContent(), message.getCreatedAt());
+        }
     }
 
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -433,7 +433,7 @@ public class ChatService {
         return getGroupMessagesByRoomId(roomId, userId, page, limit);
     }
 
-    @Transactional
+    @Transactional(readOnly = false)
     public ChatMessageDetailResponse sendMessage(Integer userId, Integer roomId, ChatMessageSendRequest request) {
         ChatRoom room = chatRoomRepository.findById(roomId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
@@ -746,7 +746,7 @@ public class ChatService {
             senderMember.restoreDirectRoom();
         }
 
-        chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
+        syncLastMessage(chatRoom, chatMessage);
         members.stream()
             .filter(member -> !member.getUserId().equals(userId))
             .filter(ChatRoomMember::hasLeft)
@@ -828,7 +828,7 @@ public class ChatService {
         ensureRoomMember(room, sender, member.getCreatedAt());
 
         ChatMessage message = chatMessageRepository.save(ChatMessage.of(room, sender, content));
-        room.updateLastMessage(message.getContent(), message.getCreatedAt());
+        syncLastMessage(room, message);
         updateClubMessageLastReadAt(roomId, userId, message.getCreatedAt());
 
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
@@ -909,7 +909,7 @@ public class ChatService {
         }
 
         ChatMessage message = chatMessageRepository.save(ChatMessage.of(room, sender, content));
-        room.updateLastMessage(message.getContent(), message.getCreatedAt());
+        syncLastMessage(room, message);
         updateLastReadAt(roomId, userId, message.getCreatedAt());
 
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
@@ -1208,6 +1208,12 @@ public class ChatService {
         if (isSystemAdminRoom && !sender.isAdmin()) {
             eventPublisher.publishEvent(AdminChatReceivedEvent.of(sender.getId(), sender.getName(), content));
         }
+    }
+
+    private void syncLastMessage(ChatRoom room, ChatMessage message) {
+        room.updateLastMessage(message.getContent(), message.getCreatedAt());
+        // 채팅방 목록은 chat_room.last_message_*를 직접 조회하므로 메시지 저장과 메타데이터 갱신을 같은 경로에서 고정한다.
+        chatRoomRepository.updateLastMessage(room.getId(), message.getContent(), message.getCreatedAt());
     }
 
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {

--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -132,6 +132,7 @@ public class UserService {
                 ChatMessage.of(chatRoom, operator, DEFAULT_WELCOME_MESSAGE)
             );
             chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
+            chatRoomRepository.updateLastMessage(chatRoom.getId(), chatMessage.getContent(), chatMessage.getCreatedAt());
         } catch (Exception e) {
             log.warn("회원가입 환영 메시지 전송 실패. userId={}", newUser.getId(), e);
         }

--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -138,8 +138,15 @@ public class UserService {
     }
 
     private void syncLastMessage(ChatRoom chatRoom, ChatMessage chatMessage) {
-        chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
-        chatRoomRepository.updateLastMessage(chatRoom.getId(), chatMessage.getContent(), chatMessage.getCreatedAt());
+        int updated = chatRoomRepository.updateLastMessageIfLatest(
+            chatRoom.getId(),
+            chatMessage.getId(),
+            chatMessage.getContent(),
+            chatMessage.getCreatedAt()
+        );
+        if (updated > 0) {
+            chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
+        }
     }
 
     private UnRegisteredUser findUnregisteredUser(String email, String providerId, Provider provider) {

--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -131,12 +131,15 @@ public class UserService {
             ChatMessage chatMessage = chatMessageRepository.save(
                 ChatMessage.of(chatRoom, operator, DEFAULT_WELCOME_MESSAGE)
             );
-            chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
-            chatRoomRepository.updateLastMessage(chatRoom.getId(), chatMessage.getContent(),
-                chatMessage.getCreatedAt());
+            syncLastMessage(chatRoom, chatMessage);
         } catch (Exception e) {
             log.warn("회원가입 환영 메시지 전송 실패. userId={}", newUser.getId(), e);
         }
+    }
+
+    private void syncLastMessage(ChatRoom chatRoom, ChatMessage chatMessage) {
+        chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
+        chatRoomRepository.updateLastMessage(chatRoom.getId(), chatMessage.getContent(), chatMessage.getCreatedAt());
     }
 
     private UnRegisteredUser findUnregisteredUser(String email, String providerId, Provider provider) {

--- a/src/main/java/gg/agit/konect/domain/user/service/UserService.java
+++ b/src/main/java/gg/agit/konect/domain/user/service/UserService.java
@@ -132,7 +132,8 @@ public class UserService {
                 ChatMessage.of(chatRoom, operator, DEFAULT_WELCOME_MESSAGE)
             );
             chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
-            chatRoomRepository.updateLastMessage(chatRoom.getId(), chatMessage.getContent(), chatMessage.getCreatedAt());
+            chatRoomRepository.updateLastMessage(chatRoom.getId(), chatMessage.getContent(),
+                chatMessage.getCreatedAt());
         } catch (Exception e) {
             log.warn("회원가입 환영 메시지 전송 실패. userId={}", newUser.getId(), e);
         }

--- a/src/main/resources/db/migration/V70__backfill_chat_room_last_message_metadata.sql
+++ b/src/main/resources/db/migration/V70__backfill_chat_room_last_message_metadata.sql
@@ -1,0 +1,24 @@
+-- 채팅방 목록/관리 쿼리는 chat_room.last_message_*를 직접 사용하므로
+-- 기존 메시지 이력이 있는 방도 최신 메시지 메타데이터를 다시 맞춰 준다.
+-- MAX(created_at)으로 최신 메시지를 고르고, 같은 시각이면 id로 타이브레이크한다.
+UPDATE chat_room cr
+LEFT JOIN (
+    SELECT
+        cm1.chat_room_id,
+        cm1.content,
+        cm1.created_at
+    FROM chat_message cm1
+    JOIN (
+        SELECT chat_room_id, MAX(created_at) AS max_created_at
+        FROM chat_message
+        GROUP BY chat_room_id
+    ) cm2 ON cm2.chat_room_id = cm1.chat_room_id AND cm2.max_created_at = cm1.created_at
+    WHERE cm1.id = (
+        SELECT MAX(id)
+        FROM chat_message
+        WHERE chat_room_id = cm1.chat_room_id
+          AND created_at = cm2.max_created_at
+    )
+) latest_msg ON latest_msg.chat_room_id = cr.id
+SET cr.last_message_content = latest_msg.content,
+    cr.last_message_sent_at = latest_msg.created_at;

--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -939,6 +939,15 @@ class ChatApiTest extends IntegrationTestSupport {
             performPost("/chats/rooms/" + chatRoom.getId() + "/messages", new ChatMessageSendRequest("다시 안녕"))
                 .andExpect(status().isOk());
 
+            transactionTemplate.execute(status -> {
+                clearPersistenceContext();
+                ChatRoomMember restoredMember = chatRoomMemberRepository
+                    .findByChatRoomIdAndUserId(chatRoom.getId(), normalUser.getId())
+                    .orElseThrow();
+                assertThat(restoredMember.hasLeft()).isFalse();
+                return null;
+            });
+
             mockLoginUser(normalUser.getId());
             performGet("/chats/rooms")
                 .andExpect(status().isOk())

--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -719,6 +719,35 @@ class ChatApiTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("메시지를 전송하면 chat_room last message 메타데이터도 함께 갱신된다")
+        @Sql(
+            statements = CHAT_TEST_DATA_CLEANUP_SQL,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+            executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+        )
+        void sendMessageUpdatesChatRoomLastMessageColumns() throws Exception {
+            // given
+            ChatRoom chatRoom = createDirectChatRoom(normalUser, targetUser);
+            mockLoginUser(normalUser.getId());
+
+            // when
+            performPost("/chats/rooms/" + chatRoom.getId() + "/messages", new ChatMessageSendRequest("메타데이터 확인"))
+                .andExpect(status().isOk());
+
+            // then
+            TestTransaction.flagForCommit();
+            TestTransaction.end();
+
+            transactionTemplate.execute(status -> {
+                clearPersistenceContext();
+                ChatRoom updatedRoom = chatRoomRepository.findById(chatRoom.getId()).orElseThrow();
+                assertThat(updatedRoom.getLastMessageContent()).isEqualTo("메타데이터 확인");
+                assertThat(updatedRoom.getLastMessageSentAt()).isNotNull();
+                return null;
+            });
+        }
+
+        @Test
         @DisplayName("관리자가 문의방에 답변하면 실제 문의 사용자에게 알림을 보낸다")
         void adminReplySendsNotificationToInquiryUser() throws Exception {
             User anotherAdmin = persist(UserFixture.createAdmin(university));

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -825,6 +825,9 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId()))
             .willReturn(List.of(senderMember, receiverMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomRepository.updateLastMessageIfLatest(
+            directRoom.getId(), savedMessage.getId(), savedMessage.getContent(), savedMessage.getCreatedAt()
+        )).willReturn(1);
         given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(directRoom.getId()), eq(senderId),
             any(LocalDateTime.class)))
             .willReturn(1);
@@ -844,6 +847,44 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
+    @DisplayName("sendMessage는 이미 더 최신 메시지가 있으면 room 마지막 메시지 메타데이터를 덮어쓰지 않는다")
+    void sendMessageDoesNotOverwriteRoomMetadataWhenNewerMessageAlreadyExists() {
+        Integer senderId = 10;
+        Integer receiverId = 20;
+        User sender = createUser(senderId, "보낸이", UserRole.USER);
+        User receiver = createUser(receiverId, "받는이", UserRole.USER);
+        ChatRoom directRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember senderMember = createRoomMember(directRoom, sender, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember receiverMember = createRoomMember(directRoom, receiver, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage savedMessage = createMessage(100, directRoom, sender, "older",
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        ReflectionTestUtils.setField(directRoom, "lastMessageContent", "newer");
+        ReflectionTestUtils.setField(directRoom, "lastMessageSentAt", LocalDateTime.of(2026, 4, 11, 10, 2));
+
+        given(chatRoomRepository.findById(directRoom.getId())).willReturn(Optional.of(directRoom));
+        given(userRepository.getById(senderId)).willReturn(sender);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(directRoom.getId(), senderId))
+            .willReturn(Optional.of(senderMember));
+        given(chatRoomMemberRepository.findByChatRoomId(directRoom.getId()))
+            .willReturn(List.of(senderMember, receiverMember));
+        given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomRepository.updateLastMessageIfLatest(
+            directRoom.getId(), savedMessage.getId(), savedMessage.getContent(), savedMessage.getCreatedAt()
+        )).willReturn(0);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(directRoom.getId()), eq(senderId),
+            any(LocalDateTime.class)))
+            .willReturn(1);
+
+        chatService.sendMessage(senderId, directRoom.getId(), new ChatMessageSendRequest("older"));
+
+        assertThat(directRoom.getLastMessageContent()).isEqualTo("newer");
+        assertThat(directRoom.getLastMessageSentAt()).isEqualTo(LocalDateTime.of(2026, 4, 11, 10, 2));
+    }
+
+    @Test
     @DisplayName("sendMessage는 group room에서 메시지를 저장하고 그룹 알림을 보낸다")
     void sendMessageInGroupRoomSavesMessageAndSendsGroupNotification() {
         // given
@@ -860,6 +901,9 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(groupRoom.getId(), senderId))
             .willReturn(Optional.of(senderMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomRepository.updateLastMessageIfLatest(
+            groupRoom.getId(), savedMessage.getId(), savedMessage.getContent(), savedMessage.getCreatedAt()
+        )).willReturn(1);
         given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(groupRoom.getId()), eq(senderId),
             any(LocalDateTime.class)))
             .willReturn(1);
@@ -926,6 +970,9 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(clubRoom.getId(), senderId))
             .willReturn(Optional.of(senderRoomMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomRepository.updateLastMessageIfLatest(
+            clubRoom.getId(), savedMessage.getId(), savedMessage.getContent(), savedMessage.getCreatedAt()
+        )).willReturn(1);
         given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(clubRoom.getId()), eq(senderId),
             any(LocalDateTime.class)))
             .willReturn(1);
@@ -972,6 +1019,9 @@ class ChatServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
             .willReturn(List.of(systemAdminMember, targetMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomRepository.updateLastMessageIfLatest(
+            systemAdminRoom.getId(), savedMessage.getId(), savedMessage.getContent(), savedMessage.getCreatedAt()
+        )).willReturn(1);
 
         // when
         ChatMessageDetailResponse response = chatService.sendMessage(adminId, systemAdminRoom.getId(),


### PR DESCRIPTION
### 🔍 개요

* 메시지는 `chat_message`에 저장되지만 `chat_room.last_message_content`, `last_message_sent_at`가 null로 남아 채팅방 목록 요약 정보가 비는 문제를 수정했습니다.
* 신규 메시지 저장 경로와 기존 운영 데이터를 함께 보정해, 현재도 맞고 과거 데이터도 복구되도록 정리했습니다.


---

### 🚀 주요 변경 내용

* `ChatRoomRepository`에 마지막 메시지 메타데이터를 명시적으로 동기화하는 update 쿼리를 추가했습니다.
* direct, club, group 메시지 전송 경로에서 공통 `syncLastMessage`를 사용하도록 바꿨습니다.
* 회원가입 환영 메시지 경로도 동일한 메타데이터 동기화 규칙을 따르도록 맞췄습니다.
* Flyway 마이그레이션을 추가해 기존 `chat_room`의 null 메타데이터를 최신 `chat_message` 기준으로 백필했습니다.
* 메시지 전송 후 `chat_room` 메타데이터가 실제 DB에 반영되는지 검증하는 통합 테스트를 추가했습니다.


---

### 💬 참고 사항

* 검증: `./gradlew test --tests "gg.agit.konect.integration.domain.chat.ChatApiTest$SendMessage" --tests "gg.agit.konect.integration.domain.user.UserSignupApiTest$Signup.signupSuccess"`
* pre-push 훅에서 IntelliJ 포맷과 checkstyle 검사를 수행했고, 포맷 변경으로 `chore: 코드 포맷팅` 커밋 1개가 추가되었습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
