### PR TITLE
chore: DB 백업을 SSM 명령 실행 방식으로 변경

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -68,35 +72,37 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Backup prod MySQL before deploy
-        uses: appleboy/ssh-action@v1.2.0
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.DB_SERVER_IP }}
-          username: ${{ secrets.DB_SERVER_USER }}
-          key: ${{ secrets.DB_SERVER_SSH_KEY }}
-          port: ${{ secrets.DB_SERVER_PORT }}
-          script: |
-            set -euo pipefail
-            START_TIME=$(date +%s)
-      
-            WORK_DIR="/home/ubuntu/konect/prod-db-compose"
-            MYSQL_CONTAINER="mysql-prod"
-      
-            set -a
-            source "$WORK_DIR/.env"
-            set +a
-      
-            BACKUP_DIR="$WORK_DIR/db-backups/"
-            mkdir -p "$BACKUP_DIR"
-      
-            DUMP_FILE="$BACKUP_DIR/$(date '+%Y%m%d_%H%M%S').sql"
-            docker exec -e MYSQL_PWD="$MYSQL_PASSWORD" "$MYSQL_CONTAINER" \
-              mysqldump --no-tablespaces -u"$MYSQL_USERNAME" "$MYSQL_DATABASE" > "$DUMP_FILE"
-      
-            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +5 -delete
-      
-            END_TIME=$(date +%s)
-            echo "Prod MySQL backup completed in $((END_TIME - START_TIME))s"
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Backup prod MySQL before deploy
+        env:
+          DB_INSTANCE_ID: ${{ secrets.DB_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$DB_INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --comment "KONECT prod MySQL backup before deploy" \
+            --parameters commands='[
+              "bash -lc '\''START_TIME=$(date +%s); bash /home/ubuntu/konect/prod-db-compose/backup-db.sh; END_TIME=$(date +%s); echo \"Prod MySQL backup completed in $((END_TIME - START_TIME))s\"'\''"
+            ]' \
+            --query "Command.CommandId" \
+            --output text)
+
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID"
+
+          aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "{Status:Status,Output:StandardOutputContent,Error:StandardErrorContent}" \
+            --output json
 
       - name: Deploy to prod server
         uses: appleboy/ssh-action@v1.2.0

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -73,7 +73,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -94,15 +94,37 @@ jobs:
             --query "Command.CommandId" \
             --output text)
 
+          set +e
           aws ssm wait command-executed \
             --command-id "$COMMAND_ID" \
             --instance-id "$DB_INSTANCE_ID"
+          WAITER_EXIT=$?
+          set -e
 
-          aws ssm get-command-invocation \
+          BACKUP_STATUS=$(aws ssm get-command-invocation \
             --command-id "$COMMAND_ID" \
             --instance-id "$DB_INSTANCE_ID" \
-            --query "{Status:Status,Output:StandardOutputContent,Error:StandardErrorContent}" \
-            --output json
+            --query "Status" \
+            --output text)
+
+          BACKUP_STATUS_DETAILS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "StatusDetails" \
+            --output text)
+
+          BACKUP_RESPONSE_CODE=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "ResponseCode" \
+            --output text)
+
+          echo "Prod MySQL backup status: $BACKUP_STATUS (details: $BACKUP_STATUS_DETAILS, response-code: $BACKUP_RESPONSE_CODE)"
+
+          if [ "$WAITER_EXIT" -ne 0 ] || [ "$BACKUP_STATUS" != "Success" ] || [ "$BACKUP_RESPONSE_CODE" != "0" ]; then
+            echo "Prod MySQL backup failed. Remote stdout/stderr is intentionally not printed to avoid leaking sensitive information."
+            exit 1
+          fi
 
       - name: Deploy to prod server
         uses: appleboy/ssh-action@v1.2.0

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -73,7 +73,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -94,15 +94,37 @@ jobs:
             --query "Command.CommandId" \
             --output text)
 
+          set +e
           aws ssm wait command-executed \
             --command-id "$COMMAND_ID" \
             --instance-id "$DB_INSTANCE_ID"
+          WAITER_EXIT=$?
+          set -e
 
