### PR TITLE
refactor: 외부 호출 트랜잭션 범위 축소

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
@@ -42,6 +42,8 @@ public interface ClubRepository extends Repository<Club, Integer> {
 
     List<Club> findAll();
 
+    boolean existsById(Integer id);
+
     Club save(Club club);
 
     @Query("SELECT COUNT(c) FROM Club c")

--- a/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
+++ b/src/main/java/gg/agit/konect/domain/club/repository/ClubRepository.java
@@ -3,6 +3,7 @@ package gg.agit.konect.domain.club.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -43,6 +44,20 @@ public interface ClubRepository extends Repository<Club, Integer> {
     List<Club> findAll();
 
     boolean existsById(Integer id);
+
+    @Modifying(flushAutomatically = true)
+    @Query(value = """
+        UPDATE Club c
+        SET c.googleSheetId = :googleSheetId,
+            c.sheetColumnMapping = :sheetColumnMapping,
+            c.updatedAt = CURRENT_TIMESTAMP
+        WHERE c.id = :clubId
+        """)
+    int updateSheetRegistration(
+        @Param(value = "clubId") Integer clubId,
+        @Param(value = "googleSheetId") String googleSheetId,
+        @Param(value = "sheetColumnMapping") String sheetColumnMapping
+    );
 
     Club save(Club club);
 

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
@@ -32,8 +32,8 @@ public class ClubMemberSheetService {
         Integer requesterId,
         ClubSheetIdUpdateRequest request
     ) {
-        String spreadsheetId = SpreadsheetUrlParser.extractId(request.spreadsheetUrl());
         validateClubExists(clubId);
+        String spreadsheetId = SpreadsheetUrlParser.extractId(request.spreadsheetUrl());
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         SheetHeaderMapper.SheetAnalysisResult result =

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
@@ -3,10 +3,6 @@ package gg.agit.konect.domain.club.service;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB_SHEET_ID;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gg.agit.konect.domain.club.dto.ClubMemberSheetSyncResponse;
 import gg.agit.konect.domain.club.dto.ClubSheetIdUpdateRequest;
@@ -15,11 +11,10 @@ import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.repository.ClubMemberRepository;
 import gg.agit.konect.domain.club.repository.ClubPreMemberRepository;
 import gg.agit.konect.domain.club.repository.ClubRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ClubMemberSheetService {
@@ -30,7 +25,7 @@ public class ClubMemberSheetService {
     private final ClubPermissionValidator clubPermissionValidator;
     private final SheetSyncExecutor sheetSyncExecutor;
     private final SheetHeaderMapper sheetHeaderMapper;
-    private final ObjectMapper objectMapper;
+    private final ClubSheetRegistrationService clubSheetRegistrationService;
 
     public void updateSheetId(
         Integer clubId,
@@ -38,15 +33,14 @@ public class ClubMemberSheetService {
         ClubSheetIdUpdateRequest request
     ) {
         String spreadsheetId = SpreadsheetUrlParser.extractId(request.spreadsheetUrl());
-        clubRepository.getById(clubId);
+        validateClubExists(clubId);
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         SheetHeaderMapper.SheetAnalysisResult result =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
-        saveSheetRegistration(clubId, spreadsheetId, result);
+        clubSheetRegistrationService.updateSheetRegistration(clubId, spreadsheetId, result);
     }
 
-    @Transactional
     void updateSheetId(
         Integer clubId,
         Integer requesterId,
@@ -54,34 +48,12 @@ public class ClubMemberSheetService {
         SheetHeaderMapper.SheetAnalysisResult result
     ) {
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
-        saveSheetRegistration(clubId, spreadsheetId, result);
+        clubSheetRegistrationService.updateSheetRegistration(clubId, spreadsheetId, result);
     }
 
-    private void saveSheetRegistration(
-        Integer clubId,
-        String spreadsheetId,
-        SheetHeaderMapper.SheetAnalysisResult result
-    ) {
-        Club club = clubRepository.getById(clubId);
-        applySheetRegistration(club, spreadsheetId, result);
-        clubRepository.save(club);
-    }
-
-    private void applySheetRegistration(
-        Club club,
-        String spreadsheetId,
-        SheetHeaderMapper.SheetAnalysisResult result
-    ) {
-        String mappingJson = null;
-        try {
-            mappingJson = objectMapper.writeValueAsString(result.memberListMapping().toMap());
-        } catch (JsonProcessingException e) {
-            log.warn("Failed to serialize mapping, skipping. cause={}", e.getMessage());
-        }
-
-        club.updateGoogleSheetId(spreadsheetId);
-        if (mappingJson != null) {
-            club.updateSheetColumnMapping(mappingJson);
+    private void validateClubExists(Integer clubId) {
+        if (!clubRepository.existsById(clubId)) {
+            throw CustomException.of(ApiResponseCode.NOT_FOUND_CLUB);
         }
     }
 

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
@@ -32,20 +32,18 @@ public class ClubMemberSheetService {
     private final SheetHeaderMapper sheetHeaderMapper;
     private final ObjectMapper objectMapper;
 
-    @Transactional
     public void updateSheetId(
         Integer clubId,
         Integer requesterId,
         ClubSheetIdUpdateRequest request
     ) {
-        Club club = clubRepository.getById(clubId);
-        clubPermissionValidator.validateManagerAccess(clubId, requesterId);
-
         String spreadsheetId = SpreadsheetUrlParser.extractId(request.spreadsheetUrl());
+        clubRepository.getById(clubId);
+        clubPermissionValidator.validateManagerAccess(clubId, requesterId);
 
         SheetHeaderMapper.SheetAnalysisResult result =
             sheetHeaderMapper.analyzeAllSheets(spreadsheetId);
-        applySheetRegistration(club, spreadsheetId, result);
+        saveSheetRegistration(clubId, spreadsheetId, result);
     }
 
     @Transactional
@@ -55,9 +53,18 @@ public class ClubMemberSheetService {
         String spreadsheetId,
         SheetHeaderMapper.SheetAnalysisResult result
     ) {
-        Club club = clubRepository.getById(clubId);
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
+        saveSheetRegistration(clubId, spreadsheetId, result);
+    }
+
+    private void saveSheetRegistration(
+        Integer clubId,
+        String spreadsheetId,
+        SheetHeaderMapper.SheetAnalysisResult result
+    ) {
+        Club club = clubRepository.getById(clubId);
         applySheetRegistration(club, spreadsheetId, result);
+        clubRepository.save(club);
     }
 
     private void applySheetRegistration(
@@ -78,7 +85,6 @@ public class ClubMemberSheetService {
         }
     }
 
-    @Transactional(readOnly = true)
     public ClubMemberSheetSyncResponse syncMembersToSheet(
         Integer clubId,
         Integer requesterId,

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubMemberSheetService.java
@@ -47,6 +47,7 @@ public class ClubMemberSheetService {
         String spreadsheetId,
         SheetHeaderMapper.SheetAnalysisResult result
     ) {
+        validateClubExists(clubId);
         clubPermissionValidator.validateManagerAccess(clubId, requesterId);
         clubSheetRegistrationService.updateSheetRegistration(clubId, spreadsheetId, result);
     }

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
@@ -7,7 +7,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.SheetColumnMapping;
 import gg.agit.konect.domain.club.repository.ClubRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,16 +38,23 @@ public class ClubSheetRegistrationService {
         String spreadsheetId,
         SheetHeaderMapper.SheetAnalysisResult result
     ) {
-        String mappingJson = null;
-        try {
-            mappingJson = objectMapper.writeValueAsString(result.memberListMapping().toMap());
-        } catch (JsonProcessingException e) {
-            log.warn("Failed to serialize mapping, skipping. cause={}", e.getMessage());
-        }
+        String mappingJson = serializeMemberListMapping(result);
 
         club.updateGoogleSheetId(spreadsheetId);
-        if (mappingJson != null) {
-            club.updateSheetColumnMapping(mappingJson);
+        club.updateSheetColumnMapping(mappingJson);
+    }
+
+    private String serializeMemberListMapping(SheetHeaderMapper.SheetAnalysisResult result) {
+        SheetColumnMapping memberListMapping = result.memberListMapping();
+        if (memberListMapping == null) {
+            throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
+        }
+
+        try {
+            return objectMapper.writeValueAsString(memberListMapping.toMap());
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize sheet column mapping. cause={}", e.getMessage());
+            throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
         }
     }
 }

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
@@ -53,7 +53,7 @@ public class ClubSheetRegistrationService {
         try {
             return objectMapper.writeValueAsString(memberListMapping.toMap());
         } catch (JsonProcessingException e) {
-            log.warn("Failed to serialize sheet column mapping. cause={}", e.getMessage());
+            log.warn("Failed to serialize sheet column mapping.", e);
             throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
         }
     }

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
@@ -1,0 +1,50 @@
+package gg.agit.konect.domain.club.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.repository.ClubRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClubSheetRegistrationService {
+
+    private final ClubRepository clubRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void updateSheetRegistration(
+        Integer clubId,
+        String spreadsheetId,
+        SheetHeaderMapper.SheetAnalysisResult result
+    ) {
+        Club club = clubRepository.getById(clubId);
+        applySheetRegistration(club, spreadsheetId, result);
+        clubRepository.save(club);
+    }
+
+    private void applySheetRegistration(
+        Club club,
+        String spreadsheetId,
+        SheetHeaderMapper.SheetAnalysisResult result
+    ) {
+        String mappingJson = null;
+        try {
+            mappingJson = objectMapper.writeValueAsString(result.memberListMapping().toMap());
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize mapping, skipping. cause={}", e.getMessage());
+        }
+
+        club.updateGoogleSheetId(spreadsheetId);
+        if (mappingJson != null) {
+            club.updateSheetColumnMapping(mappingJson);
+        }
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
@@ -29,22 +29,27 @@ public class ClubSheetRegistrationService {
         SheetHeaderMapper.SheetAnalysisResult result
     ) {
         Club club = clubRepository.getById(clubId);
-        applySheetRegistration(club, spreadsheetId, result);
+        applySheetRegistration(club, clubId, spreadsheetId, result);
         clubRepository.save(club);
     }
 
     private void applySheetRegistration(
         Club club,
+        Integer clubId,
         String spreadsheetId,
         SheetHeaderMapper.SheetAnalysisResult result
     ) {
-        String mappingJson = serializeMemberListMapping(result);
+        String mappingJson = serializeMemberListMapping(clubId, spreadsheetId, result);
 
         club.updateGoogleSheetId(spreadsheetId);
         club.updateSheetColumnMapping(mappingJson);
     }
 
-    private String serializeMemberListMapping(SheetHeaderMapper.SheetAnalysisResult result) {
+    private String serializeMemberListMapping(
+        Integer clubId,
+        String spreadsheetId,
+        SheetHeaderMapper.SheetAnalysisResult result
+    ) {
         SheetColumnMapping memberListMapping = result.memberListMapping();
         if (memberListMapping == null) {
             throw CustomException.of(ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED);
@@ -53,7 +58,12 @@ public class ClubSheetRegistrationService {
         try {
             return objectMapper.writeValueAsString(memberListMapping.toMap());
         } catch (JsonProcessingException e) {
-            log.warn("Failed to serialize sheet column mapping.", e);
+            log.warn(
+                "Failed to serialize sheet column mapping. clubId={}, spreadsheetId={}",
+                clubId,
+                spreadsheetId,
+                e
+            );
             throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
         }
     }

--- a/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/ClubSheetRegistrationService.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.SheetColumnMapping;
 import gg.agit.konect.domain.club.repository.ClubRepository;
 import gg.agit.konect.global.code.ApiResponseCode;
@@ -28,21 +27,12 @@ public class ClubSheetRegistrationService {
         String spreadsheetId,
         SheetHeaderMapper.SheetAnalysisResult result
     ) {
-        Club club = clubRepository.getById(clubId);
-        applySheetRegistration(club, clubId, spreadsheetId, result);
-        clubRepository.save(club);
-    }
-
-    private void applySheetRegistration(
-        Club club,
-        Integer clubId,
-        String spreadsheetId,
-        SheetHeaderMapper.SheetAnalysisResult result
-    ) {
         String mappingJson = serializeMemberListMapping(clubId, spreadsheetId, result);
 
-        club.updateGoogleSheetId(spreadsheetId);
-        club.updateSheetColumnMapping(mappingJson);
+        int updatedCount = clubRepository.updateSheetRegistration(clubId, spreadsheetId, mappingJson);
+        if (updatedCount == 0) {
+            throw CustomException.of(ApiResponseCode.NOT_FOUND_CLUB);
+        }
     }
 
     private String serializeMemberListMapping(

--- a/src/main/java/gg/agit/konect/domain/club/service/SheetSyncExecutor.java
+++ b/src/main/java/gg/agit/konect/domain/club/service/SheetSyncExecutor.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -64,7 +63,6 @@ public class SheetSyncExecutor {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Async("sheetSyncTaskExecutor")
-    @Transactional(readOnly = true)
     public void executeWithSort(Integer clubId, ClubSheetSortKey sortKey, boolean ascending) {
         Club club = clubRepository.getById(clubId);
         String spreadsheetId = club.getGoogleSheetId();

--- a/src/main/java/gg/agit/konect/domain/notification/service/NotificationService.java
+++ b/src/main/java/gg/agit/konect/domain/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import gg.agit.konect.domain.chat.service.ChatPresenceService;
@@ -74,7 +75,7 @@ public class NotificationService {
     }
 
     @Async("notificationTaskExecutor")
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void sendChatNotification(Integer receiverId, Integer roomId, String senderName, String messageContent) {
         try {
             if (chatPresenceService.isUserInChatRoom(roomId, receiverId)) {
@@ -114,7 +115,7 @@ public class NotificationService {
     }
 
     @Async("notificationTaskExecutor")
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void sendGroupChatNotification(
         Integer roomId,
         Integer senderId,
@@ -191,7 +192,7 @@ public class NotificationService {
     }
 
     @Async("notificationTaskExecutor")
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void sendClubApplicationSubmittedNotification(
         Integer receiverId,
         Integer applicationId,
@@ -208,7 +209,7 @@ public class NotificationService {
     }
 
     @Async("notificationTaskExecutor")
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void sendClubApplicationApprovedNotification(Integer receiverId, Integer clubId, String clubName) {
         String body = "동아리 지원이 승인되었어요.";
         String path = "clubs/" + clubId;
@@ -219,7 +220,7 @@ public class NotificationService {
     }
 
     @Async("notificationTaskExecutor")
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void sendClubApplicationRejectedNotification(Integer receiverId, Integer clubId, String clubName) {
         String body = "동아리 지원이 거절되었어요.";
         String path = "clubs/" + clubId;

--- a/src/test/java/gg/agit/konect/domain/club/service/ClubMemberSheetServicePackagePrivateTest.java
+++ b/src/test/java/gg/agit/konect/domain/club/service/ClubMemberSheetServicePackagePrivateTest.java
@@ -1,0 +1,74 @@
+package gg.agit.konect.domain.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubPreMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.support.ServiceTestSupport;
+
+class ClubMemberSheetServicePackagePrivateTest extends ServiceTestSupport {
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private ClubPreMemberRepository clubPreMemberRepository;
+
+    @Mock
+    private ClubPermissionValidator clubPermissionValidator;
+
+    @Mock
+    private SheetSyncExecutor sheetSyncExecutor;
+
+    @Mock
+    private SheetHeaderMapper sheetHeaderMapper;
+
+    @Mock
+    private ClubSheetRegistrationService clubSheetRegistrationService;
+
+    @InjectMocks
+    private ClubMemberSheetService clubMemberSheetService;
+
+    @Test
+    @DisplayName("분석 결과를 받은 updateSheetId도 동아리가 없으면 권한 검증 전에 실패한다")
+    void updateSheetIdWithAnalysisThrowsNotFoundClubBeforePermissionCheck() {
+        // given
+        Integer clubId = 1;
+        Integer requesterId = 2;
+        String spreadsheetId = "spreadsheet-id";
+        SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
+            null,
+            null,
+            null
+        );
+
+        given(clubRepository.existsById(clubId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberSheetService.updateSheetId(
+            clubId,
+            requesterId,
+            spreadsheetId,
+            analysisResult
+        ))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(
+                ApiResponseCode.NOT_FOUND_CLUB));
+
+        verifyNoInteractions(clubPermissionValidator, clubSheetRegistrationService);
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberSheetServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberSheetServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import gg.agit.konect.domain.club.service.ClubPermissionValidator;
 import gg.agit.konect.domain.club.service.ClubSheetRegistrationService;
 import gg.agit.konect.domain.club.service.SheetHeaderMapper;
 import gg.agit.konect.domain.club.service.SheetSyncExecutor;
+import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
 import gg.agit.konect.support.ServiceTestSupport;
 import gg.agit.konect.support.fixture.ClubFixture;
@@ -111,6 +113,26 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
         verify(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
         verify(sheetHeaderMapper).analyzeAllSheets("test-sheet-id");
         verify(clubSheetRegistrationService).updateSheetRegistration(clubId, "test-sheet-id", analysisResult);
+    }
+
+    @Test
+    @DisplayName("updateSheetId는 동아리가 없으면 외부 분석을 호출하지 않는다")
+    void updateSheetIdThrowsNotFoundClubBeforeSheetAnalysis() {
+        // given
+        Integer clubId = 1;
+        Integer requesterId = 2;
+        String spreadsheetUrl = "https://docs.google.com/spreadsheets/d/test-sheet-id/edit";
+        ClubSheetIdUpdateRequest request = new ClubSheetIdUpdateRequest(spreadsheetUrl);
+
+        given(clubRepository.existsById(clubId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> clubMemberSheetService.updateSheetId(clubId, requesterId, request))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(
+                ApiResponseCode.NOT_FOUND_CLUB));
+
+        verifyNoInteractions(clubPermissionValidator, sheetHeaderMapper, clubSheetRegistrationService);
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberSheetServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberSheetServiceTest.java
@@ -121,7 +121,7 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
         // given
         Integer clubId = 1;
         Integer requesterId = 2;
-        String spreadsheetUrl = "https://docs.google.com/spreadsheets/d/test-sheet-id/edit";
+        String spreadsheetUrl = "invalid-sheet-url";
         ClubSheetIdUpdateRequest request = new ClubSheetIdUpdateRequest(spreadsheetUrl);
 
         given(clubRepository.existsById(clubId)).willReturn(false);

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberSheetServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberSheetServiceTest.java
@@ -3,6 +3,7 @@ package gg.agit.konect.unit.domain.club.service;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB_SHEET_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -11,18 +12,17 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import gg.agit.konect.domain.club.dto.ClubMemberSheetSyncResponse;
 import gg.agit.konect.domain.club.dto.ClubSheetIdUpdateRequest;
 import gg.agit.konect.domain.club.enums.ClubSheetSortKey;
 import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.SheetColumnMapping;
 import gg.agit.konect.domain.club.repository.ClubMemberRepository;
 import gg.agit.konect.domain.club.repository.ClubPreMemberRepository;
 import gg.agit.konect.domain.club.repository.ClubRepository;
 import gg.agit.konect.domain.club.service.ClubMemberSheetService;
 import gg.agit.konect.domain.club.service.ClubPermissionValidator;
+import gg.agit.konect.domain.club.service.ClubSheetRegistrationService;
 import gg.agit.konect.domain.club.service.SheetHeaderMapper;
 import gg.agit.konect.domain.club.service.SheetSyncExecutor;
 import gg.agit.konect.global.exception.CustomException;
@@ -51,13 +51,13 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
     private SheetHeaderMapper sheetHeaderMapper;
 
     @Mock
-    private ObjectMapper objectMapper;
+    private ClubSheetRegistrationService clubSheetRegistrationService;
 
     @InjectMocks
     private ClubMemberSheetService clubMemberSheetService;
 
     @Test
-    @DisplayName("시트 동기화 수에 사전 회원도 포함한다")
+    @DisplayName("시트 동기화 응답에 사전 회원 수를 포함한다")
     void syncMembersToSheetIncludesPreMembersInCount() {
         // given
         Integer clubId = 1;
@@ -87,24 +87,22 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("updateSheetId는 정상 동작한다")
-    void updateSheetIdWorksNormally() throws JsonProcessingException {
+    @DisplayName("시트 ID를 분석한 뒤 등록 서비스에 위임한다")
+    void updateSheetIdWorksNormally() {
         // given
         Integer clubId = 1;
         Integer requesterId = 2;
         String spreadsheetUrl = "https://docs.google.com/spreadsheets/d/test-sheet-id/edit";
-        Club club = ClubFixture.create(UniversityFixture.create());
         ClubSheetIdUpdateRequest request = new ClubSheetIdUpdateRequest(spreadsheetUrl);
-        gg.agit.konect.domain.club.model.SheetColumnMapping mapping = gg.agit.konect.domain.club.model.SheetColumnMapping.defaultMapping();
+        SheetColumnMapping mapping = SheetColumnMapping.defaultMapping();
         SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
             mapping,
             null,
             null
         );
 
-        given(clubRepository.getById(clubId)).willReturn(club);
+        given(clubRepository.existsById(clubId)).willReturn(true);
         given(sheetHeaderMapper.analyzeAllSheets("test-sheet-id")).willReturn(analysisResult);
-        given(objectMapper.writeValueAsString(analysisResult.memberListMapping().toMap())).willReturn("{}");
 
         // when
         clubMemberSheetService.updateSheetId(clubId, requesterId, request);
@@ -112,12 +110,11 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
         // then
         verify(clubPermissionValidator).validateManagerAccess(clubId, requesterId);
         verify(sheetHeaderMapper).analyzeAllSheets("test-sheet-id");
-        assertThat(club.getGoogleSheetId()).isEqualTo("test-sheet-id");
-        assertThat(club.getSheetColumnMapping()).isEqualTo("{}");
+        verify(clubSheetRegistrationService).updateSheetRegistration(clubId, "test-sheet-id", analysisResult);
     }
 
     @Test
-    @DisplayName("syncMembersToSheet는 sheetId가 null인 경우 NOT_FOUND_CLUB_SHEET_ID 예외를 던진다")
+    @DisplayName("syncMembersToSheet는 sheetId가 null이면 예외를 던진다")
     void syncMembersToSheetThrowsNotFoundClubSheetIdWhenSheetIdIsNull() {
         // given
         Integer clubId = 1;
@@ -139,7 +136,7 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("syncMembersToSheet는 sheetId가 blank인 경우 NOT_FOUND_CLUB_SHEET_ID 예외를 던진다")
+    @DisplayName("syncMembersToSheet는 sheetId가 blank이면 예외를 던진다")
     void syncMembersToSheetThrowsNotFoundClubSheetIdWhenSheetIdIsBlank() {
         // given
         Integer clubId = 1;
@@ -162,7 +159,7 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("syncMembersToSheet는 빈 동아리(멤버 0명)에 대해 정상 동작한다")
+    @DisplayName("syncMembersToSheet는 빈 동아리도 정상 처리한다")
     void syncMembersToSheetHandlesEmptyClub() {
         // given
         Integer clubId = 1;
@@ -192,13 +189,12 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
     }
 
     @Test
-    @DisplayName("updateSheetId는 null memberListMapping 분석 결과 시 NullPointerException이 발생한다")
-    void updateSheetIdThrowsNpeWhenMemberListMappingIsNull() throws JsonProcessingException {
+    @DisplayName("updateSheetId는 null memberListMapping 분석 결과를 등록 서비스로 전달한다")
+    void updateSheetIdDelegatesNullMemberListMapping() {
         // given
         Integer clubId = 1;
         Integer requesterId = 2;
         String spreadsheetUrl = "https://docs.google.com/spreadsheets/d/test-sheet-id/edit";
-        Club club = ClubFixture.create(UniversityFixture.create());
         ClubSheetIdUpdateRequest request = new ClubSheetIdUpdateRequest(spreadsheetUrl);
         SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
             null,
@@ -206,11 +202,17 @@ class ClubMemberSheetServiceTest extends ServiceTestSupport {
             null
         );
 
-        given(clubRepository.getById(clubId)).willReturn(club);
+        given(clubRepository.existsById(clubId)).willReturn(true);
         given(sheetHeaderMapper.analyzeAllSheets("test-sheet-id")).willReturn(analysisResult);
 
-        // when & then
-        assertThatThrownBy(() -> clubMemberSheetService.updateSheetId(clubId, requesterId, request))
-            .isInstanceOf(NullPointerException.class);
+        // when
+        clubMemberSheetService.updateSheetId(clubId, requesterId, request);
+
+        // then
+        verify(clubSheetRegistrationService).updateSheetRegistration(
+            eq(clubId),
+            eq("test-sheet-id"),
+            eq(analysisResult)
+        );
     }
 }

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubSheetRegistrationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubSheetRegistrationServiceTest.java
@@ -1,7 +1,9 @@
 package gg.agit.konect.unit.domain.club.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gg.agit.konect.domain.club.model.Club;
@@ -16,6 +19,8 @@ import gg.agit.konect.domain.club.model.SheetColumnMapping;
 import gg.agit.konect.domain.club.repository.ClubRepository;
 import gg.agit.konect.domain.club.service.ClubSheetRegistrationService;
 import gg.agit.konect.domain.club.service.SheetHeaderMapper;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
 import gg.agit.konect.support.ServiceTestSupport;
 import gg.agit.konect.support.fixture.ClubFixture;
 import gg.agit.konect.support.fixture.UniversityFixture;
@@ -55,5 +60,67 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
         assertThat(club.getGoogleSheetId()).isEqualTo(spreadsheetId);
         assertThat(club.getSheetColumnMapping()).isEqualTo("{}");
         verify(clubRepository).save(club);
+    }
+
+    @Test
+    @DisplayName("회원 목록 매핑이 null이면 시트 정보를 저장하지 않는다")
+    void updateSheetRegistrationThrowsWhenMemberListMappingIsNull() {
+        // given
+        Integer clubId = 1;
+        String spreadsheetId = "spreadsheet-id";
+        Club club = ClubFixture.create(UniversityFixture.create());
+        SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
+            null,
+            null,
+            null
+        );
+
+        given(clubRepository.getById(clubId)).willReturn(club);
+
+        // when & then
+        assertThatThrownBy(() -> clubSheetRegistrationService.updateSheetRegistration(
+            clubId,
+            spreadsheetId,
+            analysisResult
+        ))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(
+                ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED));
+
+        assertThat(club.getGoogleSheetId()).isNull();
+        assertThat(club.getSheetColumnMapping()).isNull();
+        verify(clubRepository, never()).save(club);
+    }
+
+    @Test
+    @DisplayName("매핑 직렬화에 실패하면 시트 정보를 저장하지 않는다")
+    void updateSheetRegistrationThrowsWhenMappingSerializationFails() throws Exception {
+        // given
+        Integer clubId = 1;
+        String spreadsheetId = "spreadsheet-id";
+        Club club = ClubFixture.create(UniversityFixture.create());
+        SheetColumnMapping mapping = SheetColumnMapping.defaultMapping();
+        SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
+            mapping,
+            null,
+            null
+        );
+
+        given(clubRepository.getById(clubId)).willReturn(club);
+        given(objectMapper.writeValueAsString(mapping.toMap())).willThrow(new JsonProcessingException("boom") {});
+
+        // when & then
+        assertThatThrownBy(() -> clubSheetRegistrationService.updateSheetRegistration(
+            clubId,
+            spreadsheetId,
+            analysisResult
+        ))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(
+                ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET));
+
+        assertThat(club.getGoogleSheetId()).isNull();
+        assertThat(club.getSheetColumnMapping()).isNull();
+        verify(clubRepository, never()).save(club);
     }
 }

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubSheetRegistrationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubSheetRegistrationServiceTest.java
@@ -1,0 +1,59 @@
+package gg.agit.konect.unit.domain.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.SheetColumnMapping;
+import gg.agit.konect.domain.club.repository.ClubRepository;
+import gg.agit.konect.domain.club.service.ClubSheetRegistrationService;
+import gg.agit.konect.domain.club.service.SheetHeaderMapper;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+
+class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private ClubSheetRegistrationService clubSheetRegistrationService;
+
+    @Test
+    @DisplayName("시트 등록 정보를 트랜잭션 서비스에서 저장한다")
+    void updateSheetRegistrationUpdatesClubSheetInfo() throws Exception {
+        // given
+        Integer clubId = 1;
+        String spreadsheetId = "spreadsheet-id";
+        Club club = ClubFixture.create(UniversityFixture.create());
+        SheetColumnMapping mapping = SheetColumnMapping.defaultMapping();
+        SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
+            mapping,
+            null,
+            null
+        );
+
+        given(clubRepository.getById(clubId)).willReturn(club);
+        given(objectMapper.writeValueAsString(mapping.toMap())).willReturn("{}");
+
+        // when
+        clubSheetRegistrationService.updateSheetRegistration(clubId, spreadsheetId, analysisResult);
+
+        // then
+        assertThat(club.getGoogleSheetId()).isEqualTo(spreadsheetId);
+        assertThat(club.getSheetColumnMapping()).isEqualTo("{}");
+        verify(clubRepository).save(club);
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubSheetRegistrationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubSheetRegistrationServiceTest.java
@@ -14,7 +14,6 @@ import org.mockito.Mock;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.SheetColumnMapping;
 import gg.agit.konect.domain.club.repository.ClubRepository;
 import gg.agit.konect.domain.club.service.ClubSheetRegistrationService;
@@ -22,8 +21,6 @@ import gg.agit.konect.domain.club.service.SheetHeaderMapper;
 import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
 import gg.agit.konect.support.ServiceTestSupport;
-import gg.agit.konect.support.fixture.ClubFixture;
-import gg.agit.konect.support.fixture.UniversityFixture;
 
 class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
 
@@ -42,7 +39,6 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
         // given
         Integer clubId = 1;
         String spreadsheetId = "spreadsheet-id";
-        Club club = ClubFixture.create(UniversityFixture.create());
         SheetColumnMapping mapping = SheetColumnMapping.defaultMapping();
         SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
             mapping,
@@ -50,16 +46,14 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
             null
         );
 
-        given(clubRepository.getById(clubId)).willReturn(club);
         given(objectMapper.writeValueAsString(mapping.toMap())).willReturn("{}");
+        given(clubRepository.updateSheetRegistration(clubId, spreadsheetId, "{}")).willReturn(1);
 
         // when
         clubSheetRegistrationService.updateSheetRegistration(clubId, spreadsheetId, analysisResult);
 
         // then
-        assertThat(club.getGoogleSheetId()).isEqualTo(spreadsheetId);
-        assertThat(club.getSheetColumnMapping()).isEqualTo("{}");
-        verify(clubRepository).save(club);
+        verify(clubRepository).updateSheetRegistration(clubId, spreadsheetId, "{}");
     }
 
     @Test
@@ -68,14 +62,11 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
         // given
         Integer clubId = 1;
         String spreadsheetId = "spreadsheet-id";
-        Club club = ClubFixture.create(UniversityFixture.create());
         SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
             null,
             null,
             null
         );
-
-        given(clubRepository.getById(clubId)).willReturn(club);
 
         // when & then
         assertThatThrownBy(() -> clubSheetRegistrationService.updateSheetRegistration(
@@ -87,9 +78,7 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
             .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(
                 ApiResponseCode.CLUB_SHEET_ANALYSIS_REQUIRED));
 
-        assertThat(club.getGoogleSheetId()).isNull();
-        assertThat(club.getSheetColumnMapping()).isNull();
-        verify(clubRepository, never()).save(club);
+        verify(clubRepository, never()).updateSheetRegistration(clubId, spreadsheetId, null);
     }
 
     @Test
@@ -98,7 +87,6 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
         // given
         Integer clubId = 1;
         String spreadsheetId = "spreadsheet-id";
-        Club club = ClubFixture.create(UniversityFixture.create());
         SheetColumnMapping mapping = SheetColumnMapping.defaultMapping();
         SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
             mapping,
@@ -106,7 +94,6 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
             null
         );
 
-        given(clubRepository.getById(clubId)).willReturn(club);
         given(objectMapper.writeValueAsString(mapping.toMap())).willThrow(new JsonProcessingException("boom") {});
 
         // when & then
@@ -119,8 +106,33 @@ class ClubSheetRegistrationServiceTest extends ServiceTestSupport {
             .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(
                 ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET));
 
-        assertThat(club.getGoogleSheetId()).isNull();
-        assertThat(club.getSheetColumnMapping()).isNull();
-        verify(clubRepository, never()).save(club);
+        verify(clubRepository, never()).updateSheetRegistration(clubId, spreadsheetId, null);
+    }
+
+    @Test
+    @DisplayName("시트 등록 update 대상 동아리가 없으면 NOT_FOUND_CLUB 예외를 던진다")
+    void updateSheetRegistrationThrowsWhenClubIsMissing() throws Exception {
+        // given
+        Integer clubId = 1;
+        String spreadsheetId = "spreadsheet-id";
+        SheetColumnMapping mapping = SheetColumnMapping.defaultMapping();
+        SheetHeaderMapper.SheetAnalysisResult analysisResult = new SheetHeaderMapper.SheetAnalysisResult(
+            mapping,
+            null,
+            null
+        );
+
+        given(objectMapper.writeValueAsString(mapping.toMap())).willReturn("{}");
+        given(clubRepository.updateSheetRegistration(clubId, spreadsheetId, "{}")).willReturn(0);
+
+        // when & then
+        assertThatThrownBy(() -> clubSheetRegistrationService.updateSheetRegistration(
+            clubId,
+            spreadsheetId,
+            analysisResult
+        ))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(
+                ApiResponseCode.NOT_FOUND_CLUB));
     }
 }


### PR DESCRIPTION
### 🔍 개요

* DB 트랜잭션 안에서 Google Sheets, Claude, Expo Push 같은 외부 호출을 수행하던 경로를 줄여 커넥션 풀 점유 시간을 낮춥니다.

---

### 🚀 주요 변경 내용

* 시트 ID 등록 시 Google Sheets/Claude 분석을 트랜잭션 밖에서 수행하고, DB 반영은 짧게 처리하도록 변경했습니다.
* 비동기 시트 동기화 작업에서 read-only 트랜잭션을 제거해 Google Sheets API 호출 중 DB 커넥션을 잡지 않도록 변경했습니다.
* 비동기 알림 전송 메서드에 NOT_SUPPORTED 전파 옵션을 적용해 Expo Push/SSE 전송 중 서비스 클래스의 read-only 트랜잭션이 열리지 않도록 했습니다.

---

### 💬 참고 사항

* 

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)