### PR TITLE
refactor: 채팅방 멤버 명령 책임 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
@@ -4,7 +4,6 @@ import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_IN_NON_GROU
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_ROOM_OWNER;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_SELF;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_LEAVE_GROUP_CHAT_ROOM;
-import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
 import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_KICK;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 
@@ -62,8 +61,7 @@ public class ChatRoomMemberCommandService {
     }
 
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
-        return chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)
-            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
+        return ChatRoomMemberLookup.getByChatRoomIdAndUserId(chatRoomMemberRepository, roomId, userId);
     }
 
     private void validateGroupRoomForKick(ChatRoom room) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
@@ -61,7 +61,7 @@ public class ChatRoomMemberCommandService {
     }
 
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
-        return ChatRoomMemberLookup.getByChatRoomIdAndUserId(chatRoomMemberRepository, roomId, userId);
+        return ChatRoomMemberLookup.getRoomMember(chatRoomMemberRepository, roomId, userId);
     }
 
     private void validateGroupRoomForKick(ChatRoom room) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
@@ -1,0 +1,92 @@
+package gg.agit.konect.domain.chat.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_IN_NON_GROUP_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_ROOM_OWNER;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_SELF;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_LEAVE_GROUP_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_KICK;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomMemberCommandService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public void leaveChatRoom(Integer userId, Integer roomId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+
+        if (room.isClubGroupRoom()) {
+            throw CustomException.of(CANNOT_LEAVE_GROUP_CHAT_ROOM);
+        }
+
+        ChatRoomMember member = getRoomMember(roomId, userId);
+        if (room.isDirectRoom()) {
+            member.leaveDirectRoom(LocalDateTime.now());
+            return;
+        }
+
+        chatRoomMemberRepository.deleteByChatRoomIdAndUserId(roomId, userId);
+    }
+
+    public void kickMember(Integer requesterId, Integer roomId, Integer targetUserId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+
+        validateGroupRoomForKick(room);
+        validateNotSelfKick(requesterId, targetUserId);
+
+        ChatRoomMember requester = getRoomMember(roomId, requesterId);
+        validateKickAuthority(requester);
+
+        ChatRoomMember target = getRoomMember(roomId, targetUserId);
+        validateNotOwnerTarget(target);
+
+        chatRoomMemberRepository.deleteByChatRoomIdAndUserId(roomId, targetUserId);
+    }
+
+    private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
+        return chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)
+            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
+    }
+
+    private void validateGroupRoomForKick(ChatRoom room) {
+        if (!room.isGroupRoom() || room.isClubGroupRoom()) {
+            throw CustomException.of(CANNOT_KICK_IN_NON_GROUP_ROOM);
+        }
+    }
+
+    private void validateNotSelfKick(Integer requesterId, Integer targetUserId) {
+        if (requesterId.equals(targetUserId)) {
+            throw CustomException.of(CANNOT_KICK_SELF);
+        }
+    }
+
+    private void validateKickAuthority(ChatRoomMember requester) {
+        if (!requester.isOwner()) {
+            throw CustomException.of(FORBIDDEN_CHAT_ROOM_KICK);
+        }
+    }
+
+    private void validateNotOwnerTarget(ChatRoomMember target) {
+        if (target.isOwner()) {
+            throw CustomException.of(CANNOT_KICK_ROOM_OWNER);
+        }
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberLookup.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberLookup.java
@@ -1,0 +1,22 @@
+package gg.agit.konect.domain.chat.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+
+import gg.agit.konect.domain.chat.model.ChatRoomMember;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.global.exception.CustomException;
+
+final class ChatRoomMemberLookup {
+
+    private ChatRoomMemberLookup() {
+    }
+
+    static ChatRoomMember getByChatRoomIdAndUserId(
+        ChatRoomMemberRepository chatRoomMemberRepository,
+        Integer roomId,
+        Integer userId
+    ) {
+        return chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)
+            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberLookup.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberLookup.java
@@ -11,7 +11,7 @@ final class ChatRoomMemberLookup {
     private ChatRoomMemberLookup() {
     }
 
-    static ChatRoomMember getByChatRoomIdAndUserId(
+    static ChatRoomMember getRoomMember(
         ChatRoomMemberRepository chatRoomMemberRepository,
         Integer roomId,
         Integer userId

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -950,7 +950,7 @@ public class ChatService {
     }
 
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
-        return ChatRoomMemberLookup.getByChatRoomIdAndUserId(chatRoomMemberRepository, roomId, userId);
+        return ChatRoomMemberLookup.getRoomMember(chatRoomMemberRepository, roomId, userId);
     }
 
     private ChatRoomMember getAccessibleRoomMember(ChatRoom room, Integer userId) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -950,8 +950,7 @@ public class ChatService {
     }
 
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
-        return chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, userId)
-            .orElseThrow(() -> CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS));
+        return ChatRoomMemberLookup.getByChatRoomIdAndUserId(chatRoomMemberRepository, roomId, userId);
     }
 
     private ChatRoomMember getAccessibleRoomMember(ChatRoom room, Integer userId) {

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -80,6 +80,7 @@ public class ChatService {
     private final UserRepository userRepository;
     private final ChatPresenceService chatPresenceService;
     private final ChatRoomMembershipService chatRoomMembershipService;
+    private final ChatRoomMemberCommandService chatRoomMemberCommandService;
     private final ChatRoomSummaryService chatRoomSummaryService;
     private final ChatSearchService chatSearchService;
     private final ChatMessagePageResolver chatMessagePageResolver;
@@ -177,37 +178,12 @@ public class ChatService {
 
     @Transactional
     public void leaveChatRoom(Integer userId, Integer roomId) {
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-
-        if (room.isClubGroupRoom()) {
-            throw CustomException.of(CANNOT_LEAVE_GROUP_CHAT_ROOM);
-        }
-
-        ChatRoomMember member = getRoomMember(roomId, userId);
-        if (room.isDirectRoom()) {
-            member.leaveDirectRoom(LocalDateTime.now());
-            return;
-        }
-
-        chatRoomMemberRepository.deleteByChatRoomIdAndUserId(roomId, userId);
+        chatRoomMemberCommandService.leaveChatRoom(userId, roomId);
     }
 
     @Transactional
     public void kickMember(Integer requesterId, Integer roomId, Integer targetUserId) {
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
-
-        validateGroupRoomForKick(room);
-        validateNotSelfKick(requesterId, targetUserId);
-
-        ChatRoomMember requester = getRoomMember(roomId, requesterId);
-        validateKickAuthority(requester);
-
-        ChatRoomMember target = getRoomMember(roomId, targetUserId);
-        validateNotOwnerTarget(target);
-
-        chatRoomMemberRepository.deleteByChatRoomIdAndUserId(roomId, targetUserId);
+        chatRoomMemberCommandService.kickMember(requesterId, roomId, targetUserId);
     }
 
     public ChatRoomsSummaryResponse getChatRooms(Integer userId) {
@@ -1321,30 +1297,6 @@ public class ChatService {
             throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
         }
         return partner;
-    }
-
-    private void validateGroupRoomForKick(ChatRoom room) {
-        if (!room.isGroupRoom() || room.isClubGroupRoom()) {
-            throw CustomException.of(CANNOT_KICK_IN_NON_GROUP_ROOM);
-        }
-    }
-
-    private void validateNotSelfKick(Integer requesterId, Integer targetUserId) {
-        if (requesterId.equals(targetUserId)) {
-            throw CustomException.of(CANNOT_KICK_SELF);
-        }
-    }
-
-    private void validateKickAuthority(ChatRoomMember requester) {
-        if (!requester.isOwner()) {
-            throw CustomException.of(FORBIDDEN_CHAT_ROOM_KICK);
-        }
-    }
-
-    private void validateNotOwnerTarget(ChatRoomMember target) {
-        if (target.isOwner()) {
-            throw CustomException.of(CANNOT_KICK_ROOM_OWNER);
-        }
     }
 
     private void recordPresenceSafely(Integer roomId, Integer userId) {

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -54,6 +54,7 @@ import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
 import gg.agit.konect.domain.chat.service.ChatDirectRoomAccessService;
 import gg.agit.konect.domain.chat.service.ChatMessagePageResolver;
 import gg.agit.konect.domain.chat.service.ChatPresenceService;
+import gg.agit.konect.domain.chat.service.ChatRoomMemberCommandService;
 import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
 import gg.agit.konect.domain.chat.service.ChatRoomSummaryService;
 import gg.agit.konect.domain.chat.service.ChatSearchService;
@@ -136,6 +137,10 @@ class ChatServiceTest extends ServiceTestSupport {
             clubMemberRepository,
             chatRoomSystemAdminService
         );
+        ChatRoomMemberCommandService chatRoomMemberCommandService = new ChatRoomMemberCommandService(
+            chatRoomRepository,
+            chatRoomMemberRepository
+        );
         chatService = new ChatService(
             chatRoomRepository,
             chatRoomQueryRepository,
@@ -147,6 +152,7 @@ class ChatServiceTest extends ServiceTestSupport {
             userRepository,
             chatPresenceService,
             chatRoomMembershipService,
+            chatRoomMemberCommandService,
             chatRoomSummaryService,
             chatSearchService,
             chatMessagePageResolver,


### PR DESCRIPTION
### 🔍 개요

* ChatService에 남아 있던 채팅방 나가기와 멤버 강퇴 명령 책임을 ChatRoomMemberCommandService로 분리합니다.
* Closes #601


---

### 🚀 주요 변경 내용

* leaveChatRoom과 kickMember 흐름을 ChatRoomMemberCommandService로 이동
* direct 나가기는 leftAt 기반 상태 변경, group 나가기는 멤버 삭제 정책 유지
* club group 나가기 거부, 비그룹 강퇴 거부, 자기 자신/방장 강퇴 거부 정책 유지


---

### 💬 참고 사항

* 검증: ChatServiceTest, ChatApiTest LeaveChatRoom/KickMember, checkstyleMain, git diff --check 통과
* 참고: checkstyleTest는 기존 테스트 파일 3개의 LineLength 12건으로 실패합니다. 이번 변경 파일의 신규 위반은 없습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)