### PR TITLE
chore: develop 배포 빌드에서 Java 에이전트 옵션 제거

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,6 +41,7 @@ jobs:
           set -a
           source .env.example
           set +a
+          unset JAVA_TOOL_OPTIONS
           ./gradlew bootJar -x test --build-cache -Dspring.profiles.active=prod
 
       - name: Set up Docker Buildx

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -41,6 +41,7 @@ jobs:
           set -a
           source .env.example
           set +a
+          unset JAVA_TOOL_OPTIONS
           ./gradlew bootJar -x test --build-cache -Dspring.profiles.active=stage
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
### 🔍 개요

* develop 배포 빌드에서도 `.env.example`의 `JAVA_TOOL_OPTIONS`가 GitHub Actions runner에 없는 OpenTelemetry javaagent를 참조할 가능성을 제거합니다.
* main에 반영한 배포 빌드 안전장치를 develop에도 동일하게 맞춥니다.


---

### 🚀 주요 변경 내용

* `.github/workflows/deploy-stage.yml`
  * `.env.example` 로드 후 `unset JAVA_TOOL_OPTIONS`를 추가했습니다.
* `.github/workflows/deploy-prod.yml`
  * 동일한 문제를 예방하기 위해 prod 빌드 단계에도 `unset JAVA_TOOL_OPTIONS`를 추가했습니다.


---

### 💬 참고 사항

* 런타임 컨테이너의 Java agent 설정은 변경하지 않고, GitHub Actions 빌드 단계에서만 옵션을 제거합니다.
* main 대상 PR #613과 동일한 안전장치를 develop에도 반영하는 PR입니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [ ] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)