-          aws ssm get-command-invocation \
+          BACKUP_STATUS=$(aws ssm get-command-invocation \
             --command-id "$COMMAND_ID" \
             --instance-id "$DB_INSTANCE_ID" \
-            --query "{Status:Status,Output:StandardOutputContent,Error:StandardErrorContent}" \
-            --output json
+            --query "Status" \
+            --output text)
+
+          BACKUP_STATUS_DETAILS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "StatusDetails" \
+            --output text)
+
+          BACKUP_RESPONSE_CODE=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "ResponseCode" \
+            --output text)
+
+          echo "Stage MySQL backup status: $BACKUP_STATUS (details: $BACKUP_STATUS_DETAILS, response-code: $BACKUP_RESPONSE_CODE)"
+
+          if [ "$WAITER_EXIT" -ne 0 ] || [ "$BACKUP_STATUS" != "Success" ] || [ "$BACKUP_RESPONSE_CODE" != "0" ]; then
+            echo "Stage MySQL backup failed. Remote stdout/stderr is intentionally not printed to avoid leaking sensitive information."
+            exit 1
+          fi
 
       - name: Deploy to stage server
         uses: appleboy/ssh-action@v1.2.0

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -68,35 +72,37 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Backup stage MySQL before deploy
-        uses: appleboy/ssh-action@v1.2.0
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.DB_SERVER_IP }}
-          username: ${{ secrets.DB_SERVER_USER }}
-          key: ${{ secrets.DB_SERVER_SSH_KEY }}
-          port: ${{ secrets.DB_SERVER_PORT }}
-          script: |
-            set -euo pipefail
-            START_TIME=$(date +%s)
-      
-            WORK_DIR="/home/ubuntu/konect/stage-db-compose"
-            MYSQL_CONTAINER="mysql-stage"
-      
-            set -a
-            source "$WORK_DIR/.env"
-            set +a
-      
-            BACKUP_DIR="$WORK_DIR/db-backups/"
-            mkdir -p "$BACKUP_DIR"
-      
-            DUMP_FILE="$BACKUP_DIR/$(date '+%Y%m%d_%H%M%S').sql"
-            docker exec -e MYSQL_PWD="$MYSQL_PASSWORD" "$MYSQL_CONTAINER" \
-              mysqldump --no-tablespaces -u"$MYSQL_USERNAME" "$MYSQL_DATABASE" > "$DUMP_FILE"
-      
-            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +5 -delete
-      
-            END_TIME=$(date +%s)
-            echo "Stage MySQL backup completed in $((END_TIME - START_TIME))s"
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Backup stage MySQL before deploy
+        env:
+          DB_INSTANCE_ID: ${{ secrets.DB_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$DB_INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --comment "KONECT stage MySQL backup before deploy" \
+            --parameters commands='[
+              "bash -lc '\''START_TIME=$(date +%s); bash /home/ubuntu/konect/stage-db-compose/backup-db.sh; END_TIME=$(date +%s); echo \"Stage MySQL backup completed in $((END_TIME - START_TIME))s\"'\''"
+            ]' \
+            --query "Command.CommandId" \
+            --output text)
+
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID"
+
+          aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "{Status:Status,Output:StandardOutputContent,Error:StandardErrorContent}" \
+            --output json
 
       - name: Deploy to stage server
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
### 🔍 개요

* DB 서버 백업을 위해 외부 SSH 포트(22222)를 열어두던 배포 흐름을 AWS Systems Manager Run Command 기반으로 전환합니다.
* 배포 전 백업은 DB 서버 내부의 `backup-db.sh`를 SSM으로 실행하도록 변경해 DB 서버 인바운드 SSH 의존성을 줄입니다.


---

### 🚀 주요 변경 내용

* `.github/workflows/deploy-stage.yml`
  * GitHub OIDC 사용을 위한 `id-token: write` 권한을 추가했습니다.
  * AWS 자격 증명 설정 단계(`aws-actions/configure-aws-credentials`)를 추가했습니다.
  * stage DB 백업 단계를 SSH 접속 대신 SSM Run Command 호출로 변경했습니다.
* `.github/workflows/deploy-prod.yml`
  * GitHub OIDC 사용을 위한 `id-token: write` 권한을 추가했습니다.
  * AWS 자격 증명 설정 단계(`aws-actions/configure-aws-credentials`)를 추가했습니다.
  * prod DB 백업 단계를 SSH 접속 대신 SSM Run Command 호출로 변경했습니다.


---

### 💬 참고 사항

* GitHub Actions Secrets에 `AWS_ROLE_TO_ASSUME`, `AWS_REGION`, `DB_INSTANCE_ID`가 필요합니다.
* stage/prod 배포에서 SSM 백업 성공을 확인한 뒤 DB 서버 보안 그룹의 `22222/TCP 0.0.0.0/0` 규칙을 제거할 수 있습니다.
* prod 서버의 `/home/ubuntu/konect/prod-db-compose/backup-db.sh` 존재 여부와 실행 가능 여부를 배포 전 확인해야 합니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)