### PR TITLE
refactor: 채팅 검색 응답 조립 책임 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatSearchService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatSearchService.java
@@ -1,0 +1,167 @@
+package gg.agit.konect.domain.chat.service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import gg.agit.konect.domain.chat.dto.ChatMessageMatchResult;
+import gg.agit.konect.domain.chat.dto.ChatMessageMatchesResponse;
+import gg.agit.konect.domain.chat.dto.ChatRoomMatchesResponse;
+import gg.agit.konect.domain.chat.dto.ChatRoomSummaryResponse;
+import gg.agit.konect.domain.chat.dto.ChatSearchResponse;
+import gg.agit.konect.domain.chat.enums.ChatType;
+import gg.agit.konect.domain.chat.model.ChatMessage;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatSearchService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public ChatSearchResponse search(
+        Integer userId,
+        String keyword,
+        List<ChatRoomSummaryResponse> accessibleRooms,
+        Map<Integer, String> defaultRoomNameMap,
+        Integer page,
+        Integer limit
+    ) {
+        String normalizedKeyword = normalizeKeyword(keyword);
+        ChatRoomMatchesResponse roomMatches = searchRoomsByName(
+            accessibleRooms,
+            defaultRoomNameMap,
+            normalizedKeyword,
+            page,
+            limit
+        );
+        ChatMessageMatchesResponse messageMatches = searchByMessageContent(
+            userId,
+            accessibleRooms,
+            normalizedKeyword,
+            page,
+            limit
+        );
+
+        return new ChatSearchResponse(roomMatches, messageMatches);
+    }
+
+    private ChatRoomMatchesResponse searchRoomsByName(
+        List<ChatRoomSummaryResponse> accessibleRooms,
+        Map<Integer, String> defaultRoomNameMap,
+        String keyword,
+        Integer page,
+        Integer limit
+    ) {
+        List<ChatRoomSummaryResponse> matchedRooms = accessibleRooms.stream()
+            .filter(room -> matchesRoomName(room, keyword, defaultRoomNameMap))
+            .toList();
+
+        return ChatRoomMatchesResponse.from(toPage(matchedRooms, page, limit));
+    }
+
+    private ChatMessageMatchesResponse searchByMessageContent(
+        Integer userId,
+        List<ChatRoomSummaryResponse> accessibleRooms,
+        String keyword,
+        Integer page,
+        Integer limit
+    ) {
+        if (accessibleRooms.isEmpty() || keyword.isBlank()) {
+            return ChatMessageMatchesResponse.from(emptyPage(page, limit));
+        }
+
+        Map<Integer, ChatRoomSummaryResponse> roomMap = accessibleRooms.stream()
+            .collect(Collectors.toMap(ChatRoomSummaryResponse::roomId, room -> room));
+        List<Integer> roomIds = accessibleRooms.stream()
+            .map(ChatRoomSummaryResponse::roomId)
+            .toList();
+        List<Integer> directRoomIds = accessibleRooms.stream()
+            .filter(room -> room.chatType() == ChatType.DIRECT)
+            .map(ChatRoomSummaryResponse::roomId)
+            .toList();
+        Map<Integer, LocalDateTime> visibleMessageFromMap = getVisibleMessageFromMap(directRoomIds, userId);
+
+        List<ChatMessageMatchResult> matchedMessages = chatMessageRepository
+            .searchLatestMatchingMessagesByChatRoomIds(roomIds, keyword)
+            .stream()
+            .filter(message -> isVisibleMessageMatch(message, roomMap, visibleMessageFromMap))
+            .map(message -> ChatMessageMatchResult.from(roomMap.get(message.getChatRoom().getId()), message))
+            .toList();
+
+        return ChatMessageMatchesResponse.from(toPage(matchedMessages, page, limit));
+    }
+
+    private String normalizeKeyword(String keyword) {
+        return keyword == null ? "" : keyword.trim();
+    }
+
+    private boolean matchesRoomName(
+        ChatRoomSummaryResponse room,
+        String keyword,
+        Map<Integer, String> defaultRoomNameMap
+    ) {
+        return containsKeyword(room.roomName(), keyword)
+            || containsKeyword(defaultRoomNameMap.get(room.roomId()), keyword);
+    }
+
+    private boolean containsKeyword(String text, String keyword) {
+        return text != null
+            && !keyword.isBlank()
+            && text.toLowerCase(Locale.ROOT).contains(keyword.toLowerCase(Locale.ROOT));
+    }
+
+    private Map<Integer, LocalDateTime> getVisibleMessageFromMap(List<Integer> roomIds, Integer userId) {
+        if (roomIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Integer, LocalDateTime> visibleMessageFromMap = new HashMap<>();
+        for (ChatRoomMember roomMember : chatRoomMemberRepository.findByChatRoomIdsAndUserId(roomIds, userId)) {
+            visibleMessageFromMap.put(roomMember.getChatRoomId(), roomMember.getVisibleMessageFrom());
+        }
+        return visibleMessageFromMap;
+    }
+
+    private boolean isVisibleMessageMatch(
+        ChatMessage message,
+        Map<Integer, ChatRoomSummaryResponse> roomMap,
+        Map<Integer, LocalDateTime> visibleMessageFromMap
+    ) {
+        ChatRoomSummaryResponse room = roomMap.get(message.getChatRoom().getId());
+        if (room == null || room.chatType() != ChatType.DIRECT) {
+            return true;
+        }
+
+        LocalDateTime visibleMessageFrom = visibleMessageFromMap.get(room.roomId());
+        return visibleMessageFrom == null || message.getCreatedAt().isAfter(visibleMessageFrom);
+    }
+
+    private <T> Page<T> toPage(List<T> items, Integer page, Integer limit) {
+        PageRequest pageable = PageRequest.of(page - 1, limit);
+        long offset = (long)(page - 1) * limit;
+        if (offset >= items.size()) {
+            return new PageImpl<>(List.of(), pageable, items.size());
+        }
+
+        int fromIndex = (int)offset;
+        int toIndex = Math.min(fromIndex + limit, items.size());
+        return new PageImpl<>(items.subList(fromIndex, toIndex), pageable, items.size());
+    }
+
+    private Page<ChatMessageMatchResult> emptyPage(Integer page, Integer limit) {
+        return new PageImpl<>(List.of(), PageRequest.of(page - 1, limit), 0);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -9,7 +9,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -26,13 +25,10 @@ import org.springframework.util.StringUtils;
 import gg.agit.konect.domain.chat.dto.AdminChatRoomProjection;
 import gg.agit.konect.domain.chat.dto.ChatInvitableUsersResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageDetailResponse;
-import gg.agit.konect.domain.chat.dto.ChatMessageMatchResult;
-import gg.agit.konect.domain.chat.dto.ChatMessageMatchesResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
-import gg.agit.konect.domain.chat.dto.ChatRoomMatchesResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomSummaryResponse;
@@ -83,6 +79,7 @@ public class ChatService {
     private final ChatPresenceService chatPresenceService;
     private final ChatRoomMembershipService chatRoomMembershipService;
     private final ChatRoomSummaryService chatRoomSummaryService;
+    private final ChatSearchService chatSearchService;
     private final NotificationService notificationService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -224,18 +221,9 @@ public class ChatService {
     }
 
     public ChatSearchResponse searchChats(Integer userId, String keyword, Integer page, Integer limit) {
-        String normalizedKeyword = normalizeKeyword(keyword);
         AccessibleChatRooms accessibleChatRooms = getAccessibleChatRooms(userId);
-        ChatRoomMatchesResponse roomMatches = searchRoomsByName(accessibleChatRooms, normalizedKeyword, page, limit);
-        ChatMessageMatchesResponse messageMatches = searchByMessageContent(
-            userId,
-            accessibleChatRooms.rooms(),
-            normalizedKeyword,
-            page,
-            limit
-        );
-
-        return new ChatSearchResponse(roomMatches, messageMatches);
+        return chatSearchService.search(userId, keyword, accessibleChatRooms.rooms(),
+            accessibleChatRooms.defaultRoomNameMap(), page, limit);
     }
 
     public ChatInvitableUsersResponse getInvitableUsers(
@@ -913,120 +901,6 @@ public class ChatService {
             clubRooms
         );
         return new AccessibleChatRooms(rooms, defaultRoomNameMap);
-    }
-
-    private ChatRoomMatchesResponse searchRoomsByName(
-        AccessibleChatRooms accessibleChatRooms,
-        String keyword,
-        Integer page,
-        Integer limit
-    ) {
-        List<ChatRoomSummaryResponse> matchedRooms = accessibleChatRooms.rooms().stream()
-            .filter(room -> matchesRoomName(room, keyword, accessibleChatRooms.defaultRoomNameMap()))
-            .toList();
-
-        return ChatRoomMatchesResponse.from(toPage(matchedRooms, page, limit));
-    }
-
-    private ChatMessageMatchesResponse searchByMessageContent(
-        Integer userId,
-        List<ChatRoomSummaryResponse> accessibleRooms,
-        String keyword,
-        Integer page,
-        Integer limit
-    ) {
-        if (accessibleRooms.isEmpty() || keyword.isBlank()) {
-            return ChatMessageMatchesResponse.from(emptyPage(page, limit));
-        }
-
-        Map<Integer, ChatRoomSummaryResponse> roomMap = accessibleRooms.stream()
-            .collect(Collectors.toMap(ChatRoomSummaryResponse::roomId, room -> room));
-        List<Integer> roomIds = accessibleRooms.stream()
-            .map(ChatRoomSummaryResponse::roomId)
-            .toList();
-        List<Integer> directRoomIds = accessibleRooms.stream()
-            .filter(room -> room.chatType() == ChatType.DIRECT)
-            .map(ChatRoomSummaryResponse::roomId)
-            .toList();
-        Map<Integer, LocalDateTime> visibleMessageFromMap = getVisibleMessageFromMap(directRoomIds, userId);
-
-        List<ChatMessageMatchResult> matchedMessages = chatMessageRepository
-            .searchLatestMatchingMessagesByChatRoomIds(roomIds, keyword)
-            .stream()
-            .filter(message -> isVisibleMessageMatch(message, roomMap, visibleMessageFromMap))
-            .map(message -> ChatMessageMatchResult.from(roomMap.get(message.getChatRoom().getId()), message))
-            .toList();
-
-        return ChatMessageMatchesResponse.from(toPage(matchedMessages, page, limit));
-    }
-
-    private String normalizeKeyword(String keyword) {
-        if (keyword == null) {
-            return "";
-        }
-        return keyword.trim();
-    }
-
-    private boolean containsKeyword(String text, String keyword) {
-        if (text == null || keyword.isBlank()) {
-            return false;
-        }
-
-        return text.toLowerCase(Locale.ROOT).contains(keyword.toLowerCase(Locale.ROOT));
-    }
-
-    private <T> Page<T> toPage(List<T> items, Integer page, Integer limit) {
-        PageRequest pageable = PageRequest.of(page - 1, limit);
-        long offset = (long)(page - 1) * limit;
-        if (offset >= items.size()) {
-            return new PageImpl<>(List.of(), pageable, items.size());
-        }
-
-        int fromIndex = (int)offset;
-        int toIndex = Math.min(fromIndex + limit, items.size());
-        return new PageImpl<>(items.subList(fromIndex, toIndex), pageable, items.size());
-    }
-
-    private <T> Page<T> emptyPage(Integer page, Integer limit) {
-        return new PageImpl<>(List.of(), PageRequest.of(page - 1, limit), 0);
-    }
-
-    private Map<Integer, LocalDateTime> getVisibleMessageFromMap(List<Integer> roomIds, Integer userId) {
-        if (roomIds.isEmpty()) {
-            return Map.of();
-        }
-
-        Map<Integer, LocalDateTime> visibleMessageFromMap = new HashMap<>();
-        for (ChatRoomMember roomMember : chatRoomMemberRepository.findByChatRoomIdsAndUserId(roomIds, userId)) {
-            visibleMessageFromMap.put(roomMember.getChatRoomId(), roomMember.getVisibleMessageFrom());
-        }
-        return visibleMessageFromMap;
-    }
-
-    private boolean matchesRoomName(
-        ChatRoomSummaryResponse room,
-        String keyword,
-        Map<Integer, String> defaultRoomNameMap
-    ) {
-        if (containsKeyword(room.roomName(), keyword)) {
-            return true;
-        }
-
-        return containsKeyword(defaultRoomNameMap.get(room.roomId()), keyword);
-    }
-
-    private boolean isVisibleMessageMatch(
-        ChatMessage message,
-        Map<Integer, ChatRoomSummaryResponse> roomMap,
-        Map<Integer, LocalDateTime> visibleMessageFromMap
-    ) {
-        ChatRoomSummaryResponse room = roomMap.get(message.getChatRoom().getId());
-        if (room == null || room.chatType() != ChatType.DIRECT) {
-            return true;
-        }
-
-        LocalDateTime visibleMessageFrom = visibleMessageFromMap.get(room.roomId());
-        return visibleMessageFrom == null || message.getCreatedAt().isAfter(visibleMessageFrom);
     }
 
     private ChatRoom getDirectRoom(Integer roomId) {


### PR DESCRIPTION
### 🔍 개요

* 채팅 검색 응답 조립 책임을 `ChatService`에서 `ChatSearchService`로 분리했습니다.
* Refs #583


---

### 🚀 주요 변경 내용

* 방 이름 검색, 메시지 내용 검색, direct 방 `visibleMessageFrom` 필터링을 `ChatSearchService`로 이동했습니다.
* `ChatService`는 접근 가능한 방 목록과 기본 방 이름 맵을 준비한 뒤 검색 서비스에 위임하도록 축소했습니다.


---

### 💬 참고 사항

* Stacked on #589: https://github.com/BCSDLab/KONECT_BACK_END/pull/589
* 이번 PR diff는 299라인입니다. (170 additions, 129 deletions)
* 검증:
  * `CI=true ./gradlew test --tests 'gg.agit.konect.integration.domain.chat.ChatApiTest$SearchChats' --rerun-tasks`
  * `./gradlew checkstyleMain`


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
