### PR TITLE
refactor: 초대 후보 조회 책임 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatInviteService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatInviteService.java
@@ -1,0 +1,137 @@
+package gg.agit.konect.domain.chat.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.chat.dto.ChatInvitableUsersResponse;
+import gg.agit.konect.domain.chat.enums.ChatInviteSortBy;
+import gg.agit.konect.domain.chat.repository.ChatInviteQueryRepository;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatInviteService {
+
+    private static final String ETC_SECTION_NAME = "기타";
+
+    private final ChatInviteQueryRepository chatInviteQueryRepository;
+    private final UserRepository userRepository;
+
+    public ChatInvitableUsersResponse getInvitableUsers(
+        Integer userId,
+        String query,
+        ChatInviteSortBy sortBy,
+        Integer page,
+        Integer limit
+    ) {
+        userRepository.getById(userId);
+        PageRequest pageRequest = PageRequest.of(page - 1, limit);
+
+        if (sortBy == ChatInviteSortBy.CLUB) {
+            return getInvitableUsersGroupedByClub(userId, query, pageRequest);
+        }
+
+        Page<User> filteredUserEntitiesPage = chatInviteQueryRepository.findInvitableUsers(userId, query, pageRequest);
+
+        // 응답 DTO는 채팅 초대 화면에서 바로 쓰는 최소 필드만 유지한다.
+        List<ChatInvitableUsersResponse.InvitableUser> filteredUsers = filteredUserEntitiesPage.getContent().stream()
+            .map(ChatInvitableUsersResponse.InvitableUser::from)
+            .toList();
+
+        // 응답 메타(total/current page 정보)는 유지하면서 내용만 DTO로 치환한다.
+        Page<ChatInvitableUsersResponse.InvitableUser> filteredUsersPage = new PageImpl<>(
+            filteredUsers,
+            pageRequest,
+            filteredUserEntitiesPage.getTotalElements()
+        );
+
+        return ChatInvitableUsersResponse.forNameSort(filteredUsersPage);
+    }
+
+    private ChatInvitableUsersResponse getInvitableUsersGroupedByClub(
+        Integer userId,
+        String query,
+        PageRequest pageRequest
+    ) {
+        // CLUB 정렬은 DB가 현재 페이지에 들어갈 userId까지 잘라 오고,
+        // 서비스는 그 결과를 섹션 응답으로만 복원한다.
+        Page<Integer> pagedUserIds = chatInviteQueryRepository.findInvitableUserIdsGroupedByClub(
+            userId,
+            query,
+            pageRequest
+        );
+
+        if (pagedUserIds.isEmpty()) {
+            return ChatInvitableUsersResponse.forClubSort(
+                new PageImpl<>(List.of(), pageRequest, pagedUserIds.getTotalElements()),
+                List.of()
+            );
+        }
+
+        // IN 조회는 정렬 순서를 보장하지 않으므로, DB가 정한 userId 페이지 순서대로 다시 조립한다.
+        Map<Integer, User> pagedUserMap = userRepository.findAllByIdIn(pagedUserIds.getContent()).stream()
+            .collect(Collectors.toMap(User::getId, user -> user));
+
+        List<ChatInvitableUsersResponse.InvitableUser> pagedUsers = pagedUserIds.getContent().stream()
+            .map(pagedUserMap::get)
+            .filter(Objects::nonNull)
+            .map(ChatInvitableUsersResponse.InvitableUser::from)
+            .toList();
+
+        Page<ChatInvitableUsersResponse.InvitableUser> pagedInvitableUsers = new PageImpl<>(
+            pagedUsers,
+            pageRequest,
+            pagedUserIds.getTotalElements()
+        );
+
+        record SectionKey(Integer clubId, String clubName) {
+        }
+
+        Map<Integer, Integer> representativeClubByUserId = new HashMap<>();
+        Map<Integer, String> representativeClubNames = new HashMap<>();
+        // 현재 페이지 사용자에 대해서만 대표 동아리를 다시 구해도,
+        // userId 자체는 이미 대표 동아리 기준으로 정렬돼 있으므로 페이지 경계는 유지된다.
+        chatInviteQueryRepository.findSharedClubMemberships(userId, pagedUserIds.getContent()).stream()
+            .forEach(clubMember -> {
+                representativeClubNames.putIfAbsent(clubMember.getClub().getId(), clubMember.getClub().getName());
+                representativeClubByUserId.putIfAbsent(clubMember.getUser().getId(), clubMember.getClub().getId());
+            });
+
+        // 대표 동아리가 없는 사용자는 기타 섹션으로 떨어지고,
+        // 같은 대표 동아리를 가진 사용자끼리만 현재 페이지 sections[]로 묶는다.
+        Map<SectionKey, List<ChatInvitableUsersResponse.InvitableUser>> sectionMap = new LinkedHashMap<>();
+        pagedUsers.forEach(user -> {
+            Integer representativeClubId = representativeClubByUserId.get(user.userId());
+            String clubName = representativeClubId == null
+                ? ETC_SECTION_NAME
+                : representativeClubNames.get(representativeClubId);
+            SectionKey key = new SectionKey(representativeClubId, clubName);
+            sectionMap.computeIfAbsent(key, ignored -> new ArrayList<>())
+                .add(user);
+        });
+
+        List<ChatInvitableUsersResponse.InvitableSection> sections = sectionMap.entrySet().stream()
+            .map(entry -> new ChatInvitableUsersResponse.InvitableSection(
+                entry.getKey().clubId(),
+                entry.getKey().clubName(),
+                entry.getValue()
+            ))
+            .toList();
+
+        return ChatInvitableUsersResponse.forClubSort(pagedInvitableUsers, sections);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -16,7 +15,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,7 +39,6 @@ import gg.agit.konect.domain.chat.event.AdminChatReceivedEvent;
 import gg.agit.konect.domain.chat.model.ChatMessage;
 import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
-import gg.agit.konect.domain.chat.repository.ChatInviteQueryRepository;
 import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomQueryRepository;
@@ -67,7 +64,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class ChatService {
 
-    private static final String ETC_SECTION_NAME = "기타";
     private static final String DEFAULT_GROUP_ROOM_NAME = "그룹 채팅";
 
     private final ChatRoomRepository chatRoomRepository;
@@ -76,12 +72,12 @@ public class ChatService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final NotificationMuteSettingRepository notificationMuteSettingRepository;
     private final ClubMemberRepository clubMemberRepository;
-    private final ChatInviteQueryRepository chatInviteQueryRepository;
     private final UserRepository userRepository;
     private final ChatPresenceService chatPresenceService;
     private final ChatRoomMembershipService chatRoomMembershipService;
     private final ChatRoomSummaryService chatRoomSummaryService;
     private final ChatSearchService chatSearchService;
+    private final ChatInviteService chatInviteService;
     private final ChatMessagePageResolver chatMessagePageResolver;
     private final ChatRoomSystemAdminService chatRoomSystemAdminService;
     private final ChatDirectRoomAccessService chatDirectRoomAccessService;
@@ -238,101 +234,7 @@ public class ChatService {
         Integer page,
         Integer limit
     ) {
-        userRepository.getById(userId);
-        PageRequest pageRequest = PageRequest.of(page - 1, limit);
-
-        if (sortBy == ChatInviteSortBy.CLUB) {
-            return getInvitableUsersGroupedByClub(userId, query, pageRequest);
-        }
-
-        Page<User> filteredUserEntitiesPage = chatInviteQueryRepository.findInvitableUsers(userId, query, pageRequest);
-
-        // 응답 DTO는 채팅 초대 화면에서 바로 쓰는 최소 필드만 유지한다.
-        List<ChatInvitableUsersResponse.InvitableUser> filteredUsers = filteredUserEntitiesPage.getContent().stream()
-            .map(ChatInvitableUsersResponse.InvitableUser::from)
-            .toList();
-
-        // 응답 메타(total/current page 정보)는 유지하면서 내용만 DTO로 치환한다.
-        Page<ChatInvitableUsersResponse.InvitableUser> filteredUsersPage = new PageImpl<>(
-            filteredUsers,
-            pageRequest,
-            filteredUserEntitiesPage.getTotalElements()
-        );
-
-        return ChatInvitableUsersResponse.forNameSort(filteredUsersPage);
-    }
-
-    private ChatInvitableUsersResponse getInvitableUsersGroupedByClub(
-        Integer userId,
-        String query,
-        PageRequest pageRequest
-    ) {
-        // CLUB 정렬은 DB가 현재 페이지에 들어갈 userId까지 잘라 오고,
-        // 서비스는 그 결과를 섹션 응답으로만 복원한다.
-        Page<Integer> pagedUserIds = chatInviteQueryRepository.findInvitableUserIdsGroupedByClub(
-            userId,
-            query,
-            pageRequest
-        );
-
-        if (pagedUserIds.isEmpty()) {
-            return ChatInvitableUsersResponse.forClubSort(
-                new PageImpl<>(List.of(), pageRequest, pagedUserIds.getTotalElements()),
-                List.of()
-            );
-        }
-
-        // IN 조회는 정렬 순서를 보장하지 않으므로, DB가 정한 userId 페이지 순서대로 다시 조립한다.
-        Map<Integer, User> pagedUserMap = userRepository.findAllByIdIn(pagedUserIds.getContent()).stream()
-            .collect(Collectors.toMap(User::getId, user -> user));
-
-        List<ChatInvitableUsersResponse.InvitableUser> pagedUsers = pagedUserIds.getContent().stream()
-            .map(pagedUserMap::get)
-            .filter(Objects::nonNull)
-            .map(ChatInvitableUsersResponse.InvitableUser::from)
-            .toList();
-
-        Page<ChatInvitableUsersResponse.InvitableUser> pagedInvitableUsers = new PageImpl<>(
-            pagedUsers,
-            pageRequest,
-            pagedUserIds.getTotalElements()
-        );
-
-        record SectionKey(Integer clubId, String clubName) {
-        }
-
-        Map<Integer, Integer> representativeClubByUserId = new HashMap<>();
-        Map<Integer, String> representativeClubNames = new HashMap<>();
-        // 현재 페이지 사용자에 대해서만 대표 동아리를 다시 구해도,
-        // userId 자체는 이미 대표 동아리 기준으로 정렬돼 있으므로 페이지 경계는 유지된다.
-        chatInviteQueryRepository.findSharedClubMemberships(userId, pagedUserIds.getContent()).stream()
-            .forEach(clubMember -> {
-                representativeClubNames.putIfAbsent(clubMember.getClub().getId(), clubMember.getClub().getName());
-                representativeClubByUserId.putIfAbsent(clubMember.getUser().getId(), clubMember.getClub().getId());
-            });
-
-        // 대표 동아리가 없는 사용자는 기타 섹션으로 떨어지고,
-        // 같은 대표 동아리를 가진 사용자끼리만 현재 페이지 sections[]로 묶는다.
-        Map<SectionKey, List<ChatInvitableUsersResponse.InvitableUser>> sectionMap = new LinkedHashMap<>();
-        pagedUsers.forEach(user -> {
-            Integer representativeClubId = representativeClubByUserId.get(user.userId());
-            String clubName = representativeClubId == null
-                ? ETC_SECTION_NAME
-                : representativeClubNames.get(representativeClubId);
-            SectionKey key = new SectionKey(representativeClubId, clubName);
-            sectionMap.computeIfAbsent(key, ignored -> new ArrayList<>())
-                .add(user);
-        });
-
-        List<ChatInvitableUsersResponse.InvitableSection> sections = sectionMap.entrySet().stream()
-            .map(entry -> new ChatInvitableUsersResponse.InvitableSection(
-                entry.getKey().clubId(),
-                entry.getKey().clubName(),
-                entry.getValue()
-            ))
-            .toList();
-
-        return ChatInvitableUsersResponse.forClubSort(pagedInvitableUsers, sections);
+        return chatInviteService.getInvitableUsers(userId, query, sortBy, page, limit);
     }
 
     @Transactional

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatInviteServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatInviteServiceTest.java
@@ -59,6 +59,10 @@ class ChatInviteServiceTest extends ServiceTestSupport {
         );
 
         // then
+        assertThat(response.totalCount()).isEqualTo(1L);
+        assertThat(response.currentCount()).isEqualTo(1);
+        assertThat(response.totalPage()).isEqualTo(1);
+        assertThat(response.currentPage()).isEqualTo(1);
         assertThat(response.sortBy()).isEqualTo(ChatInviteSortBy.NAME);
         assertThat(response.grouped()).isFalse();
         assertThat(response.users())
@@ -74,19 +78,30 @@ class ChatInviteServiceTest extends ServiceTestSupport {
         Integer userId = 10;
         User requester = createUser(userId, "요청자");
         User bcsdUser = createUser(20, "BCSD 후보");
-        User etcUser = createUser(30, "기타 후보");
+        User dualSharedUser = createUser(30, "복수 공유 후보");
+        User etcUser = createUser(40, "기타 후보");
         Club bcsd = ClubFixture.createWithId(UniversityFixture.create(), 1, "BCSD");
+        Club seminar = ClubFixture.createWithId(UniversityFixture.create(), 2, "Seminar");
         ClubMember bcsdMembership = ClubMemberFixture.createMember(bcsd, bcsdUser);
+        ClubMember dualBcsdMembership = ClubMemberFixture.createMember(bcsd, dualSharedUser);
+        ClubMember dualSeminarMembership = ClubMemberFixture.createMember(seminar, dualSharedUser);
         PageRequest pageRequest = PageRequest.of(0, 20);
         ChatInviteService service = new ChatInviteService(chatInviteQueryRepository, userRepository);
 
         given(userRepository.getById(userId)).willReturn(requester);
         given(chatInviteQueryRepository.findInvitableUserIdsGroupedByClub(userId, null, pageRequest))
-            .willReturn(new PageImpl<>(List.of(bcsdUser.getId(), etcUser.getId()), pageRequest, 2));
-        given(userRepository.findAllByIdIn(List.of(bcsdUser.getId(), etcUser.getId())))
-            .willReturn(List.of(etcUser, bcsdUser));
-        given(chatInviteQueryRepository.findSharedClubMemberships(userId, List.of(bcsdUser.getId(), etcUser.getId())))
-            .willReturn(List.of(bcsdMembership));
+            .willReturn(new PageImpl<>(
+                List.of(bcsdUser.getId(), dualSharedUser.getId(), etcUser.getId()),
+                pageRequest,
+                3
+            ));
+        given(userRepository.findAllByIdIn(List.of(bcsdUser.getId(), dualSharedUser.getId(), etcUser.getId())))
+            .willReturn(List.of(etcUser, dualSharedUser, bcsdUser));
+        given(chatInviteQueryRepository.findSharedClubMemberships(
+            userId,
+            List.of(bcsdUser.getId(), dualSharedUser.getId(), etcUser.getId())
+        ))
+            .willReturn(List.of(bcsdMembership, dualBcsdMembership, dualSeminarMembership));
 
         // when
         ChatInvitableUsersResponse response = service.getInvitableUsers(
@@ -98,6 +113,10 @@ class ChatInviteServiceTest extends ServiceTestSupport {
         );
 
         // then
+        assertThat(response.totalCount()).isEqualTo(3L);
+        assertThat(response.currentCount()).isEqualTo(3);
+        assertThat(response.totalPage()).isEqualTo(1);
+        assertThat(response.currentPage()).isEqualTo(1);
         assertThat(response.sortBy()).isEqualTo(ChatInviteSortBy.CLUB);
         assertThat(response.grouped()).isTrue();
         assertThat(response.users()).isEmpty();
@@ -106,11 +125,11 @@ class ChatInviteServiceTest extends ServiceTestSupport {
             .containsExactly("BCSD", "기타");
         assertThat(response.sections().get(0).users())
             .extracting(ChatInvitableUsersResponse.InvitableUser::userId)
-            .containsExactly(bcsdUser.getId());
+            .containsExactly(bcsdUser.getId(), dualSharedUser.getId());
         assertThat(response.sections().get(1).users())
             .extracting(ChatInvitableUsersResponse.InvitableUser::userId)
             .containsExactly(etcUser.getId());
-        verify(userRepository).findAllByIdIn(List.of(bcsdUser.getId(), etcUser.getId()));
+        verify(userRepository).findAllByIdIn(List.of(bcsdUser.getId(), dualSharedUser.getId(), etcUser.getId()));
     }
 
     private User createUser(Integer id, String name) {

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatInviteServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatInviteServiceTest.java
@@ -1,0 +1,125 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import gg.agit.konect.domain.chat.dto.ChatInvitableUsersResponse;
+import gg.agit.konect.domain.chat.enums.ChatInviteSortBy;
+import gg.agit.konect.domain.chat.repository.ChatInviteQueryRepository;
+import gg.agit.konect.domain.chat.service.ChatInviteService;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.ClubMember;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
+import gg.agit.konect.support.fixture.ClubMemberFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ChatInviteServiceTest extends ServiceTestSupport {
+
+    @Mock
+    private ChatInviteQueryRepository chatInviteQueryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("이름 정렬은 초대 후보를 단일 사용자 목록으로 변환한다")
+    void getInvitableUsersReturnsNameSortedUsers() {
+        // given
+        Integer userId = 10;
+        User requester = createUser(userId, "요청자");
+        User candidate = createUser(20, "후보");
+        PageRequest pageRequest = PageRequest.of(0, 20);
+        ChatInviteService service = new ChatInviteService(chatInviteQueryRepository, userRepository);
+
+        given(userRepository.getById(userId)).willReturn(requester);
+        given(chatInviteQueryRepository.findInvitableUsers(userId, "후보", pageRequest))
+            .willReturn(new PageImpl<>(List.of(candidate), pageRequest, 1));
+
+        // when
+        ChatInvitableUsersResponse response = service.getInvitableUsers(
+            userId,
+            "후보",
+            ChatInviteSortBy.NAME,
+            1,
+            20
+        );
+
+        // then
+        assertThat(response.sortBy()).isEqualTo(ChatInviteSortBy.NAME);
+        assertThat(response.grouped()).isFalse();
+        assertThat(response.users())
+            .extracting(ChatInvitableUsersResponse.InvitableUser::userId)
+            .containsExactly(candidate.getId());
+        assertThat(response.sections()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("동아리 정렬은 현재 페이지 후보만 대표 동아리 섹션으로 묶는다")
+    void getInvitableUsersReturnsClubSections() {
+        // given
+        Integer userId = 10;
+        User requester = createUser(userId, "요청자");
+        User bcsdUser = createUser(20, "BCSD 후보");
+        User etcUser = createUser(30, "기타 후보");
+        Club bcsd = ClubFixture.createWithId(UniversityFixture.create(), 1, "BCSD");
+        ClubMember bcsdMembership = ClubMemberFixture.createMember(bcsd, bcsdUser);
+        PageRequest pageRequest = PageRequest.of(0, 20);
+        ChatInviteService service = new ChatInviteService(chatInviteQueryRepository, userRepository);
+
+        given(userRepository.getById(userId)).willReturn(requester);
+        given(chatInviteQueryRepository.findInvitableUserIdsGroupedByClub(userId, null, pageRequest))
+            .willReturn(new PageImpl<>(List.of(bcsdUser.getId(), etcUser.getId()), pageRequest, 2));
+        given(userRepository.findAllByIdIn(List.of(bcsdUser.getId(), etcUser.getId())))
+            .willReturn(List.of(etcUser, bcsdUser));
+        given(chatInviteQueryRepository.findSharedClubMemberships(userId, List.of(bcsdUser.getId(), etcUser.getId())))
+            .willReturn(List.of(bcsdMembership));
+
+        // when
+        ChatInvitableUsersResponse response = service.getInvitableUsers(
+            userId,
+            null,
+            ChatInviteSortBy.CLUB,
+            1,
+            20
+        );
+
+        // then
+        assertThat(response.sortBy()).isEqualTo(ChatInviteSortBy.CLUB);
+        assertThat(response.grouped()).isTrue();
+        assertThat(response.users()).isEmpty();
+        assertThat(response.sections())
+            .extracting(ChatInvitableUsersResponse.InvitableSection::clubName)
+            .containsExactly("BCSD", "기타");
+        assertThat(response.sections().get(0).users())
+            .extracting(ChatInvitableUsersResponse.InvitableUser::userId)
+            .containsExactly(bcsdUser.getId());
+        assertThat(response.sections().get(1).users())
+            .extracting(ChatInvitableUsersResponse.InvitableUser::userId)
+            .containsExactly(etcUser.getId());
+        verify(userRepository).findAllByIdIn(List.of(bcsdUser.getId(), etcUser.getId()));
+    }
+
+    private User createUser(Integer id, String name) {
+        return UserFixture.createUserWithId(
+            UniversityFixture.create(),
+            id,
+            name,
+            "2024" + String.format("%04d", id),
+            UserRole.USER
+        );
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -46,12 +46,12 @@ import gg.agit.konect.domain.chat.enums.ChatType;
 import gg.agit.konect.domain.chat.model.ChatMessage;
 import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
-import gg.agit.konect.domain.chat.repository.ChatInviteQueryRepository;
 import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomQueryRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
 import gg.agit.konect.domain.chat.service.ChatDirectRoomAccessService;
+import gg.agit.konect.domain.chat.service.ChatInviteService;
 import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
 import gg.agit.konect.domain.chat.service.ChatPresenceService;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
@@ -98,9 +98,6 @@ class ChatServiceTest extends ServiceTestSupport {
     private ClubMemberRepository clubMemberRepository;
 
     @Mock
-    private ChatInviteQueryRepository chatInviteQueryRepository;
-
-    @Mock
     private UserRepository userRepository;
 
     @Mock
@@ -114,6 +111,9 @@ class ChatServiceTest extends ServiceTestSupport {
 
     @Mock
     private ChatSearchService chatSearchService;
+
+    @Mock
+    private ChatInviteService chatInviteService;
 
     @Mock
     private ChatRoomSystemAdminService chatRoomSystemAdminService;
@@ -143,12 +143,12 @@ class ChatServiceTest extends ServiceTestSupport {
             chatRoomMemberRepository,
             notificationMuteSettingRepository,
             clubMemberRepository,
-            chatInviteQueryRepository,
             userRepository,
             chatPresenceService,
             chatRoomMembershipService,
             chatRoomSummaryService,
             chatSearchService,
+            chatInviteService,
             chatMessagePageResolver,
             chatRoomSystemAdminService,
             chatDirectRoomAccessService,


### PR DESCRIPTION
### 🔍 개요

* Closes #596
* ChatService에 남아 있던 초대 후보 조회와 CLUB 정렬 섹션 조립 책임을 ChatInviteService로 분리했습니다.


---

### 🚀 주요 변경 내용

* ChatInviteService를 추가해 이름 정렬과 동아리 정렬 초대 후보 응답 생성을 담당하도록 분리
* ChatService는 getInvitableUsers 요청을 새 서비스에 위임하도록 축소
* ChatInviteServiceTest를 추가해 이름 정렬 목록 응답과 동아리 섹션 조립을 검증


---

### 💬 참고 사항

* `checkstyleTest`는 기존 테스트 파일의 120자 초과 위반으로 실패합니다. 이번 변경 파일에서는 신규 위반이 없습니다.
* `CI=true`를 붙인 특정 통합 테스트 실행은 기존 테스트 소스 일부가 메인 클래스를 찾지 못하는 컴파일 실패가 재현되어, 동일 대상은 `CI=true` 없이 별도로 통과 확인했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)