### PR TITLE
refactor: 채팅방 생성 재사용 책임 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomCreationService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomCreationService.java
@@ -1,0 +1,156 @@
+package gg.agit.konect.domain.chat.service;
+
+import static gg.agit.konect.domain.chat.service.ChatRoomMembershipService.SYSTEM_ADMIN_ID;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_CREATE_CHAT_ROOM_WITH_SELF;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
+import gg.agit.konect.domain.chat.enums.ChatType;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomCreationService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomSystemAdminService chatRoomSystemAdminService;
+
+    public ChatRoomResponse createOrGetChatRoom(Integer currentUserId, ChatRoomCreateRequest request) {
+        User currentUser = userRepository.getById(currentUserId);
+        User targetUser = userRepository.getById(request.userId());
+
+        if (currentUser.getId().equals(targetUser.getId())) {
+            throw CustomException.of(CANNOT_CREATE_CHAT_ROOM_WITH_SELF);
+        }
+
+        if (currentUser.isAdmin() && !targetUser.isAdmin()) {
+            return getOrCreateSystemAdminChatRoomForUser(targetUser, currentUser);
+        }
+
+        ChatRoom chatRoom = chatRoomRepository.findByTwoUsers(
+                currentUser.getId(),
+                targetUser.getId(),
+                ChatType.DIRECT
+            )
+            .orElseGet(() -> chatRoomRepository.save(ChatRoom.directOf()));
+
+        LocalDateTime joinedAt = Objects.requireNonNull(chatRoom.getCreatedAt(), "chatRoom.createdAt must not be null");
+        ensureDirectRoomRequester(chatRoom, currentUser, joinedAt);
+        ensureRoomMember(chatRoom, targetUser, joinedAt);
+
+        return ChatRoomResponse.from(chatRoom);
+    }
+
+    public ChatRoomResponse createOrGetAdminChatRoom(Integer currentUserId) {
+        User adminUser = userRepository.findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole.ADMIN)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_USER));
+
+        return createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(adminUser.getId()));
+    }
+
+    public ChatRoomResponse createGroupChatRoom(Integer currentUserId, ChatRoomCreateRequest.Group request) {
+        User creator = userRepository.getById(currentUserId);
+
+        List<Integer> distinctUserIds = request.userIds().stream()
+            .distinct()
+            .filter(id -> !id.equals(currentUserId))
+            .toList();
+
+        if (distinctUserIds.isEmpty()) {
+            throw CustomException.of(CANNOT_CREATE_CHAT_ROOM_WITH_SELF);
+        }
+
+        List<User> invitees = userRepository.findAllByIdIn(distinctUserIds);
+        if (invitees.size() != distinctUserIds.size()) {
+            throw CustomException.of(NOT_FOUND_USER);
+        }
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.groupOf());
+        LocalDateTime joinedAt = Objects.requireNonNull(
+            chatRoom.getCreatedAt(), "chatRoom.createdAt must not be null"
+        );
+
+        List<ChatRoomMember> members = new ArrayList<>();
+        members.add(ChatRoomMember.ofOwner(chatRoom, creator, joinedAt));
+        invitees.forEach(user -> members.add(ChatRoomMember.of(chatRoom, user, joinedAt)));
+        chatRoomMemberRepository.saveAll(members);
+
+        return ChatRoomResponse.from(chatRoom);
+    }
+
+    private ChatRoomResponse getOrCreateSystemAdminChatRoomForUser(User targetUser, User adminUser) {
+        ChatRoom chatRoom = chatRoomRepository.findByTwoUsers(SYSTEM_ADMIN_ID, targetUser.getId(), ChatType.DIRECT)
+            .orElseGet(() -> {
+                ChatRoom newRoom = chatRoomRepository.save(ChatRoom.directOf());
+                User systemAdmin = userRepository.getById(SYSTEM_ADMIN_ID);
+                LocalDateTime joinedAt = Objects.requireNonNull(
+                    newRoom.getCreatedAt(), "chatRoom.createdAt must not be null"
+                );
+                ensureRoomMember(newRoom, systemAdmin, joinedAt);
+                ensureRoomMember(newRoom, targetUser, joinedAt);
+                return newRoom;
+            });
+
+        LocalDateTime joinedAt = Objects.requireNonNull(
+            chatRoom.getCreatedAt(), "chatRoom.createdAt must not be null"
+        );
+        ensureDirectRoomRequester(chatRoom, adminUser, joinedAt);
+
+        return ChatRoomResponse.from(chatRoom);
+    }
+
+    private void ensureRoomMember(ChatRoom room, User user, LocalDateTime joinedAt) {
+        chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+            .ifPresentOrElse(member -> {
+                LocalDateTime lastReadAt = member.getLastReadAt();
+                if (lastReadAt == null || lastReadAt.isBefore(joinedAt)) {
+                    member.updateLastReadAt(joinedAt);
+                }
+            }, () -> chatRoomMemberRepository.save(ChatRoomMember.of(room, user, joinedAt)));
+    }
+
+    private void ensureDirectRoomRequester(ChatRoom room, User user, LocalDateTime joinedAt) {
+        if (shouldSkipSystemAdminMembership(room, user)) {
+            return;
+        }
+
+        chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+            .ifPresentOrElse(member -> {
+                if (member.hasLeft()) {
+                    member.reopenDirectRoom(LocalDateTime.now());
+                    return;
+                }
+
+                LocalDateTime lastReadAt = member.getLastReadAt();
+                if (lastReadAt == null || lastReadAt.isBefore(joinedAt)) {
+                    member.updateLastReadAt(joinedAt);
+                }
+            }, () -> chatRoomMemberRepository.save(ChatRoomMember.of(room, user, joinedAt)));
+    }
+
+    private boolean shouldSkipSystemAdminMembership(ChatRoom room, User user) {
+        // 문의방은 SYSTEM_ADMIN + 일반 사용자 2인 구조를 전제로 재사용(findByTwoUsers)되므로,
+        // 생성/재오픈 경로에서도 일반 ADMIN을 멤버로 추가하면 안 된다.
+        return user.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -83,6 +83,7 @@ public class ChatService {
     private final ChatRoomSummaryService chatRoomSummaryService;
     private final ChatSearchService chatSearchService;
     private final ChatMessagePageResolver chatMessagePageResolver;
+    private final ChatRoomCreationService chatRoomCreationService;
     private final ChatRoomSystemAdminService chatRoomSystemAdminService;
     private final ChatDirectRoomAccessService chatDirectRoomAccessService;
     private final NotificationService notificationService;
@@ -90,89 +91,17 @@ public class ChatService {
 
     @Transactional
     public ChatRoomResponse createOrGetChatRoom(Integer currentUserId, ChatRoomCreateRequest request) {
-        User currentUser = userRepository.getById(currentUserId);
-        User targetUser = userRepository.getById(request.userId());
-
-        if (currentUser.getId().equals(targetUser.getId())) {
-            throw CustomException.of(CANNOT_CREATE_CHAT_ROOM_WITH_SELF);
-        }
-
-        if (currentUser.isAdmin() && !targetUser.isAdmin()) {
-            return getOrCreateSystemAdminChatRoomForUser(targetUser, currentUser);
-        }
-
-        ChatRoom chatRoom = chatRoomRepository.findByTwoUsers(
-                currentUser.getId(),
-                targetUser.getId(),
-                ChatType.DIRECT
-            )
-            .orElseGet(() -> chatRoomRepository.save(ChatRoom.directOf()));
-
-        LocalDateTime joinedAt = Objects.requireNonNull(chatRoom.getCreatedAt(), "chatRoom.createdAt must not be null");
-        ensureDirectRoomRequester(chatRoom, currentUser, joinedAt);
-        ensureRoomMember(chatRoom, targetUser, joinedAt);
-
-        return ChatRoomResponse.from(chatRoom);
-    }
-
-    private ChatRoomResponse getOrCreateSystemAdminChatRoomForUser(User targetUser, User adminUser) {
-        ChatRoom chatRoom = chatRoomRepository.findByTwoUsers(SYSTEM_ADMIN_ID, targetUser.getId(), ChatType.DIRECT)
-            .orElseGet(() -> {
-                ChatRoom newRoom = chatRoomRepository.save(ChatRoom.directOf());
-                User systemAdmin = userRepository.getById(SYSTEM_ADMIN_ID);
-                LocalDateTime joinedAt = Objects.requireNonNull(
-                    newRoom.getCreatedAt(), "chatRoom.createdAt must not be null"
-                );
-                ensureRoomMember(newRoom, systemAdmin, joinedAt);
-                ensureRoomMember(newRoom, targetUser, joinedAt);
-                return newRoom;
-            });
-
-        LocalDateTime joinedAt = Objects.requireNonNull(
-            chatRoom.getCreatedAt(), "chatRoom.createdAt must not be null"
-        );
-        ensureDirectRoomRequester(chatRoom, adminUser, joinedAt);
-
-        return ChatRoomResponse.from(chatRoom);
+        return chatRoomCreationService.createOrGetChatRoom(currentUserId, request);
     }
 
     @Transactional
     public ChatRoomResponse createOrGetAdminChatRoom(Integer currentUserId) {
-        User adminUser = userRepository.findFirstByRoleAndDeletedAtIsNullOrderByIdAsc(UserRole.ADMIN)
-            .orElseThrow(() -> CustomException.of(NOT_FOUND_USER));
-
-        return createOrGetChatRoom(currentUserId, new ChatRoomCreateRequest(adminUser.getId()));
+        return chatRoomCreationService.createOrGetAdminChatRoom(currentUserId);
     }
 
     @Transactional
     public ChatRoomResponse createGroupChatRoom(Integer currentUserId, ChatRoomCreateRequest.Group request) {
-        User creator = userRepository.getById(currentUserId);
-
-        List<Integer> distinctUserIds = request.userIds().stream()
-            .distinct()
-            .filter(id -> !id.equals(currentUserId))
-            .toList();
-
-        if (distinctUserIds.isEmpty()) {
-            throw CustomException.of(CANNOT_CREATE_CHAT_ROOM_WITH_SELF);
-        }
-
-        List<User> invitees = userRepository.findAllByIdIn(distinctUserIds);
-        if (invitees.size() != distinctUserIds.size()) {
-            throw CustomException.of(NOT_FOUND_USER);
-        }
-
-        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.groupOf());
-        LocalDateTime joinedAt = Objects.requireNonNull(
-            chatRoom.getCreatedAt(), "chatRoom.createdAt must not be null"
-        );
-
-        List<ChatRoomMember> members = new ArrayList<>();
-        members.add(ChatRoomMember.ofOwner(chatRoom, creator, joinedAt));
-        invitees.forEach(user -> members.add(ChatRoomMember.of(chatRoom, user, joinedAt)));
-        chatRoomMemberRepository.saveAll(members);
-
-        return ChatRoomResponse.from(chatRoom);
+        return chatRoomCreationService.createGroupChatRoom(currentUserId, request);
     }
 
     @Transactional
@@ -1007,31 +936,6 @@ public class ChatService {
                     member.updateLastReadAt(joinedAt);
                 }
             }, () -> chatRoomMemberRepository.save(ChatRoomMember.of(room, user, joinedAt)));
