### PR TITLE
refactor: 메시지 검색 조회를 QueryRepository로 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageQueryRepository.java
@@ -1,0 +1,63 @@
+package gg.agit.konect.domain.chat.repository;
+
+import static gg.agit.konect.domain.chat.model.QChatMessage.chatMessage;
+import static gg.agit.konect.domain.chat.model.QChatRoom.chatRoom;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import gg.agit.konect.domain.chat.model.ChatMessage;
+import gg.agit.konect.domain.chat.model.QChatMessage;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<ChatMessage> searchLatestMatchingMessagesByChatRoomIds(
+        List<Integer> roomIds,
+        String keyword
+    ) {
+        if (roomIds.isEmpty()) {
+            return List.of();
+        }
+
+        QChatMessage innerMessage = new QChatMessage("innerMessage");
+
+        return jpaQueryFactory
+            .selectFrom(chatMessage)
+            .join(chatMessage.chatRoom, chatRoom).fetchJoin()
+            .where(
+                chatRoom.id.in(roomIds),
+                containsKeyword(chatMessage, keyword),
+                chatMessage.id.eq(
+                    JPAExpressions
+                        .select(innerMessage.id.max())
+                        .from(innerMessage)
+                        .where(
+                            innerMessage.chatRoom.id.eq(chatRoom.id),
+                            containsKeyword(innerMessage, keyword)
+                        )
+                )
+            )
+            .orderBy(chatMessage.createdAt.desc(), chatMessage.id.desc())
+            .fetch();
+    }
+
+    private BooleanExpression containsKeyword(QChatMessage message, String keyword) {
+        return Expressions.booleanTemplate(
+            "LOCATE({0}, LOWER({1})) > 0",
+            keyword.toLowerCase(Locale.ROOT),
+            message.content
+        );
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageQueryRepository.java
@@ -4,7 +4,7 @@ import static gg.agit.konect.domain.chat.model.QChatMessage.chatMessage;
 import static gg.agit.konect.domain.chat.model.QChatRoom.chatRoom;
 
 import java.util.List;
-import java.util.Locale;
+import java.util.Objects;
 
 import org.springframework.stereotype.Repository;
 
@@ -27,6 +27,8 @@ public class ChatMessageQueryRepository {
         List<Integer> roomIds,
         String keyword
     ) {
+        Objects.requireNonNull(keyword, "keyword must not be null");
+
         if (roomIds.isEmpty()) {
             return List.of();
         }
@@ -55,8 +57,8 @@ public class ChatMessageQueryRepository {
 
     private BooleanExpression containsKeyword(QChatMessage message, String keyword) {
         return Expressions.booleanTemplate(
-            "LOCATE({0}, LOWER({1})) > 0",
-            keyword.toLowerCase(Locale.ROOT),
+            "LOCATE(LOWER({0}), LOWER({1})) > 0",
+            keyword,
             message.content
         );
     }

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatMessageRepository.java
@@ -122,27 +122,6 @@ public interface ChatMessageRepository extends Repository<ChatMessage, Integer> 
         """)
     List<ChatMessage> findLatestMessagesByRoomIds(@Param("roomIds") List<Integer> roomIds);
 
-    @Query(
-        value = """
-            SELECT cm
-            FROM ChatMessage cm
-            JOIN FETCH cm.chatRoom cr
-            WHERE cr.id IN :roomIds
-              AND LOCATE(LOWER(:keyword), LOWER(cm.content)) > 0
-              AND cm.id = (
-                  SELECT MAX(innerCm.id)
-                  FROM ChatMessage innerCm
-                  WHERE innerCm.chatRoom.id = cr.id
-                    AND LOCATE(LOWER(:keyword), LOWER(innerCm.content)) > 0
-              )
-            ORDER BY cm.createdAt DESC, cm.id DESC
-            """
-    )
-    List<ChatMessage> searchLatestMatchingMessagesByChatRoomIds(
-        @Param("roomIds") List<Integer> roomIds,
-        @Param("keyword") String keyword
-    );
-
     @Query("SELECT cm FROM ChatMessage cm JOIN FETCH cm.chatRoom WHERE cm.id = :messageId")
     Optional<ChatMessage> findByIdWithChatRoom(@Param("messageId") Integer messageId);
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -46,6 +46,7 @@ import gg.agit.konect.domain.chat.model.ChatMessage;
 import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
 import gg.agit.konect.domain.chat.repository.ChatInviteQueryRepository;
+import gg.agit.konect.domain.chat.repository.ChatMessageQueryRepository;
 import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
@@ -79,6 +80,7 @@ public class ChatService {
     private final NotificationMuteSettingRepository notificationMuteSettingRepository;
     private final ClubMemberRepository clubMemberRepository;
     private final ChatInviteQueryRepository chatInviteQueryRepository;
+    private final ChatMessageQueryRepository chatMessageQueryRepository;
     private final UserRepository userRepository;
     private final ChatPresenceService chatPresenceService;
     private final ChatRoomMembershipService chatRoomMembershipService;
@@ -1016,7 +1018,7 @@ public class ChatService {
             .toList();
         Map<Integer, LocalDateTime> visibleMessageFromMap = getVisibleMessageFromMap(directRoomIds, userId);
 
-        List<ChatMessageMatchResult> matchedMessages = chatMessageRepository
+        List<ChatMessageMatchResult> matchedMessages = chatMessageQueryRepository
             .searchLatestMatchingMessagesByChatRoomIds(roomIds, keyword)
             .stream()
             .filter(message -> isVisibleMessageMatch(message, roomMap, visibleMessageFromMap))

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -47,6 +47,7 @@ import gg.agit.konect.domain.chat.model.ChatMessage;
 import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
 import gg.agit.konect.domain.chat.repository.ChatInviteQueryRepository;
+import gg.agit.konect.domain.chat.repository.ChatMessageQueryRepository;
 import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
@@ -90,6 +91,9 @@ class ChatServiceTest extends ServiceTestSupport {
 
     @Mock
     private ChatInviteQueryRepository chatInviteQueryRepository;
+
+    @Mock
+    private ChatMessageQueryRepository chatMessageQueryRepository;
 
     @Mock
     private UserRepository userRepository;


### PR DESCRIPTION
### 🔍 개요

* #579 채팅 리팩토링의 두 번째 작은 PR입니다.
* #581 범위 중 메시지 검색 조회 1개만 QueryDSL 조회 전용 리포지토리로 분리했습니다.
* PR 크기를 줄이기 위해 목록 조회나 서비스 책임 분리는 포함하지 않았습니다.

---

### 🚀 주요 변경 내용

* `ChatMessageQueryRepository`를 추가해 메시지 검색 read model 조회를 담당하게 했습니다.
* `ChatMessageRepository`에서 검색용 JPQL 메서드를 제거했습니다.
* `ChatService`는 메시지 검색 시 조회 전용 리포지토리를 사용하도록 변경했습니다.
* 기존 `LOCATE` 기반 검색 조건을 유지해 `%` 같은 LIKE 특수문자를 리터럴로 처리하는 정책을 보존했습니다.

---

### 💬 참고 사항

* Refs #581
* 코드 변경은 70줄 추가, 22줄 삭제입니다.
* 검증:
  * `CI=true ./gradlew test --tests 'gg.agit.konect.integration.domain.chat.ChatApiTest$SearchChats' --rerun-tasks`
  * `./gradlew checkstyleMain`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
