### PR TITLE
chore: 배포 빌드에서 Java 에이전트 옵션 추가

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,6 +41,7 @@ jobs:
           set -a
           source .env.example
           set +a
+          unset JAVA_TOOL_OPTIONS
           ./gradlew bootJar -x test --build-cache -Dspring.profiles.active=prod
 
       - name: Set up Docker Buildx

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -41,6 +41,7 @@ jobs:
           set -a
           source .env.example
           set +a
+          unset JAVA_TOOL_OPTIONS
           ./gradlew bootJar -x test --build-cache -Dspring.profiles.active=stage
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
### 🔍 개요

* main 배포 빌드에서 `.env.example`의 `JAVA_TOOL_OPTIONS`가 로드되어 GitHub Actions runner에 없는 OpenTelemetry javaagent를 참조하는 문제를 수정합니다.
* 배포 서버 런타임 설정은 유지하되, CI 빌드 단계에서는 Java agent 옵션을 제거합니다.


---

### 🚀 주요 변경 내용

* `.github/workflows/deploy-prod.yml`
  * `.env.example` 로드 후 `unset JAVA_TOOL_OPTIONS`를 추가했습니다.
* `.github/workflows/deploy-stage.yml`
  * 동일한 문제를 예방하기 위해 stage 빌드 단계에도 `unset JAVA_TOOL_OPTIONS`를 추가했습니다.


---

### 💬 참고 사항

* 이전 main 배포 실패 원인은 SSM 백업 단계가 아니라 `Build with Gradle` 단계에서 `/app/opentelemetry-javaagent.jar`를 찾지 못한 문제였습니다.
* 이 PR은 #612 merge 후 누락된 CI 빌드 안전장치만 추가합니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)