-    }
-
-    private void ensureDirectRoomRequester(ChatRoom room, User user, LocalDateTime joinedAt) {
-        if (shouldSkipSystemAdminMembership(room, user)) {
-            return;
-        }
-
-        chatRoomMemberRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
-            .ifPresentOrElse(member -> {
-                if (member.hasLeft()) {
-                    member.reopenDirectRoom(LocalDateTime.now());
-                    return;
-                }
-
-                LocalDateTime lastReadAt = member.getLastReadAt();
-                if (lastReadAt == null || lastReadAt.isBefore(joinedAt)) {
-                    member.updateLastReadAt(joinedAt);
-                }
-            }, () -> chatRoomMemberRepository.save(ChatRoomMember.of(room, user, joinedAt)));
-    }
-
-    private boolean shouldSkipSystemAdminMembership(ChatRoom room, User user) {
-        // 문의방은 SYSTEM_ADMIN + 일반 사용자 2인 구조를 전제로 재사용(findByTwoUsers)되므로,
-        // 생성/재오픈 경로에서도 일반 ADMIN을 멤버로 추가하면 안 된다.
-        return user.isAdmin() && chatRoomSystemAdminService.isSystemAdminRoom(room.getId());
     }
 
     private String normalizeCustomRoomName(String roomName) {

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -54,6 +54,7 @@ import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
 import gg.agit.konect.domain.chat.service.ChatDirectRoomAccessService;
 import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
 import gg.agit.konect.domain.chat.service.ChatPresenceService;
+import gg.agit.konect.domain.chat.service.ChatRoomCreationService;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.chat.service.ChatRoomSummaryService;
 import gg.agit.konect.domain.chat.service.ChatSearchService;
@@ -136,6 +137,12 @@ class ChatServiceTest extends ServiceTestSupport {
             clubMemberRepository,
             chatRoomSystemAdminService
         );
+        ChatRoomCreationService chatRoomCreationService = new ChatRoomCreationService(
+            chatRoomRepository,
+            chatRoomMemberRepository,
+            userRepository,
+            chatRoomSystemAdminService
+        );
         chatService = new ChatService(
             chatRoomRepository,
             chatRoomQueryRepository,
@@ -150,6 +157,7 @@ class ChatServiceTest extends ServiceTestSupport {
             chatRoomSummaryService,
             chatSearchService,
             chatMessagePageResolver,
+            chatRoomCreationService,
             chatRoomSystemAdminService,
             chatDirectRoomAccessService,
             notificationService,


### PR DESCRIPTION
### 🔍 개요

* Closes #598
* ChatService에 남아 있던 direct 생성/재사용, SYSTEM_ADMIN 문의방 재사용, group 생성 책임을 ChatRoomCreationService로 분리했습니다.


---

### 🚀 주요 변경 내용

* ChatRoomCreationService를 추가해 일반 direct, SYSTEM_ADMIN 문의방, group room 생성 흐름을 담당하도록 이동
* direct room 재오픈과 SYSTEM_ADMIN 문의방 멤버십 예외 정책을 새 서비스 내부에 보존
* ChatService의 생성 API 메서드는 새 서비스로 위임하도록 축소


---

### 💬 참고 사항

* `checkstyleTest`는 기존 테스트 파일의 120자 초과 위반 12건으로 실패합니다. 이번 변경 파일에서는 신규 위반이 없습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)