### PR TITLE
chore: (main)배포 워크플로우에 SSM 백업 반영

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,23 +33,6 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      - name: Cache OpenTelemetry Java Agent
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/.cache/otel-java-agent
-          key: otel-agent-${{ runner.os }}-${{ vars.OTEL_JAVA_AGENT_VERSION }}-${{ vars.OTEL_JAVA_AGENT_SHA256 }}
-
-      - name: Prepare OpenTelemetry Agent
-        run: |
-          mkdir -p ~/.cache/otel-java-agent
-          if [ ! -f ~/.cache/otel-java-agent/opentelemetry-javaagent.jar ]; then
-            wget -O ~/.cache/otel-java-agent/opentelemetry-javaagent.jar \
-              "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${{ vars.OTEL_JAVA_AGENT_VERSION }}/opentelemetry-javaagent.jar"
-          fi
-          # Verify checksum
-          echo "${{ vars.OTEL_JAVA_AGENT_SHA256 }}  $HOME/.cache/otel-java-agent/opentelemetry-javaagent.jar" | sha256sum -c -
-          cp ~/.cache/otel-java-agent/opentelemetry-javaagent.jar .
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -54,7 +41,6 @@ jobs:
           set -a
           source .env.example
           set +a
-          unset JAVA_TOOL_OPTIONS
           ./gradlew bootJar -x test --build-cache -Dspring.profiles.active=prod
 
       - name: Set up Docker Buildx
@@ -85,38 +71,60 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            OTEL_JAVA_AGENT_VERSION=${{ vars.OTEL_JAVA_AGENT_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Backup prod MySQL before deploy
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.DB_SERVER_IP }}
-          username: ${{ secrets.DB_SERVER_USER }}
-          key: ${{ secrets.DB_SERVER_SSH_KEY }}
-          port: ${{ secrets.DB_SERVER_PORT }}
-          script: |
-            set -euo pipefail
-            START_TIME=$(date +%s)
-      
-            WORK_DIR="/home/ubuntu/konect/prod-db-compose"
-            MYSQL_CONTAINER="mysql-prod"
-      
-            set -a
-            source "$WORK_DIR/.env"
-            set +a
-      
-            BACKUP_DIR="$WORK_DIR/db-backups/"
-            mkdir -p "$BACKUP_DIR"
-      
-            DUMP_FILE="$BACKUP_DIR/$(date '+%Y%m%d_%H%M%S').sql"
-            docker exec -e MYSQL_PWD="$MYSQL_PASSWORD" "$MYSQL_CONTAINER" \
-              mysqldump --no-tablespaces -u"$MYSQL_USERNAME" "$MYSQL_DATABASE" > "$DUMP_FILE"
-      
-            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +5 -delete
-      
-            END_TIME=$(date +%s)
-            echo "Prod MySQL backup completed in $((END_TIME - START_TIME))s"
+        env:
+          DB_INSTANCE_ID: ${{ secrets.DB_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$DB_INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --comment "KONECT prod MySQL backup before deploy" \
+            --parameters commands='[
+              "bash -lc '\''START_TIME=$(date +%s); bash /home/ubuntu/konect/prod-db-compose/backup-db.sh; END_TIME=$(date +%s); echo \"Prod MySQL backup completed in $((END_TIME - START_TIME))s\"'\''"
+            ]' \
+            --query "Command.CommandId" \
+            --output text)
+
+          set +e
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID"
+          WAITER_EXIT=$?
+          set -e
+
+          BACKUP_STATUS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "Status" \
+            --output text)
+
+          BACKUP_STATUS_DETAILS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "StatusDetails" \
+            --output text)
+
+          BACKUP_RESPONSE_CODE=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "ResponseCode" \
+            --output text)
+
+          echo "Prod MySQL backup status: $BACKUP_STATUS (details: $BACKUP_STATUS_DETAILS, response-code: $BACKUP_RESPONSE_CODE)"
+
+          if [ "$WAITER_EXIT" -ne 0 ] || [ "$BACKUP_STATUS" != "Success" ] || [ "$BACKUP_RESPONSE_CODE" != "0" ]; then
+            echo "Prod MySQL backup failed. Remote stdout/stderr is intentionally not printed to avoid leaking sensitive information."
+            exit 1
+          fi
 
       - name: Deploy to prod server
         uses: appleboy/ssh-action@v1.2.0

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,23 +33,6 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      - name: Cache OpenTelemetry Java Agent
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/.cache/otel-java-agent
-          key: otel-agent-${{ runner.os }}-${{ vars.OTEL_JAVA_AGENT_VERSION }}-${{ vars.OTEL_JAVA_AGENT_SHA256 }}
-
-      - name: Prepare OpenTelemetry Agent
-        run: |
-          mkdir -p ~/.cache/otel-java-agent
-          if [ ! -f ~/.cache/otel-java-agent/opentelemetry-javaagent.jar ]; then
-            wget -O ~/.cache/otel-java-agent/opentelemetry-javaagent.jar \
-              "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${{ vars.OTEL_JAVA_AGENT_VERSION }}/opentelemetry-javaagent.jar"
-          fi
-          # Verify checksum
-          echo "${{ vars.OTEL_JAVA_AGENT_SHA256 }}  $HOME/.cache/otel-java-agent/opentelemetry-javaagent.jar" | sha256sum -c -
-          cp ~/.cache/otel-java-agent/opentelemetry-javaagent.jar .
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -54,7 +41,6 @@ jobs:
           set -a
           source .env.example
           set +a
