### PR TITLE
test: 문의방 검색 기준선 테스트 추가

### DIFF
--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -1279,6 +1279,40 @@ class ChatApiTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("관리자는 멤버가 아니어도 사용자 문의방을 검색할 수 있다")
+        void searchChatsIncludesInquiryRoomForAdminWithoutMembership() throws Exception {
+            // given
+            User anotherAdmin = persist(UserFixture.createAdmin(university));
+            clearPersistenceContext();
+
+            mockLoginUser(normalUser.getId());
+            int chatRoomId = parseChatRoomId(
+                performPost("/chats/rooms/admin")
+                    .andExpect(status().isOk())
+                    .andReturn()
+            );
+            performPost("/chats/rooms/" + chatRoomId + "/messages",
+                new ChatMessageSendRequest("관리자 검색 문의"))
+                .andExpect(status().isOk());
+
+            clearPersistenceContext();
+            mockLoginUser(anotherAdmin.getId());
+
+            // when & then
+            performGet("/chats/rooms/search?keyword=일반유저&page=1&limit=10")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomMatches.totalCount").value(1))
+                .andExpect(jsonPath("$.roomMatches.currentCount").value(1))
+                .andExpect(jsonPath("$.roomMatches.rooms[0].roomId").value(chatRoomId))
+                .andExpect(jsonPath("$.roomMatches.rooms[0].roomName").value("일반유저"))
+                .andExpect(jsonPath("$.messageMatches.totalCount").value(0));
+
+            assertThat(chatRoomMemberRepository.findByChatRoomId(chatRoomId))
+                .extracting(ChatRoomMember::getUserId)
+                .containsExactlyInAnyOrder(SYSTEM_ADMIN_ID, normalUser.getId());
+        }
+
+        @Test
         @DisplayName("채팅방 검색 결과에 페이지네이션을 적용한다")
         void searchChatsAppliesPaginationToRoomMatches() throws Exception {
             // given


### PR DESCRIPTION
### 🔍 개요

* #579 채팅 리팩토링을 작은 PR 단위로 진행하기 위한 첫 기준선 테스트입니다.
* 관리자가 문의방 멤버가 아니어도 사용자 문의방을 검색할 수 있어야 하는 기존 정책을 통합 테스트로 고정했습니다.
* 후속 QueryRepository 분리 과정에서 admin direct 조회 조건이 누락되는 회귀를 막기 위한 안전망입니다.

---

### 🚀 주요 변경 내용

* `ChatApiTest`에 admin 문의방 검색 회귀 테스트를 추가했습니다.
* 사용자가 문의방을 만들고 메시지를 남긴 뒤, 멤버가 아닌 다른 admin이 사용자명으로 문의방을 검색할 수 있음을 검증합니다.
* 문의방 멤버가 `SYSTEM_ADMIN + 일반 사용자` 2명으로 유지되는지도 함께 확인합니다.

---

### 💬 참고 사항

* Refs #580
* 코드 변경은 테스트 34줄로 제한했습니다.
* 검증:
  * `CI=true ./gradlew test --tests 'gg.agit.konect.integration.domain.chat.ChatApiTest$SearchChats.searchChatsIncludesInquiryRoomForAdminWithoutMembership' --rerun-tasks`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
