### PR TITLE
refactor: direct room 접근 복원 책임 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatDirectRoomAccessService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatDirectRoomAccessService.java
@@ -1,0 +1,57 @@
+package gg.agit.konect.domain.chat.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatDirectRoomAccessService {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public ChatRoomMember getAccessibleMember(ChatRoom chatRoom, User user) {
+        ChatRoomMember member = getMember(chatRoom, user);
+        restoreIfVisible(member, chatRoom);
+        return member;
+    }
+
+    public LocalDateTime prepareAccessAndGetVisibleMessageFrom(ChatRoom chatRoom, User user) {
+        ChatRoomMember member = getMember(chatRoom, user);
+        LocalDateTime visibleMessageFrom = member.getVisibleMessageFrom();
+        restoreIfVisible(member, chatRoom);
+        return visibleMessageFrom;
+    }
+
+    private ChatRoomMember getMember(ChatRoom chatRoom, User user) {
+        return chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoom.getId(), user.getId())
+            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
+    }
+
+    /**
+     * direct 채팅방에서 나간 사용자가 다시 볼 수 있는 상태인지 확인하고,
+     * 새 메시지가 이미 존재하면 나간 상태를 해제한다.
+     */
+    private void restoreIfVisible(ChatRoomMember member, ChatRoom chatRoom) {
+        if (!member.hasLeft()) {
+            return;
+        }
+
+        if (!member.hasVisibleMessages(chatRoom)) {
+            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
+        }
+
+        member.restoreDirectRoom();
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatDirectRoomAccessService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatDirectRoomAccessService.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class ChatDirectRoomAccessService {
 
     private final ChatRoomMemberRepository chatRoomMemberRepository;

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -335,12 +335,12 @@ public class ChatService {
         return ChatInvitableUsersResponse.forClubSort(pagedInvitableUsers, sections);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ChatMessagePageResponse getMessages(Integer userId, Integer roomId, Integer page, Integer limit) {
         return getMessages(userId, roomId, page, limit, null);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ChatMessagePageResponse getMessages(
         Integer userId, Integer roomId, Integer page, Integer limit, Integer messageId
     ) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -84,6 +84,7 @@ public class ChatService {
     private final ChatSearchService chatSearchService;
     private final ChatMessagePageResolver chatMessagePageResolver;
     private final ChatRoomSystemAdminService chatRoomSystemAdminService;
+    private final ChatDirectRoomAccessService chatDirectRoomAccessService;
     private final NotificationService notificationService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -410,7 +411,7 @@ public class ChatService {
             boolean isAdminAccessingSystemAdminRoom = user.isAdmin()
                 && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
             if (!isAdminAccessingSystemAdminRoom) {
-                getAccessibleDirectRoomMember(room, user);
+                chatDirectRoomAccessService.getAccessibleMember(room, user);
             }
         } else {
             getAccessibleRoomMember(room, userId);
@@ -627,8 +628,8 @@ public class ChatService {
         ChatRoom chatRoom = getDirectRoom(roomId);
         User user = userRepository.getById(userId);
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        LocalDateTime visibleMessageFrom = prepareDirectRoomAccess(getOrCreateDirectRoomMember(chatRoom, user),
-            chatRoom);
+        LocalDateTime visibleMessageFrom =
+            chatDirectRoomAccessService.prepareAccessAndGetVisibleMessageFrom(chatRoom, user);
 
         List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
 
@@ -670,7 +671,7 @@ public class ChatService {
         boolean senderHadLeft = false;
 
         if (!isAdminSendingToSystemAdminRoom) {
-            senderMember = getAccessibleDirectRoomMember(chatRoom, sender);
+            senderMember = chatDirectRoomAccessService.getAccessibleMember(chatRoom, sender);
             senderHadLeft = senderMember.hasLeft();
         }
 
@@ -994,7 +995,7 @@ public class ChatService {
 
         if (room.isDirectRoom()) {
             User user = userRepository.getById(userId);
-            return getAccessibleDirectRoomMember(room, user);
+            return chatDirectRoomAccessService.getAccessibleMember(room, user);
         }
 
         ChatRoomMember member = getRoomMember(room.getId(), userId);
@@ -1147,42 +1148,9 @@ public class ChatService {
         return unreadCountMap;
     }
 
-    private ChatRoomMember getOrCreateDirectRoomMember(ChatRoom chatRoom, User user) {
-        return chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoom.getId(), user.getId())
-            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
-    }
-
-    private ChatRoomMember getAccessibleDirectRoomMember(ChatRoom chatRoom, User user) {
-        ChatRoomMember member = getOrCreateDirectRoomMember(chatRoom, user);
-        restoreDirectRoomIfVisible(member, chatRoom);
-        return member;
-    }
-
-    private LocalDateTime prepareDirectRoomAccess(ChatRoomMember member, ChatRoom chatRoom) {
-        LocalDateTime visibleMessageFrom = member.getVisibleMessageFrom();
-        restoreDirectRoomIfVisible(member, chatRoom);
-        return visibleMessageFrom;
-    }
-
     private LocalDateTime resolveAdminSystemRoomVisibleMessageFrom(List<ChatRoomMember> members) {
         ChatRoomMember systemAdminMember = chatRoomSystemAdminService.findSystemAdminMember(members);
         return systemAdminMember != null ? systemAdminMember.getVisibleMessageFrom() : null;
-    }
-
-    /**
-     * direct 채팅방에서 나간 사용자가 다시 볼 수 있는 상태인지 확인하고,
-     * 새 메시지가 이미 존재하면 나간 상태를 해제한다.
-     */
-    private void restoreDirectRoomIfVisible(ChatRoomMember member, ChatRoom chatRoom) {
-        if (!member.hasLeft()) {
-            return;
-        }
-
-        if (!member.hasVisibleMessages(chatRoom)) {
-            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
-        }
-
-        member.restoreDirectRoom();
     }
 
     private boolean shouldDisplayAsOwnMessage(

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -667,12 +667,8 @@ public class ChatService {
         boolean isAdminSendingToSystemAdminRoom = sender.isAdmin()
             && chatRoomSystemAdminService.isSystemAdminRoom(chatRoom.getId());
 
-        ChatRoomMember senderMember = null;
-        boolean senderHadLeft = false;
-
         if (!isAdminSendingToSystemAdminRoom) {
-            senderMember = chatDirectRoomAccessService.getAccessibleMember(chatRoom, sender);
-            senderHadLeft = senderMember.hasLeft();
+            chatDirectRoomAccessService.getAccessibleMember(chatRoom, sender);
         }
 
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
@@ -681,10 +677,6 @@ public class ChatService {
         ChatMessage chatMessage = chatMessageRepository.save(
             ChatMessage.of(chatRoom, sender, request.content())
         );
-
-        if (senderHadLeft && senderMember != null) {
-            senderMember.restoreDirectRoom();
-        }
 
         syncLastMessage(chatRoom, chatMessage);
         members.stream()

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatDirectRoomAccessServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatDirectRoomAccessServiceTest.java
@@ -1,0 +1,125 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.service.ChatDirectRoomAccessService;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ChatDirectRoomAccessServiceTest extends ServiceTestSupport {
+
+    private static final LocalDateTime BASE_TIME = LocalDateTime.of(2026, 4, 27, 10, 0);
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @InjectMocks
+    private ChatDirectRoomAccessService chatDirectRoomAccessService;
+
+    @Test
+    @DisplayName("접근 가능한 direct room 멤버를 반환한다")
+    void getAccessibleMemberReturnsMember() {
+        User user = user(10);
+        ChatRoom room = room(1);
+        ChatRoomMember member = member(room, user);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(member));
+
+        ChatRoomMember result = chatDirectRoomAccessService.getAccessibleMember(room, user);
+
+        assertThat(result).isSameAs(member);
+    }
+
+    @Test
+    @DisplayName("나간 direct room에 새 메시지가 있으면 접근 시 나간 상태를 해제한다")
+    void getAccessibleMemberRestoresLeftMemberWhenVisibleMessageExists() {
+        User user = user(10);
+        ChatRoom room = room(1);
+        room.updateLastMessage("새 메시지", BASE_TIME.plusHours(2));
+        ChatRoomMember member = member(room, user);
+        member.leaveDirectRoom(BASE_TIME.plusHours(1));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(member));
+
+        ChatRoomMember result = chatDirectRoomAccessService.getAccessibleMember(room, user);
+
+        assertThat(result.hasLeft()).isFalse();
+    }
+
+    @Test
+    @DisplayName("나간 direct room에 새 메시지가 없으면 접근을 거부한다")
+    void getAccessibleMemberRejectsLeftMemberWithoutVisibleMessage() {
+        User user = user(10);
+        ChatRoom room = room(1);
+        ChatRoomMember member = member(room, user);
+        member.leaveDirectRoom(BASE_TIME.plusHours(1));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> chatDirectRoomAccessService.getAccessibleMember(room, user))
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception ->
+                assertThat(((CustomException)exception).getErrorCode()).isEqualTo(FORBIDDEN_CHAT_ROOM_ACCESS));
+    }
+
+    @Test
+    @DisplayName("접근 준비는 복원 전 visibleMessageFrom을 반환한다")
+    void prepareAccessAndGetVisibleMessageFromReturnsPreviousVisibilityBoundary() {
+        User user = user(10);
+        ChatRoom room = room(1);
+        room.updateLastMessage("새 메시지", BASE_TIME.plusHours(2));
+        ChatRoomMember member = member(room, user);
+        LocalDateTime visibleMessageFrom = BASE_TIME.plusHours(1);
+        ReflectionTestUtils.setField(member, "leftAt", visibleMessageFrom);
+        ReflectionTestUtils.setField(member, "visibleMessageFrom", visibleMessageFrom);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
+            .willReturn(Optional.of(member));
+
+        LocalDateTime result = chatDirectRoomAccessService.prepareAccessAndGetVisibleMessageFrom(room, user);
+
+        assertThat(result).isEqualTo(visibleMessageFrom);
+        assertThat(member.hasLeft()).isFalse();
+    }
+
+    private User user(Integer id) {
+        return UserFixture.createUserWithId(
+            UniversityFixture.createWithId(1),
+            id,
+            "사용자" + id,
+            "2024" + String.format("%04d", id),
+            UserRole.USER
+        );
+    }
+
+    private ChatRoom room(Integer id) {
+        ChatRoom room = ChatRoom.directOf();
+        ReflectionTestUtils.setField(room, "id", id);
+        ReflectionTestUtils.setField(room, "createdAt", BASE_TIME);
+        return room;
+    }
+
+    private ChatRoomMember member(ChatRoom room, User user) {
+        ChatRoomMember member = ChatRoomMember.of(room, user, BASE_TIME);
+        ReflectionTestUtils.setField(member, "createdAt", BASE_TIME);
+        return member;
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatDirectRoomAccessServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatDirectRoomAccessServiceTest.java
@@ -60,9 +60,9 @@ class ChatDirectRoomAccessServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId()))
             .willReturn(Optional.of(member));
 
-        ChatRoomMember result = chatDirectRoomAccessService.getAccessibleMember(room, user);
+        chatDirectRoomAccessService.getAccessibleMember(room, user);
 
-        assertThat(result.hasLeft()).isFalse();
+        assertThat(member.hasLeft()).isFalse();
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -51,11 +51,12 @@ import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomQueryRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.chat.service.ChatDirectRoomAccessService;
+import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
 import gg.agit.konect.domain.chat.service.ChatPresenceService;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.chat.service.ChatRoomSummaryService;
 import gg.agit.konect.domain.chat.service.ChatSearchService;
-import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
 import gg.agit.konect.domain.chat.service.ChatRoomSystemAdminService;
 import gg.agit.konect.domain.chat.service.ChatService;
 import gg.agit.konect.domain.club.model.Club;
@@ -125,10 +126,13 @@ class ChatServiceTest extends ServiceTestSupport {
 
     private ChatMessagePageResolver chatMessagePageResolver;
 
+    private ChatDirectRoomAccessService chatDirectRoomAccessService;
+
     private ChatService chatService;
 
     @BeforeEach
     void setUp() {
+        chatDirectRoomAccessService = new ChatDirectRoomAccessService(chatRoomMemberRepository);
         chatMessagePageResolver = new ChatMessagePageResolver(
             chatMessageRepository,
             chatRoomMemberRepository,
@@ -150,6 +154,7 @@ class ChatServiceTest extends ServiceTestSupport {
             chatSearchService,
             chatMessagePageResolver,
             chatRoomSystemAdminService,
+            chatDirectRoomAccessService,
             notificationService,
             eventPublisher
         );

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -124,16 +124,13 @@ class ChatServiceTest extends ServiceTestSupport {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    private ChatMessagePageResolver chatMessagePageResolver;
-
-    private ChatDirectRoomAccessService chatDirectRoomAccessService;
-
     private ChatService chatService;
 
     @BeforeEach
     void setUp() {
-        chatDirectRoomAccessService = new ChatDirectRoomAccessService(chatRoomMemberRepository);
-        chatMessagePageResolver = new ChatMessagePageResolver(
+        ChatDirectRoomAccessService chatDirectRoomAccessService =
+            new ChatDirectRoomAccessService(chatRoomMemberRepository);
+        ChatMessagePageResolver chatMessagePageResolver = new ChatMessagePageResolver(
             chatMessageRepository,
             chatRoomMemberRepository,
             clubMemberRepository,


### PR DESCRIPTION
### 🔍 개요

* `ChatService`에 남아 있던 direct room 멤버 접근 검증과 나간 방 복원 판단을 `ChatDirectRoomAccessService`로 분리했습니다.
* Refs #594


---

### 🚀 주요 변경 내용

* direct room 멤버 조회, 접근 가능 여부 확인, `visibleMessageFrom` 기준 반환을 전용 서비스로 이동
* `ChatService`의 메시지 조회/전송/뮤트 접근 검증 경로가 새 서비스를 사용하도록 정리
* 나간 direct room 복원/접근 거부 조건을 단위 테스트로 보강


---

### 💬 참고 사항

* API 응답 스펙 변경은 없습니다.
* 검증:
  * `./gradlew compileJava compileTestJava`
  * `CI=true ./gradlew test --tests 'gg.agit.konect.unit.domain.chat.service.ChatDirectRoomAccessServiceTest' --tests 'gg.agit.konect.unit.domain.chat.service.ChatServiceTest' --rerun-tasks`
  * `./gradlew checkstyleMain --rerun-tasks`
  * `CI=true ./gradlew test --tests 'gg.agit.konect.integration.domain.chat.ChatApiTest' --rerun-tasks`
* `checkstyleTest`는 기존 `ClubMemberManagementServiceTest`, `NotificationInboxServiceTest`, `ChatApiTest`의 120자 초과 위반으로 실패하며, 이번 변경 파일에는 별도 위반이 없습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)