### PR TITLE
refactor: 메시지 조회 페이지 계산 책임 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
@@ -1,11 +1,11 @@
 package gg.agit.konect.domain.chat.service;
 
-import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB_MEMBER;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +28,7 @@ public class ChatMessagePageResolver {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ClubMemberRepository clubMemberRepository;
+    private final ChatRoomSystemAdminService chatRoomSystemAdminService;
 
     public int resolvePageForMessage(
         Integer roomId,
@@ -36,7 +37,7 @@ public class ChatMessagePageResolver {
         User user,
         int limit
     ) {
-        ensureMessageLookupAccess(room, user);
+        AccessContext accessContext = ensureMessageLookupAccess(room, user);
 
         ChatMessage targetMessage = chatMessageRepository.findByIdWithChatRoom(messageId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
@@ -45,7 +46,7 @@ public class ChatMessagePageResolver {
             throw CustomException.of(NOT_FOUND_CHAT_ROOM);
         }
 
-        LocalDateTime visibleMessageFrom = resolveVisibleMessageFrom(room, user);
+        LocalDateTime visibleMessageFrom = resolveVisibleMessageFrom(room, user, accessContext);
         if (visibleMessageFrom != null && !targetMessage.getCreatedAt().isAfter(visibleMessageFrom)) {
             throw CustomException.of(NOT_FOUND_CHAT_ROOM);
         }
@@ -60,15 +61,16 @@ public class ChatMessagePageResolver {
      * messageId 조회 전 방 접근 권한을 검증한다.
      * 권한 없음과 메시지 미존재를 구분할 수 없게 NOT_FOUND_CHAT_ROOM으로 통일한다.
      */
-    private void ensureMessageLookupAccess(ChatRoom room, User user) {
+    private AccessContext ensureMessageLookupAccess(ChatRoom room, User user) {
         if (room.isDirectRoom()) {
-            boolean isMember = chatRoomMemberRepository
-                .findByChatRoomIdAndUserId(room.getId(), user.getId())
-                .isPresent();
-            if (!isMember && !(user.isAdmin() && isSystemAdminRoom(room))) {
+            Optional<ChatRoomMember> member = chatRoomMemberRepository
+                .findByChatRoomIdAndUserId(room.getId(), user.getId());
+            boolean isAdminViewingSystemRoom = user.isAdmin()
+                && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
+            if (member.isEmpty() && !isAdminViewingSystemRoom) {
                 throw CustomException.of(NOT_FOUND_CHAT_ROOM);
             }
-            return;
+            return new AccessContext(member, isAdminViewingSystemRoom);
         }
 
         if (room.isClubGroupRoom()) {
@@ -80,43 +82,35 @@ public class ChatMessagePageResolver {
                 }
                 throw e;
             }
-            return;
+            return AccessContext.none();
         }
 
-        chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
-            .filter(member -> !member.hasLeft())
+        ChatRoomMember member = chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+            .filter(roomMember -> !roomMember.hasLeft())
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+        return new AccessContext(Optional.of(member), false);
     }
 
-    private LocalDateTime resolveVisibleMessageFrom(ChatRoom room, User user) {
+    private LocalDateTime resolveVisibleMessageFrom(ChatRoom room, User user, AccessContext accessContext) {
         if (!room.isDirectRoom()) {
             return null;
         }
 
-        if (user.isAdmin() && isSystemAdminRoom(room)) {
+        if (user.isAdmin() && accessContext.isAdminViewingSystemRoom()) {
             List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(room.getId());
-            ChatRoomMember systemAdminMember = findRoomMember(members, SYSTEM_ADMIN_ID);
+            ChatRoomMember systemAdminMember = chatRoomSystemAdminService.findSystemAdminMember(members);
             return systemAdminMember != null ? systemAdminMember.getVisibleMessageFrom() : null;
         }
 
-        return chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+        return accessContext.member()
             .map(ChatRoomMember::getVisibleMessageFrom)
             .orElse(null);
     }
 
-    private boolean isSystemAdminRoom(ChatRoom chatRoom) {
-        List<Object[]> memberIds = chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(
-            List.of(chatRoom.getId())
-        );
-        return memberIds.stream()
-            .map(row -> (Integer)row[1])
-            .anyMatch(userId -> userId.equals(SYSTEM_ADMIN_ID));
-    }
+    private record AccessContext(Optional<ChatRoomMember> member, boolean isAdminViewingSystemRoom) {
 
-    private ChatRoomMember findRoomMember(List<ChatRoomMember> members, Integer userId) {
-        return members.stream()
-            .filter(member -> member.getUserId().equals(userId))
-            .findFirst()
-            .orElse(null);
+        private static AccessContext none() {
+            return new AccessContext(Optional.empty(), false);
+        }
     }
 }

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
@@ -65,9 +65,13 @@ public class ChatMessagePageResolver {
         if (room.isDirectRoom()) {
             Optional<ChatRoomMember> member = chatRoomMemberRepository
                 .findByChatRoomIdAndUserId(room.getId(), user.getId());
+            if (member.isPresent()) {
+                return new AccessContext(member, false);
+            }
+
             boolean isAdminViewingSystemRoom = user.isAdmin()
                 && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
-            if (member.isEmpty() && !isAdminViewingSystemRoom) {
+            if (!isAdminViewingSystemRoom) {
                 throw CustomException.of(NOT_FOUND_CHAT_ROOM);
             }
             return new AccessContext(member, isAdminViewingSystemRoom);

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
@@ -1,0 +1,122 @@
+package gg.agit.konect.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB_MEMBER;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.chat.model.ChatMessage;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatMessagePageResolver {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ClubMemberRepository clubMemberRepository;
+
+    public int resolvePageForMessage(
+        Integer roomId,
+        Integer messageId,
+        ChatRoom room,
+        User user,
+        int limit
+    ) {
+        ensureMessageLookupAccess(room, user);
+
+        ChatMessage targetMessage = chatMessageRepository.findByIdWithChatRoom(messageId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+
+        if (!targetMessage.getChatRoom().getId().equals(roomId)) {
+            throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+        }
+
+        LocalDateTime visibleMessageFrom = resolveVisibleMessageFrom(room, user);
+        if (visibleMessageFrom != null && !targetMessage.getCreatedAt().isAfter(visibleMessageFrom)) {
+            throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+        }
+
+        long newerCount = chatMessageRepository.countNewerMessagesByChatRoomId(
+            roomId, messageId, targetMessage.getCreatedAt(), visibleMessageFrom
+        );
+        return (int)(newerCount / limit) + 1;
+    }
+
+    /**
+     * messageId 조회 전 방 접근 권한을 검증한다.
+     * 권한 없음과 메시지 미존재를 구분할 수 없게 NOT_FOUND_CHAT_ROOM으로 통일한다.
+     */
+    private void ensureMessageLookupAccess(ChatRoom room, User user) {
+        if (room.isDirectRoom()) {
+            boolean isMember = chatRoomMemberRepository
+                .findByChatRoomIdAndUserId(room.getId(), user.getId())
+                .isPresent();
+            if (!isMember && !(user.isAdmin() && isSystemAdminRoom(room))) {
+                throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+            }
+            return;
+        }
+
+        if (room.isClubGroupRoom()) {
+            try {
+                clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), user.getId());
+            } catch (CustomException e) {
+                if (e.getErrorCode() == NOT_FOUND_CLUB_MEMBER) {
+                    throw CustomException.of(NOT_FOUND_CHAT_ROOM);
+                }
+                throw e;
+            }
+            return;
+        }
+
+        chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+            .filter(member -> !member.hasLeft())
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+    }
+
+    private LocalDateTime resolveVisibleMessageFrom(ChatRoom room, User user) {
+        if (!room.isDirectRoom()) {
+            return null;
+        }
+
+        if (user.isAdmin() && isSystemAdminRoom(room)) {
+            List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(room.getId());
+            ChatRoomMember systemAdminMember = findRoomMember(members, SYSTEM_ADMIN_ID);
+            return systemAdminMember != null ? systemAdminMember.getVisibleMessageFrom() : null;
+        }
+
+        return chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+            .map(ChatRoomMember::getVisibleMessageFrom)
+            .orElse(null);
+    }
+
+    private boolean isSystemAdminRoom(ChatRoom chatRoom) {
+        List<Object[]> memberIds = chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(
+            List.of(chatRoom.getId())
+        );
+        return memberIds.stream()
+            .map(row -> (Integer)row[1])
+            .anyMatch(userId -> userId.equals(SYSTEM_ADMIN_ID));
+    }
+
+    private ChatRoomMember findRoomMember(List<ChatRoomMember> members, Integer userId) {
+        return members.stream()
+            .filter(member -> member.getUserId().equals(userId))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatMessagePageResolver.java
@@ -74,7 +74,7 @@ public class ChatMessagePageResolver {
             if (!isAdminViewingSystemRoom) {
                 throw CustomException.of(NOT_FOUND_CHAT_ROOM);
             }
-            return new AccessContext(member, isAdminViewingSystemRoom);
+            return new AccessContext(Optional.empty(), true);
         }
 
         if (room.isClubGroupRoom()) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMembershipService.java
@@ -41,6 +41,7 @@ public class ChatRoomMembershipService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ClubMemberRepository clubMemberRepository;
     private final UserRepository userRepository;
+    private final ChatRoomSystemAdminService chatRoomSystemAdminService;
 
     @Transactional(readOnly = true)
     public ChatRoomMembersResponse getChatRoomMembers(Integer chatRoomId, Integer currentUserId) {
@@ -63,7 +64,7 @@ public class ChatRoomMembershipService {
 
     private void validateMembership(ChatRoom chatRoom, User currentUser) {
         // 어드민은 시스템 어드민 방의 멤버를 조회할 수 있음
-        if (currentUser.isAdmin() && isSystemAdminRoom(chatRoom.getId())) {
+        if (currentUser.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(chatRoom.getId())) {
             return;
         }
 
@@ -110,7 +111,7 @@ public class ChatRoomMembershipService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateDirectRoomLastReadAt(Integer roomId, User user, LocalDateTime readAt, ChatRoom room) {
         // 어드민이 SYSTEM_ADMIN 방의 메시지를 읽으면 SYSTEM_ADMIN의 lastReadAt을 업데이트
-        if (user.isAdmin() && isSystemAdminRoom(roomId)) {
+        if (user.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(roomId)) {
             chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, SYSTEM_ADMIN_ID, readAt);
             return;
         }
@@ -176,18 +177,11 @@ public class ChatRoomMembershipService {
 
         // 어드민은 SYSTEM_ADMIN 방의 메시지를 조회할 수 있지만, 멤버로 추가되지는 않는다
         // (멤버가 추가되면 findByTwoUsers에서 해당 방을 찾지 못해 채팅방이 중복 생성됨)
-        if (user.isAdmin() && isSystemAdminRoom(room.getId())) {
+        if (user.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(room.getId())) {
             return;
         }
 
         throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
-    }
-
-    private boolean isSystemAdminRoom(Integer roomId) {
-        List<Object[]> memberIds = chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(roomId));
-        return memberIds.stream()
-            .map(row -> (Integer)row[1])
-            .anyMatch(userId -> userId.equals(SYSTEM_ADMIN_ID));
     }
 
     private boolean isDuplicateKeyException(DataIntegrityViolationException e) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomSystemAdminService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomSystemAdminService.java
@@ -1,0 +1,34 @@
+package gg.agit.konect.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomSystemAdminService {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public boolean isSystemAdminRoom(Integer roomId) {
+        List<Object[]> memberIds = chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(roomId));
+        return memberIds.stream()
+            .map(row -> (Integer)row[1])
+            .anyMatch(userId -> userId.equals(SYSTEM_ADMIN_ID));
+    }
+
+    public ChatRoomMember findSystemAdminMember(List<ChatRoomMember> members) {
+        return members.stream()
+            .filter(member -> member.getUserId().equals(SYSTEM_ADMIN_ID))
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomSystemAdminService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomSystemAdminService.java
@@ -19,10 +19,7 @@ public class ChatRoomSystemAdminService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     public boolean isSystemAdminRoom(Integer roomId) {
-        List<Object[]> memberIds = chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(roomId));
-        return memberIds.stream()
-            .map(row -> (Integer)row[1])
-            .anyMatch(userId -> userId.equals(SYSTEM_ADMIN_ID));
+        return chatRoomMemberRepository.existsByChatRoomIdAndUserId(roomId, SYSTEM_ADMIN_ID);
     }
 
     public ChatRoomMember findSystemAdminMember(List<ChatRoomMember> members) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -82,6 +82,7 @@ public class ChatService {
     private final ChatRoomMembershipService chatRoomMembershipService;
     private final ChatRoomSummaryService chatRoomSummaryService;
     private final ChatSearchService chatSearchService;
+    private final ChatMessagePageResolver chatMessagePageResolver;
     private final NotificationService notificationService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -346,8 +347,7 @@ public class ChatService {
         User user = userRepository.getById(userId);
 
         if (messageId != null) {
-            ensureMessageLookupAccess(room, user, userId);
-            page = resolvePageForMessage(roomId, messageId, room, user, limit);
+            page = chatMessagePageResolver.resolvePageForMessage(roomId, messageId, room, user, limit);
         }
 
         LocalDateTime readAt = LocalDateTime.now();
@@ -1198,85 +1198,6 @@ public class ChatService {
             .toList();
 
         return userIds.contains(SYSTEM_ADMIN_ID);
-    }
-
-    /**
-     * messageId 조회 전 방 접근 권한을 검증한다.
-     * 권한 없음과 메시지 미존재를 구분할 수 없게 NOT_FOUND_CHAT_ROOM으로 통일하여
-     * 메시지 존재 여부 오라클을 방지한다.
-     */
-    private void ensureMessageLookupAccess(ChatRoom room, User user, Integer userId) {
-        if (room.isDirectRoom()) {
-            boolean isMember = chatRoomMemberRepository
-                .findByChatRoomIdAndUserId(room.getId(), userId)
-                .isPresent();
-            if (!isMember && !(user.isAdmin() && isSystemAdminRoom(room))) {
-                throw CustomException.of(NOT_FOUND_CHAT_ROOM);
-            }
-        } else if (room.isClubGroupRoom()) {
-            try {
-                clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), userId);
-            } catch (CustomException e) {
-                // 동아리 멤버십 없음만 404로 변환, 다른 예외는 그대로 전파
-                if (e.getErrorCode() == NOT_FOUND_CLUB_MEMBER) {
-                    throw CustomException.of(NOT_FOUND_CHAT_ROOM);
-                }
-                throw e;
-            }
-        } else {
-            chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), userId)
-                .filter(member -> !member.hasLeft())
-                .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-        }
-    }
-
-    /**
-     * messageId가 가리키는 메시지가 포함된 페이지 번호를 계산한다.
-     * 가시성 검증 및 정보 누출 방지를 위해 동일한 에러 코드를 사용한다.
-     */
-    private int resolvePageForMessage(
-        Integer roomId, Integer messageId, ChatRoom room, User user, int limit
-    ) {
-        ChatMessage targetMessage = chatMessageRepository.findByIdWithChatRoom(messageId)
-            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-
-        // 정보 누출 방지를 위해 동일한 에러 코드 사용
-        if (!targetMessage.getChatRoom().getId().equals(roomId)) {
-            throw CustomException.of(NOT_FOUND_CHAT_ROOM);
-        }
-
-        LocalDateTime visibleMessageFrom = resolveVisibleMessageFromPure(room, user);
-
-        if (visibleMessageFrom != null && !targetMessage.getCreatedAt().isAfter(visibleMessageFrom)) {
-            throw CustomException.of(NOT_FOUND_CHAT_ROOM);
-        }
-
-        // NOTE: count와 fetch 사이에 새 메시지가 삽입될 수 있으나,
-        // 호출부(getMessages)에서 응답에 타겟 메시지가 없으면 1회 재계산함
-        long newerCount = chatMessageRepository.countNewerMessagesByChatRoomId(
-            roomId, messageId, targetMessage.getCreatedAt(), visibleMessageFrom
-        );
-        return (int)(newerCount / limit) + 1;
-    }
-
-    /**
-     * 채팅방 타입에 따른 메시지 가시성 기준 시간을 조회한다.
-     * 기존 getMessages() 흐름의 가시성 로직과 동일한 값을 반환하되,
-     * 방 복원 등 부수효과는 발생시키지 않는다.
-     */
-    private LocalDateTime resolveVisibleMessageFromPure(ChatRoom room, User user) {
-        if (!room.isDirectRoom()) {
-            return null;
-        }
-
-        if (user.isAdmin() && isSystemAdminRoom(room)) {
-            List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(room.getId());
-            return resolveAdminSystemRoomVisibleMessageFrom(members);
-        }
-
-        return chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
-            .map(ChatRoomMember::getVisibleMessageFrom)
-            .orElse(null);
     }
 
     private boolean shouldDisplayAsOwnMessage(

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -83,6 +83,7 @@ public class ChatService {
     private final ChatRoomSummaryService chatRoomSummaryService;
     private final ChatSearchService chatSearchService;
     private final ChatMessagePageResolver chatMessagePageResolver;
+    private final ChatRoomSystemAdminService chatRoomSystemAdminService;
     private final NotificationService notificationService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -353,7 +354,8 @@ public class ChatService {
         LocalDateTime readAt = LocalDateTime.now();
 
         if (room.isDirectRoom()) {
-            boolean isAdminViewingSystemRoom = user.isAdmin() && isSystemAdminRoom(room);
+            boolean isAdminViewingSystemRoom = user.isAdmin()
+                && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
             if (isAdminViewingSystemRoom) {
                 chatRoomMembershipService.updateLastReadAt(roomId, SYSTEM_ADMIN_ID, readAt);
                 recordPresenceSafely(roomId, userId);
@@ -406,7 +408,7 @@ public class ChatService {
         } else if (room.isDirectRoom()) {
             // 어드민이 SYSTEM_ADMIN 방에 접근하는 경우는 멤버십 체크를 건너뜀
             boolean isAdminAccessingSystemAdminRoom = user.isAdmin()
-                && isSystemAdminRoom(room);
+                && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
             if (!isAdminAccessingSystemAdminRoom) {
                 getAccessibleDirectRoomMember(room, user);
             }
@@ -662,7 +664,7 @@ public class ChatService {
 
         // 어드민이 SYSTEM_ADMIN 방에 메시지를 보내는 경우
         boolean isAdminSendingToSystemAdminRoom = sender.isAdmin()
-            && isSystemAdminRoom(chatRoom);
+            && chatRoomSystemAdminService.isSystemAdminRoom(chatRoom.getId());
 
         ChatRoomMember senderMember = null;
         boolean senderHadLeft = false;
@@ -1036,7 +1038,7 @@ public class ChatService {
     private boolean shouldSkipSystemAdminMembership(ChatRoom room, User user) {
         // 문의방은 SYSTEM_ADMIN + 일반 사용자 2인 구조를 전제로 재사용(findByTwoUsers)되므로,
         // 생성/재오픈 경로에서도 일반 ADMIN을 멤버로 추가하면 안 된다.
-        return user.isAdmin() && isSystemAdminRoom(room);
+        return user.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
     }
 
     private String normalizeCustomRoomName(String roomName) {
@@ -1149,7 +1151,7 @@ public class ChatService {
         return chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoom.getId(), user.getId())
             .orElseGet(() -> {
                 // 어드민은 SYSTEM_ADMIN 방에 멤버로 추가되지 않음
-                if (user.isAdmin() && isSystemAdminRoom(chatRoom)) {
+                if (user.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(chatRoom.getId())) {
                     throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
                 }
                 throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
@@ -1169,7 +1171,7 @@ public class ChatService {
     }
 
     private LocalDateTime resolveAdminSystemRoomVisibleMessageFrom(List<ChatRoomMember> members) {
-        ChatRoomMember systemAdminMember = findRoomMember(members, SYSTEM_ADMIN_ID);
+        ChatRoomMember systemAdminMember = chatRoomSystemAdminService.findSystemAdminMember(members);
         return systemAdminMember != null ? systemAdminMember.getVisibleMessageFrom() : null;
     }
 
@@ -1187,17 +1189,6 @@ public class ChatService {
         }
 
         member.restoreDirectRoom();
-    }
-
-    private boolean isSystemAdminRoom(ChatRoom chatRoom) {
-        List<Object[]> memberIds = chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(
-            List.of(chatRoom.getId())
-        );
-        List<Integer> userIds = memberIds.stream()
-            .map(row -> (Integer)row[1])
-            .toList();
-
-        return userIds.contains(SYSTEM_ADMIN_ID);
     }
 
     private boolean shouldDisplayAsOwnMessage(

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -1149,13 +1149,7 @@ public class ChatService {
 
     private ChatRoomMember getOrCreateDirectRoomMember(ChatRoom chatRoom, User user) {
         return chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoom.getId(), user.getId())
-            .orElseGet(() -> {
-                // 어드민은 SYSTEM_ADMIN 방에 멤버로 추가되지 않음
-                if (user.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(chatRoom.getId())) {
-                    throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
-                }
-                throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
-            });
+            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
     }
 
     private ChatRoomMember getAccessibleDirectRoomMember(ChatRoom chatRoom, User user) {

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatMessagePageResolverTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatMessagePageResolverTest.java
@@ -1,0 +1,306 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB_MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gg.agit.konect.domain.chat.enums.ChatType;
+import gg.agit.konect.domain.chat.model.ChatMessage;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
+import gg.agit.konect.support.fixture.ClubMemberFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ChatMessagePageResolverTest extends ServiceTestSupport {
+
+    private static final LocalDateTime BASE_TIME = LocalDateTime.of(2026, 4, 27, 10, 0);
+    private static final LocalDateTime TARGET_TIME = LocalDateTime.of(2026, 4, 27, 14, 0);
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @InjectMocks
+    private ChatMessagePageResolver chatMessagePageResolver;
+
+    @Test
+    @DisplayName("group room 접근 권한 확인 후 messageId 페이지를 계산한다")
+    void resolvePageForGroupRoomMessage() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = room(1, ChatType.GROUP);
+        ChatMessage message = message(50, room, user, TARGET_TIME);
+        stubActiveMember(room, user);
+        stubTargetMessage(message);
+        given(chatMessageRepository.countNewerMessagesByChatRoomId(room.getId(), message.getId(), TARGET_TIME, null))
+            .willReturn(25L);
+
+        int page = chatMessagePageResolver.resolvePageForMessage(room.getId(), message.getId(), room, user, 20);
+
+        assertThat(page).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("group room 비회원이면 messageId 조회 전에 404를 던진다")
+    void resolvePageForGroupRoomRejectsNonMemberBeforeMessageLookup() {
+        User user = user(99, UserRole.USER);
+        ChatRoom room = room(1, ChatType.GROUP);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.empty());
+
+        assertNotFound(() -> chatMessagePageResolver.resolvePageForMessage(room.getId(), 50, room, user, 20));
+        verify(chatMessageRepository, never()).findByIdWithChatRoom(50);
+    }
+
+    @Test
+    @DisplayName("group room에서 나간 멤버를 404로 거부한다")
+    void resolvePageForGroupRoomRejectsLeftMember() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = room(1, ChatType.GROUP);
+        ChatRoomMember member = member(room, user);
+        ReflectionTestUtils.setField(member, "leftAt", BASE_TIME.plusHours(1));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(member));
+
+        assertNotFound(() -> chatMessagePageResolver.resolvePageForMessage(room.getId(), 50, room, user, 20));
+        verify(chatMessageRepository, never()).findByIdWithChatRoom(50);
+    }
+
+    @Test
+    @DisplayName("direct room은 visibleMessageFrom 이후 메시지만 페이지 계산한다")
+    void resolvePageForDirectRoomUsesVisibleMessageFrom() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = room(1, ChatType.DIRECT);
+        LocalDateTime visibleMessageFrom = BASE_TIME.plusHours(2);
+        ChatMessage message = message(50, room, user(20, UserRole.USER), BASE_TIME.plusHours(3));
+        stubDirectMember(room, user, visibleMessageFrom);
+        stubTargetMessage(message);
+        given(chatMessageRepository.countNewerMessagesByChatRoomId(
+            room.getId(), message.getId(), message.getCreatedAt(), visibleMessageFrom
+        )).willReturn(0L);
+
+        int page = chatMessagePageResolver.resolvePageForMessage(room.getId(), message.getId(), room, user, 20);
+
+        assertThat(page).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("direct room의 visibleMessageFrom 이전 messageId를 404로 숨긴다")
+    void resolvePageForDirectRoomRejectsHiddenMessage() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = room(1, ChatType.DIRECT);
+        LocalDateTime visibleMessageFrom = BASE_TIME.plusHours(2);
+        ChatMessage message = message(50, room, user(20, UserRole.USER), BASE_TIME.plusHours(1));
+        stubDirectMember(room, user, visibleMessageFrom);
+        stubTargetMessage(message);
+
+        assertNotFound(() -> chatMessagePageResolver.resolvePageForMessage(room.getId(), 50, room, user, 20));
+        verify(chatMessageRepository, never()).countNewerMessagesByChatRoomId(
+            room.getId(), message.getId(), message.getCreatedAt(), visibleMessageFrom
+        );
+    }
+
+    @Test
+    @DisplayName("direct room 비회원 일반 사용자를 404로 거부한다")
+    void resolvePageForDirectRoomRejectsNonMemberUser() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = room(1, ChatType.DIRECT);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.empty());
+
+        assertNotFound(() -> chatMessagePageResolver.resolvePageForMessage(room.getId(), 50, room, user, 20));
+        verify(chatMessageRepository, never()).findByIdWithChatRoom(50);
+    }
+
+    @Test
+    @DisplayName("admin의 system admin 방 조회는 SYSTEM_ADMIN 가시 범위를 사용한다")
+    void resolvePageForAdminSystemRoomUsesSystemAdminVisibility() {
+        User admin = user(99, UserRole.ADMIN);
+        ChatRoom room = room(1, ChatType.DIRECT);
+        LocalDateTime visibleMessageFrom = BASE_TIME.plusHours(2);
+        ChatMessage message = message(50, room, admin, BASE_TIME.plusHours(3));
+        stubSystemAdminRoom(room);
+        stubSystemAdminMember(room, visibleMessageFrom);
+        stubTargetMessage(message);
+        given(chatMessageRepository.countNewerMessagesByChatRoomId(
+            room.getId(), message.getId(), message.getCreatedAt(), visibleMessageFrom
+        )).willReturn(0L);
+
+        int page = chatMessagePageResolver.resolvePageForMessage(room.getId(), message.getId(), room, admin, 20);
+
+        assertThat(page).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("system admin 멤버가 없으면 admin 조회 가시 범위를 null로 계산한다")
+    void resolvePageForAdminSystemRoomAllowsMissingSystemAdminMember() {
+        User admin = user(99, UserRole.ADMIN);
+        ChatRoom room = room(1, ChatType.DIRECT);
+        ChatMessage message = message(50, room, admin, BASE_TIME.plusHours(3));
+        stubSystemAdminRoom(room);
+        given(chatRoomMemberRepository.findByChatRoomId(room.getId())).willReturn(List.of());
+        stubTargetMessage(message);
+        given(chatMessageRepository.countNewerMessagesByChatRoomId(
+            room.getId(), message.getId(), message.getCreatedAt(), null
+        )).willReturn(0L);
+
+        int page = chatMessagePageResolver.resolvePageForMessage(room.getId(), message.getId(), room, admin, 20);
+
+        assertThat(page).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("club group 동아리 멤버십 없음만 404로 변환한다")
+    void resolvePageForClubRoomConvertsMissingClubMemberToNotFoundRoom() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = clubRoom(1);
+        given(clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), user.getId()))
+            .willThrow(CustomException.of(NOT_FOUND_CLUB_MEMBER));
+
+        assertNotFound(() -> chatMessagePageResolver.resolvePageForMessage(room.getId(), 50, room, user, 20));
+        verify(chatMessageRepository, never()).findByIdWithChatRoom(50);
+    }
+
+    @Test
+    @DisplayName("club group 멤버십 조회 예외가 404가 아니면 그대로 전파한다")
+    void resolvePageForClubRoomPropagatesNonMembershipException() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = clubRoom(1);
+        CustomException exception = CustomException.of(ApiResponseCode.NOT_FOUND_USER);
+        given(clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), user.getId()))
+            .willThrow(exception);
+
+        assertThatThrownBy(() -> chatMessagePageResolver.resolvePageForMessage(room.getId(), 50, room, user, 20))
+            .isSameAs(exception);
+        verify(chatMessageRepository, never()).findByIdWithChatRoom(50);
+    }
+
+    @Test
+    @DisplayName("club group 접근 가능 사용자의 messageId 페이지를 계산한다")
+    void resolvePageForClubRoomMessage() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = clubRoom(1);
+        ChatMessage message = message(50, room, user, TARGET_TIME);
+        given(clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), user.getId()))
+            .willReturn(ClubMemberFixture.createMember(room.getClub(), user));
+        stubTargetMessage(message);
+        given(chatMessageRepository.countNewerMessagesByChatRoomId(room.getId(), message.getId(), TARGET_TIME, null))
+            .willReturn(0L);
+
+        int page = chatMessagePageResolver.resolvePageForMessage(room.getId(), message.getId(), room, user, 20);
+
+        assertThat(page).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("다른 방의 messageId를 404로 숨긴다")
+    void resolvePageForMessageRejectsMessageFromOtherRoom() {
+        User user = user(10, UserRole.USER);
+        ChatRoom room = room(1, ChatType.GROUP);
+        ChatMessage message = message(50, room(2, ChatType.GROUP), user, TARGET_TIME);
+        stubActiveMember(room, user);
+        stubTargetMessage(message);
+
+        assertNotFound(() -> chatMessagePageResolver.resolvePageForMessage(room.getId(), 50, room, user, 20));
+    }
+
+    private void stubActiveMember(ChatRoom room, User user) {
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(member(room, user)));
+    }
+
+    private void stubDirectMember(ChatRoom room, User user, LocalDateTime visibleMessageFrom) {
+        ChatRoomMember member = member(room, user);
+        ReflectionTestUtils.setField(member, "visibleMessageFrom", visibleMessageFrom);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(member));
+    }
+
+    private void stubSystemAdminRoom(ChatRoom room) {
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), 99)).willReturn(Optional.empty());
+        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(room.getId())))
+            .willReturn(List.<Object[]>of(new Object[] {room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()}));
+    }
+
+    private void stubSystemAdminMember(ChatRoom room, LocalDateTime visibleMessageFrom) {
+        ChatRoomMember member = member(room, user(SYSTEM_ADMIN_ID, UserRole.ADMIN));
+        ReflectionTestUtils.setField(member, "visibleMessageFrom", visibleMessageFrom);
+        given(chatRoomMemberRepository.findByChatRoomId(room.getId())).willReturn(List.of(member));
+    }
+
+    private void stubTargetMessage(ChatMessage message) {
+        given(chatMessageRepository.findByIdWithChatRoom(message.getId())).willReturn(Optional.of(message));
+    }
+
+    private User user(Integer id, UserRole role) {
+        return UserFixture.createUserWithId(UniversityFixture.createWithId(1), id, "사용자" + id,
+            "2024" + String.format("%04d", id), role);
+    }
+
+    private ChatRoom room(Integer id, ChatType type) {
+        ChatRoom room = type == ChatType.DIRECT ? ChatRoom.directOf() : ChatRoom.groupOf();
+        ReflectionTestUtils.setField(room, "id", id);
+        ReflectionTestUtils.setField(room, "createdAt", BASE_TIME);
+        return room;
+    }
+
+    private ChatRoom clubRoom(Integer id) {
+        Club club = ClubFixture.createWithId(UniversityFixture.createWithId(1), 77, "BCSD");
+        ChatRoom room = ChatRoom.clubGroupOf(club);
+        ReflectionTestUtils.setField(room, "id", id);
+        ReflectionTestUtils.setField(room, "createdAt", BASE_TIME);
+        return room;
+    }
+
+    private ChatRoomMember member(ChatRoom room, User user) {
+        ChatRoomMember member = ChatRoomMember.of(room, user, BASE_TIME);
+        ReflectionTestUtils.setField(member, "createdAt", BASE_TIME);
+        return member;
+    }
+
+    private ChatMessage message(Integer id, ChatRoom room, User sender, LocalDateTime createdAt) {
+        ChatMessage message = ChatMessage.of(room, sender, "메시지");
+        ReflectionTestUtils.setField(message, "id", id);
+        ReflectionTestUtils.setField(message, "createdAt", createdAt);
+        return message;
+    }
+
+    private void assertNotFound(ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception ->
+                assertThat(((CustomException)exception).getErrorCode()).isEqualTo(NOT_FOUND_CHAT_ROOM));
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatMessagePageResolverTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatMessagePageResolverTest.java
@@ -27,6 +27,7 @@ import gg.agit.konect.domain.chat.model.ChatRoomMember;
 import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
+import gg.agit.konect.domain.chat.service.ChatRoomSystemAdminService;
 import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.repository.ClubMemberRepository;
 import gg.agit.konect.domain.user.enums.UserRole;
@@ -52,6 +53,9 @@ class ChatMessagePageResolverTest extends ServiceTestSupport {
 
     @Mock
     private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private ChatRoomSystemAdminService chatRoomSystemAdminService;
 
     @InjectMocks
     private ChatMessagePageResolver chatMessagePageResolver;
@@ -250,14 +254,14 @@ class ChatMessagePageResolverTest extends ServiceTestSupport {
 
     private void stubSystemAdminRoom(ChatRoom room) {
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), 99)).willReturn(Optional.empty());
-        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(room.getId())))
-            .willReturn(List.<Object[]>of(new Object[] {room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()}));
+        given(chatRoomSystemAdminService.isSystemAdminRoom(room.getId())).willReturn(true);
     }
 
     private void stubSystemAdminMember(ChatRoom room, LocalDateTime visibleMessageFrom) {
         ChatRoomMember member = member(room, user(SYSTEM_ADMIN_ID, UserRole.ADMIN));
         ReflectionTestUtils.setField(member, "visibleMessageFrom", visibleMessageFrom);
         given(chatRoomMemberRepository.findByChatRoomId(room.getId())).willReturn(List.of(member));
+        given(chatRoomSystemAdminService.findSystemAdminMember(List.of(member))).willReturn(member);
     }
 
     private void stubTargetMessage(ChatMessage message) {

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMembershipServiceTest.java
@@ -32,6 +32,7 @@ import gg.agit.konect.domain.chat.model.ChatRoomMember;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.chat.service.ChatRoomSystemAdminService;
 import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.ClubMember;
 import gg.agit.konect.domain.club.repository.ClubMemberRepository;
@@ -59,6 +60,9 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ChatRoomSystemAdminService chatRoomSystemAdminService;
 
     @InjectMocks
     private ChatRoomMembershipService chatRoomMembershipService;
@@ -316,8 +320,7 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
         User admin = createUser(99, "관리자", UserRole.ADMIN);
         ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
-        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(roomId)))
-            .willReturn(List.<Object[]>of(new Object[] {roomId, SYSTEM_ADMIN_ID, readAt}));
+        given(chatRoomSystemAdminService.isSystemAdminRoom(roomId)).willReturn(true);
 
         // when
         chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, admin, readAt, room);
@@ -371,8 +374,7 @@ class ChatRoomMembershipServiceTest extends ServiceTestSupport {
         User admin = createUser(99, "관리자", UserRole.ADMIN);
         ChatRoom room = createRoom(roomId, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
         LocalDateTime readAt = LocalDateTime.of(2026, 4, 11, 10, 5);
-        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(roomId)))
-            .willReturn(List.<Object[]>of(new Object[] {roomId, SYSTEM_ADMIN_ID, readAt}));
+        given(chatRoomSystemAdminService.isSystemAdminRoom(roomId)).willReturn(true);
 
         // when
         chatRoomMembershipService.updateDirectRoomLastReadAt(roomId, admin, readAt, room);

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomSystemAdminServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomSystemAdminServiceTest.java
@@ -1,0 +1,61 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.service.ChatRoomSystemAdminService;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ChatRoomSystemAdminServiceTest extends ServiceTestSupport {
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @InjectMocks
+    private ChatRoomSystemAdminService chatRoomSystemAdminService;
+
+    @Test
+    @DisplayName("isSystemAdminRoom은 SYSTEM_ADMIN 멤버가 있으면 true를 반환한다")
+    void isSystemAdminRoomReturnsTrueWhenSystemAdminMemberExists() {
+        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(1)))
+            .willReturn(List.<Object[]>of(new Object[] {1, SYSTEM_ADMIN_ID, LocalDateTime.now()}));
+
+        boolean result = chatRoomSystemAdminService.isSystemAdminRoom(1);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("findSystemAdminMember는 멤버 목록에서 SYSTEM_ADMIN 멤버를 반환한다")
+    void findSystemAdminMemberReturnsSystemAdminMember() {
+        ChatRoom room = ChatRoom.directOf();
+        User systemAdmin = UserFixture.createUserWithId(
+            UniversityFixture.createWithId(1),
+            SYSTEM_ADMIN_ID,
+            "시스템관리자",
+            "20240001",
+            UserRole.ADMIN
+        );
+        ChatRoomMember member = ChatRoomMember.of(room, systemAdmin, LocalDateTime.now());
+
+        ChatRoomMember result = chatRoomSystemAdminService.findSystemAdminMember(List.of(member));
+
+        assertThat(result).isSameAs(member);
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomSystemAdminServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomSystemAdminServiceTest.java
@@ -33,8 +33,7 @@ class ChatRoomSystemAdminServiceTest extends ServiceTestSupport {
     @Test
     @DisplayName("isSystemAdminRoom은 SYSTEM_ADMIN 멤버가 있으면 true를 반환한다")
     void isSystemAdminRoomReturnsTrueWhenSystemAdminMemberExists() {
-        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(1)))
-            .willReturn(List.<Object[]>of(new Object[] {1, SYSTEM_ADMIN_ID, LocalDateTime.now()}));
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(1, SYSTEM_ADMIN_ID)).willReturn(true);
 
         boolean result = chatRoomSystemAdminService.isSystemAdminRoom(1);
 

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -56,6 +56,7 @@ import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.chat.service.ChatRoomSummaryService;
 import gg.agit.konect.domain.chat.service.ChatSearchService;
 import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
+import gg.agit.konect.domain.chat.service.ChatRoomSystemAdminService;
 import gg.agit.konect.domain.chat.service.ChatService;
 import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.ClubMember;
@@ -114,6 +115,9 @@ class ChatServiceTest extends ServiceTestSupport {
     private ChatSearchService chatSearchService;
 
     @Mock
+    private ChatRoomSystemAdminService chatRoomSystemAdminService;
+
+    @Mock
     private NotificationService notificationService;
 
     @Mock
@@ -128,7 +132,8 @@ class ChatServiceTest extends ServiceTestSupport {
         chatMessagePageResolver = new ChatMessagePageResolver(
             chatMessageRepository,
             chatRoomMemberRepository,
-            clubMemberRepository
+            clubMemberRepository,
+            chatRoomSystemAdminService
         );
         chatService = new ChatService(
             chatRoomRepository,
@@ -144,6 +149,7 @@ class ChatServiceTest extends ServiceTestSupport {
             chatRoomSummaryService,
             chatSearchService,
             chatMessagePageResolver,
+            chatRoomSystemAdminService,
             notificationService,
             eventPublisher
         );
@@ -221,11 +227,7 @@ class ChatServiceTest extends ServiceTestSupport {
             .willReturn(Optional.empty());
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), targetUserId))
             .willReturn(Optional.empty());
-        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(room.getId())))
-            .willReturn(List.of(
-                new Object[] {room.getId(), SYSTEM_ADMIN_ID, room.getCreatedAt()},
-                new Object[] {room.getId(), targetUserId, room.getCreatedAt()}
-            ));
+        given(chatRoomSystemAdminService.isSystemAdminRoom(room.getId())).willReturn(true);
 
         // when
         ChatRoomResponse response = chatService.createOrGetChatRoom(adminUserId,
@@ -809,11 +811,9 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
         given(userRepository.getById(adminId)).willReturn(admin);
-        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
-            .willReturn(List.of(
-                new Object[] {systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
-                new Object[] {systemAdminRoom.getId(), 20, systemAdminRoom.getCreatedAt()}
-            ));
+        given(chatRoomSystemAdminService.isSystemAdminRoom(systemAdminRoom.getId())).willReturn(true);
+        given(chatRoomSystemAdminService.findSystemAdminMember(List.of(systemAdminMember, targetMember)))
+            .willReturn(systemAdminMember);
         given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
             .willReturn(List.of(systemAdminMember, targetMember));
         given(chatMessageRepository.findByChatRoomId(eq(systemAdminRoom.getId()), nullable(LocalDateTime.class),
@@ -1051,11 +1051,7 @@ class ChatServiceTest extends ServiceTestSupport {
 
         given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
         given(userRepository.getById(adminId)).willReturn(admin);
-        given(chatRoomMemberRepository.findRoomMemberIdsByChatRoomIds(List.of(systemAdminRoom.getId())))
-            .willReturn(List.of(
-                new Object[] {systemAdminRoom.getId(), SYSTEM_ADMIN_ID, systemAdminRoom.getCreatedAt()},
-                new Object[] {systemAdminRoom.getId(), targetUserId, systemAdminRoom.getCreatedAt()}
-            ));
+        given(chatRoomSystemAdminService.isSystemAdminRoom(systemAdminRoom.getId())).willReturn(true);
         given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
             .willReturn(List.of(systemAdminMember, targetMember));
         given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -25,10 +25,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageImpl;
@@ -55,6 +55,7 @@ import gg.agit.konect.domain.chat.service.ChatPresenceService;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.chat.service.ChatRoomSummaryService;
 import gg.agit.konect.domain.chat.service.ChatSearchService;
+import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
 import gg.agit.konect.domain.chat.service.ChatService;
 import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.club.model.ClubMember;
@@ -118,8 +119,35 @@ class ChatServiceTest extends ServiceTestSupport {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    @InjectMocks
+    private ChatMessagePageResolver chatMessagePageResolver;
+
     private ChatService chatService;
+
+    @BeforeEach
+    void setUp() {
+        chatMessagePageResolver = new ChatMessagePageResolver(
+            chatMessageRepository,
+            chatRoomMemberRepository,
+            clubMemberRepository
+        );
+        chatService = new ChatService(
+            chatRoomRepository,
+            chatRoomQueryRepository,
+            chatMessageRepository,
+            chatRoomMemberRepository,
+            notificationMuteSettingRepository,
+            clubMemberRepository,
+            chatInviteQueryRepository,
+            userRepository,
+            chatPresenceService,
+            chatRoomMembershipService,
+            chatRoomSummaryService,
+            chatSearchService,
+            chatMessagePageResolver,
+            notificationService,
+            eventPublisher
+        );
+    }
 
     @Test
     @DisplayName("createOrGetChatRoom은 자기 자신과의 direct room 생성을 거부한다")


### PR DESCRIPTION
### 🔍 개요

* messageId 기반 메시지 조회의 접근 검증과 페이지 계산 책임을 ChatService에서 분리합니다.
* Refs #592


---

### 🚀 주요 변경 내용

* ChatMessagePageResolver를 추가해 messageId 조회 권한 검증, visibleMessageFrom 검증, 페이지 계산을 담당하도록 정리했습니다.
* ChatService는 messageId가 있는 조회 요청에서 resolver에 위임하도록 단순화했습니다.
* 기존 ChatService 단위 테스트가 실제 resolver를 사용하도록 구성해 기존 조회 정책 검증을 유지했습니다.


---

### 💬 참고 사항

* #592의 1차 분리 작업이며, 이 PR만으로 이슈를 닫지 않습니다.
* 검증: `./gradlew checkstyleMain`
* 검증: `CI=true ./gradlew test --tests 'gg.agit.konect.unit.domain.chat.service.ChatServiceTest' --rerun-tasks`
* 검증: `CI=true ./gradlew test --tests 'gg.agit.konect.integration.domain.chat.ChatApiTest' --rerun-tasks`


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
