### PR TITLE
fix: 운영 환경에서 Swagger를 비활성화

### DIFF
--- a/src/main/java/gg/agit/konect/global/config/SwaggerConfig.java
+++ b/src/main/java/gg/agit/konect/global/config/SwaggerConfig.java
@@ -60,8 +60,8 @@ public class SwaggerConfig {
             .addOpenApiCustomizer(openApi -> openApi.setTags(
                 openApi.getTags() != null
                     ? openApi.getTags().stream()
-                        .sorted((a, b) -> a.getName().compareTo(b.getName()))
-                        .toList()
+                      .sorted((a, b) -> a.getName().compareTo(b.getName()))
+                      .toList()
                     : null
             ))
             .build();

--- a/src/main/java/gg/agit/konect/global/config/SwaggerConfig.java
+++ b/src/main/java/gg/agit/konect/global/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import org.springdoc.core.models.GroupedOpenApi;
 
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
+@Profile("!prod")
 public class SwaggerConfig {
 
     private final String serverUrl;

--- a/src/main/java/gg/agit/konect/global/config/SwaggerUiResourceController.java
+++ b/src/main/java/gg/agit/konect/global/config/SwaggerUiResourceController.java
@@ -2,6 +2,7 @@ package gg.agit.konect.global.config;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 
 @Hidden
 @RestController
+@Profile("!prod")
 public class SwaggerUiResourceController {
 
     private static final String SWAGGER_INITIALIZER_PATH = "static/swagger-ui/swagger-initializer.js";

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
### 🔍 개요

* 운영 환경에서 Swagger UI와 OpenAPI 문서가 외부에 노출되지 않도록 `prod` 프로필에서만 Swagger 관련 설정을 비활성화했습니다.
* `stage`와 `local`은 기존처럼 문서를 유지하고, 운영 환경에만 최소 범위로 적용했습니다.


---

### 🚀 주요 변경 내용

* `src/main/resources/application-prod.yml`을 추가해 `springdoc.api-docs.enabled=false`, `springdoc.swagger-ui.enabled=false`를 적용했습니다.
* `SwaggerConfig`에 `@Profile("!prod")`를 추가해 운영에서는 OpenAPI Bean이 생성되지 않도록 했습니다.
* `SwaggerUiResourceController`에 `@Profile("!prod")`를 추가해 운영에서 커스텀 swagger initializer 경로가 노출되지 않도록 했습니다.


---

### 💬 참고 사항

* `springdoc` 설정만 끄는 것보다 Swagger 관련 Bean과 커스텀 리소스 컨트롤러까지 함께 막아 운영 환경 우회 노출 가능성을 줄였습니다.
* `./gradlew compileJava`로 컴파일 검증을 완료했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)