### PR TITLE
refactor: 메시지 전송 책임 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatMessageSendService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatMessageSendService.java
@@ -1,0 +1,337 @@
+package gg.agit.konect.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.chat.dto.ChatMessageDetailResponse;
+import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
+import gg.agit.konect.domain.chat.event.AdminChatReceivedEvent;
+import gg.agit.konect.domain.chat.model.ChatMessage;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatMessageRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.club.model.ClubMember;
+import gg.agit.konect.domain.club.repository.ClubMemberRepository;
+import gg.agit.konect.domain.notification.service.NotificationService;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageSendService {
+
+    private static final String DEFAULT_GROUP_ROOM_NAME = "그룹 채팅";
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomSystemAdminService chatRoomSystemAdminService;
+    private final ChatDirectRoomAccessService chatDirectRoomAccessService;
+    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ChatMessageDetailResponse sendMessage(Integer userId, Integer roomId, ChatMessageSendRequest request) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+
+        if (room.isDirectRoom()) {
+            return sendDirectMessage(userId, room, request);
+        }
+
+        if (room.isClubGroupRoom()) {
+            return sendClubMessageByRoomId(room, userId, request.content());
+        }
+
+        return sendGroupMessageByRoomId(room, userId, request.content());
+    }
+
+    private ChatMessageDetailResponse sendDirectMessage(
+        Integer userId,
+        ChatRoom chatRoom,
+        ChatMessageSendRequest request
+    ) {
+        Integer roomId = chatRoom.getId();
+        User sender = userRepository.getById(userId);
+
+        // 어드민이 SYSTEM_ADMIN 방에 메시지를 보내는 경우
+        boolean isAdminSendingToSystemAdminRoom = sender.isAdmin()
+            && chatRoomSystemAdminService.isSystemAdminRoom(chatRoom.getId());
+
+        if (!isAdminSendingToSystemAdminRoom) {
+            chatDirectRoomAccessService.getAccessibleMember(chatRoom, sender);
+        }
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        User receiver = resolveDirectMessageReceiver(members, sender);
+
+        ChatMessage chatMessage = chatMessageRepository.save(
+            ChatMessage.of(chatRoom, sender, request.content())
+        );
+
+        syncLastMessage(chatRoom, chatMessage);
+        members.stream()
+            .filter(member -> !member.getUserId().equals(userId))
+            .filter(ChatRoomMember::hasLeft)
+            .forEach(member -> member.restoreDirectRoomFromIncomingMessage(chatMessage.getCreatedAt()));
+
+        // 어드민이 보낸 경우는 lastReadAt 업데이트하지 않음 (멤버가 아니므로)
+        if (!isAdminSendingToSystemAdminRoom) {
+            updateMemberLastReadAt(roomId, userId, chatMessage.getCreatedAt());
+        }
+
+        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
+
+        notificationService.sendChatNotification(receiver.getId(), roomId, sender.getName(), request.content());
+
+        boolean isSystemAdminRoom = members.stream()
+            .map(ChatRoomMember::getUserId)
+            .anyMatch(memberUserId -> memberUserId.equals(SYSTEM_ADMIN_ID));
+        publishAdminChatEventIfNeeded(isSystemAdminRoom, sender, request.content());
+
+        return new ChatMessageDetailResponse(
+            chatMessage.getId(),
+            chatMessage.getSender().getId(),
+            null,
+            chatMessage.getContent(),
+            chatMessage.getCreatedAt(),
+            true,
+            countUnreadSince(chatMessage.getCreatedAt(), sortedReadBaselines),
+            true
+        );
+    }
+
+    private ChatMessageDetailResponse sendClubMessageByRoomId(ChatRoom room, Integer userId, String content) {
+        Integer roomId = room.getId();
+        ClubMember member = clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), userId);
+        User sender = member.getUser();
+
+        ensureRoomMember(room, sender, member.getCreatedAt());
+
+        ChatMessage message = chatMessageRepository.save(ChatMessage.of(room, sender, content));
+        syncLastMessage(room, message);
+        updateClubMessageLastReadAt(roomId, userId, message.getCreatedAt());
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        List<Integer> recipientUserIds = members.stream().map(ChatRoomMember::getUserId).toList();
+        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
+
+        notificationService.sendGroupChatNotification(
+            roomId,
+            sender.getId(),
+            room.getClub().getName(),
+            sender.getName(),
+            message.getContent(),
+            recipientUserIds
+        );
+
+        return new ChatMessageDetailResponse(
+            message.getId(),
+            sender.getId(),
+            sender.getName(),
+            message.getContent(),
+            message.getCreatedAt(),
+            null,
+            countUnreadSince(message.getCreatedAt(), sortedReadBaselines),
+            true
+        );
+    }
+
+    private ChatMessageDetailResponse sendGroupMessageByRoomId(ChatRoom room, Integer userId, String content) {
+        Integer roomId = room.getId();
+        User sender = userRepository.getById(userId);
+
+        ChatRoomMember senderMember = getRoomMember(roomId, userId);
+        if (senderMember.hasLeft()) {
+            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
+        }
+
+        ChatMessage message = chatMessageRepository.save(ChatMessage.of(room, sender, content));
+        syncLastMessage(room, message);
+        updateLastReadAt(roomId, userId, message.getCreatedAt());
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
+        List<Integer> recipientUserIds = members.stream()
+            .map(ChatRoomMember::getUserId)
+            .filter(id -> !id.equals(userId))
+            .toList();
+        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
+
+        notificationService.sendGroupChatNotification(
+            roomId,
+            sender.getId(),
+            DEFAULT_GROUP_ROOM_NAME,
+            sender.getName(),
+            message.getContent(),
+            recipientUserIds
+        );
+
+        return new ChatMessageDetailResponse(
+            message.getId(),
+            sender.getId(),
+            sender.getName(),
+            message.getContent(),
+            message.getCreatedAt(),
+            null,
+            countUnreadSince(message.getCreatedAt(), sortedReadBaselines),
+            true
+        );
+    }
+
+    private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
+        return chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)
+            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
+    }
+
+    private void ensureRoomMember(ChatRoom room, User user, LocalDateTime joinedAt) {
+        chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+            .ifPresentOrElse(member -> {
+                LocalDateTime lastReadAt = member.getLastReadAt();
+                if (lastReadAt == null || lastReadAt.isBefore(joinedAt)) {
+                    member.updateLastReadAt(joinedAt);
+                }
+            }, () -> chatRoomMemberRepository.save(ChatRoomMember.of(room, user, joinedAt)));
+    }
+
+    private void updateMemberLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
+        int updated = chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
+        if (updated == 0) {
+            ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+            User user = userRepository.getById(userId);
+            ensureRoomMember(room, user, lastReadAt);
+        }
+    }
+
+    private void updateLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
+        chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
+    }
+
+    private void updateClubMessageLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
+        int updated = chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
+        if (updated == 0) {
+            ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+            User user = userRepository.getById(userId);
+            ensureRoomMember(room, user, lastReadAt);
+        }
+    }
+
+    private List<LocalDateTime> toSortedReadBaselines(List<ChatRoomMember> members) {
+        return members.stream()
+            .map(ChatRoomMember::getLastReadAt)
+            .sorted()
+            .toList();
+    }
+
+    private int countUnreadSince(LocalDateTime messageCreatedAt, List<LocalDateTime> sortedReadBaselines) {
+        int left = 0;
+        int right = sortedReadBaselines.size();
+
+        while (left < right) {
+            int mid = (left + right) >>> 1;
+            LocalDateTime baseline = sortedReadBaselines.get(mid);
+
+            if (baseline.isBefore(messageCreatedAt)) {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+
+        return left;
+    }
+
+    private void syncLastMessage(ChatRoom room, ChatMessage message) {
+        // 채팅방 목록은 chat_room.last_message_*를 직접 조회하므로
+        // 동시 전송에서도 가장 최신 메시지만 메타데이터를 덮어쓰도록 DB 조건을 같이 건다.
+        int updated = chatRoomRepository.updateLastMessageIfLatest(
+            room.getId(),
+            message.getId(),
+            message.getContent(),
+            message.getCreatedAt()
+        );
+        if (updated > 0) {
+            room.updateLastMessage(message.getContent(), message.getCreatedAt());
+        }
+    }
+
+    private void publishAdminChatEventIfNeeded(boolean isSystemAdminRoom, User sender, String content) {
+        if (isSystemAdminRoom && !sender.isAdmin()) {
+            eventPublisher.publishEvent(AdminChatReceivedEvent.of(sender.getId(), sender.getName(), content));
+        }
+    }
+
+    private User resolveDirectMessageReceiver(List<ChatRoomMember> members, User sender) {
+        Map<Integer, User> userMap = members.stream()
+            .collect(Collectors.toMap(
+                ChatRoomMember::getUserId,
+                ChatRoomMember::getUser,
+                (existing, replacement) -> existing
+            ));
+        List<MemberInfo> memberInfos = members.stream()
+            .map(member -> new MemberInfo(member.getUserId(), member.getCreatedAt()))
+            .toList();
+        return resolveMessageReceiverFromMemberInfo(sender, memberInfos, userMap);
+    }
+
+    private User findDirectPartnerFromMemberInfo(
+        List<MemberInfo> memberInfos,
+        Integer userId,
+        Map<Integer, User> userMap
+    ) {
+        return memberInfos.stream()
+            .filter(info -> !info.userId().equals(userId))
+            .min(Comparator.comparing(MemberInfo::createdAt))
+            .map(info -> userMap.get(info.userId()))
+            .orElse(null);
+    }
+
+    private User findNonAdminUserFromMemberInfo(List<MemberInfo> memberInfos, Map<Integer, User> userMap) {
+        return memberInfos.stream()
+            .sorted(Comparator.comparing(MemberInfo::createdAt))
+            .map(info -> userMap.get(info.userId()))
+            .filter(user -> user != null && !user.isAdmin())
+            .findFirst()
+            .orElse(null);
+    }
+
+    private User resolveMessageReceiverFromMemberInfo(
+        User sender,
+        List<MemberInfo> memberInfos,
+        Map<Integer, User> userMap
+    ) {
+        if (sender.isAdmin()) {
+            User nonAdminUser = findNonAdminUserFromMemberInfo(memberInfos, userMap);
+            if (nonAdminUser != null) {
+                return nonAdminUser;
+            }
+        }
+
+        User partner = findDirectPartnerFromMemberInfo(memberInfos, sender.getId(), userMap);
+        if (partner == null) {
+            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
+        }
+        return partner;
+    }
+
+    private record MemberInfo(Integer userId, LocalDateTime createdAt) {
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatMessageSendService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatMessageSendService.java
@@ -94,7 +94,7 @@ public class ChatMessageSendService {
 
         // 어드민이 보낸 경우는 lastReadAt 업데이트하지 않음 (멤버가 아니므로)
         if (!isAdminSendingToSystemAdminRoom) {
-            updateMemberLastReadAt(roomId, userId, chatMessage.getCreatedAt());
+            updateLastReadAtOrEnsureMember(roomId, userId, chatMessage.getCreatedAt());
         }
 
         List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
@@ -127,7 +127,7 @@ public class ChatMessageSendService {
 
         ChatMessage message = chatMessageRepository.save(ChatMessage.of(room, sender, content));
         syncLastMessage(room, message);
-        updateClubMessageLastReadAt(roomId, userId, message.getCreatedAt());
+        updateLastReadAtOrEnsureMember(roomId, userId, message.getCreatedAt());
 
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
         List<Integer> recipientUserIds = members.stream().map(ChatRoomMember::getUserId).toList();
@@ -210,7 +210,7 @@ public class ChatMessageSendService {
             }, () -> chatRoomMemberRepository.save(ChatRoomMember.of(room, user, joinedAt)));
     }
 
-    private void updateMemberLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
+    private void updateLastReadAtOrEnsureMember(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
         int updated = chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
         if (updated == 0) {
             ChatRoom room = chatRoomRepository.findById(roomId)
@@ -222,16 +222,6 @@ public class ChatMessageSendService {
 
     private void updateLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
         chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
-    }
-
-    private void updateClubMessageLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
-        int updated = chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
-        if (updated == 0) {
-            ChatRoom room = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-            User user = userRepository.getById(userId);
-            ensureRoomMember(room, user, lastReadAt);
-        }
     }
 
     private List<LocalDateTime> toSortedReadBaselines(List<ChatRoomMember> members) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -37,7 +36,6 @@ import gg.agit.konect.domain.chat.dto.ChatSearchResponse;
 import gg.agit.konect.domain.chat.dto.UnreadMessageCount;
 import gg.agit.konect.domain.chat.enums.ChatInviteSortBy;
 import gg.agit.konect.domain.chat.enums.ChatType;
-import gg.agit.konect.domain.chat.event.AdminChatReceivedEvent;
 import gg.agit.konect.domain.chat.model.ChatMessage;
 import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
@@ -52,7 +50,6 @@ import gg.agit.konect.domain.club.repository.ClubMemberRepository;
 import gg.agit.konect.domain.notification.enums.NotificationTargetType;
 import gg.agit.konect.domain.notification.model.NotificationMuteSetting;
 import gg.agit.konect.domain.notification.repository.NotificationMuteSettingRepository;
-import gg.agit.konect.domain.notification.service.NotificationService;
 import gg.agit.konect.domain.user.enums.UserRole;
 import gg.agit.konect.domain.user.model.User;
 import gg.agit.konect.domain.user.repository.UserRepository;
@@ -85,8 +82,7 @@ public class ChatService {
     private final ChatMessagePageResolver chatMessagePageResolver;
     private final ChatRoomSystemAdminService chatRoomSystemAdminService;
     private final ChatDirectRoomAccessService chatDirectRoomAccessService;
-    private final NotificationService notificationService;
-    private final ApplicationEventPublisher eventPublisher;
+    private final ChatMessageSendService chatMessageSendService;
 
     @Transactional
     public ChatRoomResponse createOrGetChatRoom(Integer currentUserId, ChatRoomCreateRequest request) {
@@ -383,18 +379,7 @@ public class ChatService {
 
     @Transactional
     public ChatMessageDetailResponse sendMessage(Integer userId, Integer roomId, ChatMessageSendRequest request) {
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-
-        if (room.isDirectRoom()) {
-            return sendDirectMessage(userId, roomId, request);
-        }
-
-        if (room.isClubGroupRoom()) {
-            return sendClubMessageByRoomId(roomId, userId, request.content());
-        }
-
-        return sendGroupMessageByRoomId(roomId, userId, request.content());
+        return chatMessageSendService.sendMessage(userId, roomId, request);
     }
 
     @Transactional
@@ -655,61 +640,6 @@ public class ChatService {
             visibleMessageFrom, sortedReadBaselines, maskedAdminId);
     }
 
-    private ChatMessageDetailResponse sendDirectMessage(
-        Integer userId,
-        Integer roomId,
-        ChatMessageSendRequest request
-    ) {
-        ChatRoom chatRoom = getDirectRoom(roomId);
-        User sender = userRepository.getById(userId);
-
-        // 어드민이 SYSTEM_ADMIN 방에 메시지를 보내는 경우
-        boolean isAdminSendingToSystemAdminRoom = sender.isAdmin()
-            && chatRoomSystemAdminService.isSystemAdminRoom(chatRoom.getId());
-
-        if (!isAdminSendingToSystemAdminRoom) {
-            chatDirectRoomAccessService.getAccessibleMember(chatRoom, sender);
-        }
-
-        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        User receiver = resolveDirectMessageReceiver(members, sender);
-
-        ChatMessage chatMessage = chatMessageRepository.save(
-            ChatMessage.of(chatRoom, sender, request.content())
-        );
-
-        syncLastMessage(chatRoom, chatMessage);
-        members.stream()
-            .filter(member -> !member.getUserId().equals(userId))
-            .filter(ChatRoomMember::hasLeft)
-            .forEach(member -> member.restoreDirectRoomFromIncomingMessage(chatMessage.getCreatedAt()));
-
-        // 어드민이 보낸 경우는 lastReadAt 업데이트하지 않음 (멤버가 아니므로)
-        if (!isAdminSendingToSystemAdminRoom) {
-            updateMemberLastReadAt(roomId, userId, chatMessage.getCreatedAt());
-        }
-
-        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
-
-        notificationService.sendChatNotification(receiver.getId(), roomId, sender.getName(), request.content());
-
-        boolean isSystemAdminRoom = members.stream()
-            .map(ChatRoomMember::getUserId)
-            .anyMatch(memberUserId -> memberUserId.equals(SYSTEM_ADMIN_ID));
-        publishAdminChatEventIfNeeded(isSystemAdminRoom, sender, request.content());
-
-        return new ChatMessageDetailResponse(
-            chatMessage.getId(),
-            chatMessage.getSender().getId(),
-            null,
-            chatMessage.getContent(),
-            chatMessage.getCreatedAt(),
-            true,
-            countUnreadSince(chatMessage.getCreatedAt(), sortedReadBaselines),
-            true
-        );
-    }
-
     private ChatMessagePageResponse getClubMessagesByRoomId(
         Integer roomId,
         Integer userId,
@@ -752,42 +682,6 @@ public class ChatService {
         );
     }
 
-    private ChatMessageDetailResponse sendClubMessageByRoomId(Integer roomId, Integer userId, String content) {
-        ChatRoom room = getClubRoom(roomId);
-        ClubMember member = clubMemberRepository.getByClubIdAndUserId(room.getClub().getId(), userId);
-        User sender = member.getUser();
-
-        ensureRoomMember(room, sender, member.getCreatedAt());
-
-        ChatMessage message = chatMessageRepository.save(ChatMessage.of(room, sender, content));
-        syncLastMessage(room, message);
-        updateClubMessageLastReadAt(roomId, userId, message.getCreatedAt());
-
-        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        List<Integer> recipientUserIds = members.stream().map(ChatRoomMember::getUserId).toList();
-        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
-
-        notificationService.sendGroupChatNotification(
-            roomId,
-            sender.getId(),
-            room.getClub().getName(),
-            sender.getName(),
-            message.getContent(),
-            recipientUserIds
-        );
-
-        return new ChatMessageDetailResponse(
-            message.getId(),
-            sender.getId(),
-            sender.getName(),
-            message.getContent(),
-            message.getCreatedAt(),
-            null,
-            countUnreadSince(message.getCreatedAt(), sortedReadBaselines),
-            true
-        );
-    }
-
     private ChatMessagePageResponse getGroupMessagesByRoomId(
         Integer roomId,
         Integer userId,
@@ -827,48 +721,6 @@ public class ChatService {
             page,
             null,
             responseMessages
-        );
-    }
-
-    private ChatMessageDetailResponse sendGroupMessageByRoomId(Integer roomId, Integer userId, String content) {
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-        User sender = userRepository.getById(userId);
-
-        ChatRoomMember senderMember = getRoomMember(roomId, userId);
-        if (senderMember.hasLeft()) {
-            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
-        }
-
-        ChatMessage message = chatMessageRepository.save(ChatMessage.of(room, sender, content));
-        syncLastMessage(room, message);
-        updateLastReadAt(roomId, userId, message.getCreatedAt());
-
-        List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(roomId);
-        List<Integer> recipientUserIds = members.stream()
-            .map(ChatRoomMember::getUserId)
-            .filter(id -> !id.equals(userId))
-            .toList();
-        List<LocalDateTime> sortedReadBaselines = toSortedReadBaselines(members);
-
-        notificationService.sendGroupChatNotification(
-            roomId,
-            sender.getId(),
-            DEFAULT_GROUP_ROOM_NAME,
-            sender.getName(),
-            message.getContent(),
-            recipientUserIds
-        );
-
-        return new ChatMessageDetailResponse(
-            message.getId(),
-            sender.getId(),
-            sender.getName(),
-            message.getContent(),
-            message.getCreatedAt(),
-            null,
-            countUnreadSince(message.getCreatedAt(), sortedReadBaselines),
-            true
         );
     }
 
@@ -953,26 +805,6 @@ public class ChatService {
         return null;
     }
 
-    private void publishAdminChatEventIfNeeded(boolean isSystemAdminRoom, User sender, String content) {
-        if (isSystemAdminRoom && !sender.isAdmin()) {
-            eventPublisher.publishEvent(AdminChatReceivedEvent.of(sender.getId(), sender.getName(), content));
-        }
-    }
-
-    private void syncLastMessage(ChatRoom room, ChatMessage message) {
-        // 채팅방 목록은 chat_room.last_message_*를 직접 조회하므로
-        // 동시 전송에서도 가장 최신 메시지만 메타데이터를 덮어쓰도록 DB 조건을 같이 건다.
-        int updated = chatRoomRepository.updateLastMessageIfLatest(
-            room.getId(),
-            message.getId(),
-            message.getContent(),
-            message.getCreatedAt()
-        );
-        if (updated > 0) {
-            room.updateLastMessage(message.getContent(), message.getCreatedAt());
-        }
-    }
-
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
         return chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)
             .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
@@ -1040,30 +872,6 @@ public class ChatService {
         }
 
         return roomName.trim();
-    }
-
-    private void updateMemberLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
-        int updated = chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
-        if (updated == 0) {
-            ChatRoom room = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-            User user = userRepository.getById(userId);
-            ensureRoomMember(room, user, lastReadAt);
-        }
-    }
-
-    private void updateLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
-        chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
-    }
-
-    private void updateClubMessageLastReadAt(Integer roomId, Integer userId, LocalDateTime lastReadAt) {
-        int updated = chatRoomMemberRepository.updateLastReadAtIfOlder(roomId, userId, lastReadAt);
-        if (updated == 0) {
-            ChatRoom room = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-            User user = userRepository.getById(userId);
-            ensureRoomMember(room, user, lastReadAt);
-        }
     }
 
     private List<LocalDateTime> toSortedReadBaselines(List<ChatRoomMember> members) {
@@ -1241,32 +1049,6 @@ public class ChatService {
         return findDirectPartner(members, userId);
     }
 
-    private User findNonAdminUser(List<ChatRoomMember> members) {
-        Map<Integer, User> userMap = members.stream()
-            .collect(Collectors.toMap(
-                ChatRoomMember::getUserId,
-                ChatRoomMember::getUser,
-                (existing, replacement) -> existing
-            ));
-        List<MemberInfo> memberInfos = members.stream()
-            .map(m -> new MemberInfo(m.getUserId(), m.getCreatedAt()))
-            .toList();
-        return findNonAdminUserFromMemberInfo(memberInfos, userMap);
-    }
-
-    private User resolveDirectMessageReceiver(List<ChatRoomMember> members, User sender) {
-        Map<Integer, User> userMap = members.stream()
-            .collect(Collectors.toMap(
-                ChatRoomMember::getUserId,
-                ChatRoomMember::getUser,
-                (existing, replacement) -> existing
-            ));
-        List<MemberInfo> memberInfos = members.stream()
-            .map(m -> new MemberInfo(m.getUserId(), m.getCreatedAt()))
-            .toList();
-        return resolveMessageReceiverFromMemberInfo(sender, memberInfos, userMap);
-    }
-
     private User findDirectPartnerFromMemberInfo(
         List<MemberInfo> memberInfos,
         Integer userId,
@@ -1292,35 +1074,6 @@ public class ChatService {
         }
 
         return findDirectPartnerFromMemberInfo(memberInfos, userId, userMap);
-    }
-
-    private User findNonAdminUserFromMemberInfo(List<MemberInfo> memberInfos, Map<Integer, User> userMap) {
-        return memberInfos.stream()
-            .sorted(Comparator.comparing(MemberInfo::createdAt))
-            .map(info -> userMap.get(info.userId()))
-            .filter(Objects::nonNull)
-            .filter(user -> !user.isAdmin())
-            .findFirst()
-            .orElse(null);
-    }
-
-    private User resolveMessageReceiverFromMemberInfo(
-        User sender,
-        List<MemberInfo> memberInfos,
-        Map<Integer, User> userMap
-    ) {
-        if (sender.isAdmin()) {
-            User nonAdminUser = findNonAdminUserFromMemberInfo(memberInfos, userMap);
-            if (nonAdminUser != null) {
-                return nonAdminUser;
-            }
-        }
-
-        User partner = findDirectPartnerFromMemberInfo(memberInfos, sender.getId(), userMap);
-        if (partner == null) {
-            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
-        }
-        return partner;
     }
 
     private void validateGroupRoomForKick(ChatRoom room) {

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -52,6 +52,7 @@ import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomQueryRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
 import gg.agit.konect.domain.chat.service.ChatDirectRoomAccessService;
+import gg.agit.konect.domain.chat.service.ChatMessageSendService;
 import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
 import gg.agit.konect.domain.chat.service.ChatPresenceService;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
@@ -136,6 +137,17 @@ class ChatServiceTest extends ServiceTestSupport {
             clubMemberRepository,
             chatRoomSystemAdminService
         );
+        ChatMessageSendService chatMessageSendService = new ChatMessageSendService(
+            chatRoomRepository,
+            chatMessageRepository,
+            chatRoomMemberRepository,
+            clubMemberRepository,
+            userRepository,
+            chatRoomSystemAdminService,
+            chatDirectRoomAccessService,
+            notificationService,
+            eventPublisher
+        );
         chatService = new ChatService(
             chatRoomRepository,
             chatRoomQueryRepository,
@@ -152,8 +164,7 @@ class ChatServiceTest extends ServiceTestSupport {
             chatMessagePageResolver,
             chatRoomSystemAdminService,
             chatDirectRoomAccessService,
-            notificationService,
-            eventPublisher
+            chatMessageSendService
         );
     }
 

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -43,6 +43,7 @@ import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
 import gg.agit.konect.domain.chat.enums.ChatType;
+import gg.agit.konect.domain.chat.event.AdminChatReceivedEvent;
 import gg.agit.konect.domain.chat.model.ChatMessage;
 import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
@@ -1046,6 +1047,51 @@ class ChatServiceTest extends ServiceTestSupport {
     }
 
     @Test
+    @DisplayName("sendMessage는 일반 사용자가 SYSTEM_ADMIN 방에 보내면 관리자 문의 이벤트를 발행한다")
+    void sendMessageByUserInSystemAdminRoomPublishesAdminChatEvent() {
+        // given
+        Integer senderId = 20;
+        String content = "문의합니다";
+        User sender = createUser(senderId, "사용자", UserRole.USER);
+        User systemAdmin = createUser(SYSTEM_ADMIN_ID, "시스템관리자", UserRole.ADMIN);
+        ChatRoom systemAdminRoom = createRoom(1, ChatType.DIRECT, LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember senderMember = createRoomMember(systemAdminRoom, sender, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatRoomMember systemAdminMember = createRoomMember(systemAdminRoom, systemAdmin, false,
+            LocalDateTime.of(2026, 4, 11, 10, 0));
+        ChatMessage savedMessage = createMessage(100, systemAdminRoom, sender, content,
+            LocalDateTime.of(2026, 4, 11, 10, 1));
+
+        given(chatRoomRepository.findById(systemAdminRoom.getId())).willReturn(Optional.of(systemAdminRoom));
+        given(userRepository.getById(senderId)).willReturn(sender);
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(systemAdminRoom.getId(), senderId))
+            .willReturn(Optional.of(senderMember));
+        given(chatRoomMemberRepository.findByChatRoomId(systemAdminRoom.getId()))
+            .willReturn(List.of(systemAdminMember, senderMember));
+        given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(savedMessage);
+        given(chatRoomRepository.updateLastMessageIfLatest(
+            systemAdminRoom.getId(), savedMessage.getId(), savedMessage.getContent(), savedMessage.getCreatedAt()
+        )).willReturn(1);
+        given(chatRoomMemberRepository.updateLastReadAtIfOlder(eq(systemAdminRoom.getId()), eq(senderId),
+            any(LocalDateTime.class)))
+            .willReturn(1);
+
+        // when
+        chatService.sendMessage(senderId, systemAdminRoom.getId(), new ChatMessageSendRequest(content));
+
+        // then
+        ArgumentCaptor<AdminChatReceivedEvent> eventCaptor = ArgumentCaptor.forClass(AdminChatReceivedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue())
+            .extracting(
+                AdminChatReceivedEvent::senderId,
+                AdminChatReceivedEvent::senderName,
+                AdminChatReceivedEvent::content
+            )
+            .containsExactly(senderId, sender.getName(), content);
+    }
+
+    @Test
     @DisplayName("sendMessage는 admin이 system admin room에 보내면 멤버십 체크를 건너뛰고 lastReadAt 업데이트도 하지 않는다")
     void sendMessageAdminBypassesMembershipInSystemAdminRoom() {
         // given
@@ -1087,6 +1133,7 @@ class ChatServiceTest extends ServiceTestSupport {
         // 비관리자에게 알림이 전송되어야 한다
         verify(notificationService).sendChatNotification(eq(targetUserId), eq(systemAdminRoom.getId()), eq("관리자"),
             eq("문의"));
+        verify(eventPublisher, never()).publishEvent(any(AdminChatReceivedEvent.class));
     }
 
     // ===== toggleMute additional =====


### PR DESCRIPTION
### 🔍 개요

* Closes #597
* ChatService에 남아 있던 direct/club group/group 메시지 전송 책임을 ChatMessageSendService로 분리했습니다.


---

### 🚀 주요 변경 내용

* ChatMessageSendService를 추가해 메시지 저장, 마지막 메시지 메타데이터 갱신, 알림 발송, SYSTEM_ADMIN 문의 이벤트 발행을 담당하도록 이동
* ChatService.sendMessage는 새 서비스로 위임하도록 축소
* 기존 ChatServiceTest의 메시지 전송 검증이 새 서비스를 실제 객체로 타도록 테스트 구성을 갱신


---

### 💬 참고 사항

* `checkstyleTest`는 기존 테스트 파일의 120자 초과 위반 12건으로 실패합니다. 이번 변경 파일에서는 신규 위반이 없습니다.
* Gradle 작업을 병렬로 실행하면 test/checkstyleMain 산출물이 충돌해 무관한 compileTestJava 오류가 재현되어, 테스트와 체크스타일은 단독 실행 기준으로 확인했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)