-          unset JAVA_TOOL_OPTIONS
           ./gradlew bootJar -x test --build-cache -Dspring.profiles.active=stage
 
       - name: Set up Docker Buildx
@@ -85,38 +71,60 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            OTEL_JAVA_AGENT_VERSION=${{ vars.OTEL_JAVA_AGENT_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Backup stage MySQL before deploy
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.DB_SERVER_IP }}
-          username: ${{ secrets.DB_SERVER_USER }}
-          key: ${{ secrets.DB_SERVER_SSH_KEY }}
-          port: ${{ secrets.DB_SERVER_PORT }}
-          script: |
-            set -euo pipefail
-            START_TIME=$(date +%s)
-      
-            WORK_DIR="/home/ubuntu/konect/stage-db-compose"
-            MYSQL_CONTAINER="mysql-stage"
-      
-            set -a
-            source "$WORK_DIR/.env"
-            set +a
-      
-            BACKUP_DIR="$WORK_DIR/db-backups/"
-            mkdir -p "$BACKUP_DIR"
-      
-            DUMP_FILE="$BACKUP_DIR/$(date '+%Y%m%d_%H%M%S').sql"
-            docker exec -e MYSQL_PWD="$MYSQL_PASSWORD" "$MYSQL_CONTAINER" \
-              mysqldump --no-tablespaces -u"$MYSQL_USERNAME" "$MYSQL_DATABASE" > "$DUMP_FILE"
-      
-            find "$BACKUP_DIR" -type f -name '*.sql' -mtime +5 -delete
-      
-            END_TIME=$(date +%s)
-            echo "Stage MySQL backup completed in $((END_TIME - START_TIME))s"
+        env:
+          DB_INSTANCE_ID: ${{ secrets.DB_INSTANCE_ID }}
+        run: |
+          set -euo pipefail
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$DB_INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --comment "KONECT stage MySQL backup before deploy" \
+            --parameters commands='[
+              "bash -lc '\''START_TIME=$(date +%s); bash /home/ubuntu/konect/stage-db-compose/backup-db.sh; END_TIME=$(date +%s); echo \"Stage MySQL backup completed in $((END_TIME - START_TIME))s\"'\''"
+            ]' \
+            --query "Command.CommandId" \
+            --output text)
+
+          set +e
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID"
+          WAITER_EXIT=$?
+          set -e
+
+          BACKUP_STATUS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "Status" \
+            --output text)
+
+          BACKUP_STATUS_DETAILS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "StatusDetails" \
+            --output text)
+
+          BACKUP_RESPONSE_CODE=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$DB_INSTANCE_ID" \
+            --query "ResponseCode" \
+            --output text)
+
+          echo "Stage MySQL backup status: $BACKUP_STATUS (details: $BACKUP_STATUS_DETAILS, response-code: $BACKUP_RESPONSE_CODE)"
+
+          if [ "$WAITER_EXIT" -ne 0 ] || [ "$BACKUP_STATUS" != "Success" ] || [ "$BACKUP_RESPONSE_CODE" != "0" ]; then
+            echo "Stage MySQL backup failed. Remote stdout/stderr is intentionally not printed to avoid leaking sensitive information."
+            exit 1
+          fi
 
       - name: Deploy to stage server
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
### 🔍 개요

* develop에 반영된 DB 백업 SSM 전환 워크플로우를 main 브랜치에도 동일하게 반영합니다.
* prod 배포 전 DB 백업이 DB 서버 SSH 접속 대신 AWS Systems Manager Run Command로 실행되도록 맞춥니다.


---

### 🚀 주요 변경 내용

* `.github/workflows/deploy-stage.yml`
  * develop 브랜치의 SSM 기반 백업 워크플로우와 동일하게 반영했습니다.
* `.github/workflows/deploy-prod.yml`
  * GitHub OIDC 기반 AWS 자격 증명 설정을 추가했습니다.
  * prod DB 백업 단계를 SSM Run Command와 `prod-db-compose/backup-db.sh` 호출 방식으로 변경했습니다.
  * 원격 stdout/stderr 원문 대신 백업 명령 상태 요약만 Actions 로그에 출력하도록 유지했습니다.


---

### 💬 참고 사항

* GitHub Actions Secrets `AWS_ROLE_TO_ASSUME`, `AWS_REGION`, `DB_INSTANCE_ID`가 main 배포에서도 필요합니다.
* prod 배포 성공 확인 후 DB 서버 보안 그룹의 `22222/TCP 0.0.0.0/0` 규칙 제거를 진행할 수 있습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)