### PR TITLE
fix: main Docker 빌드에서 미사용 Java 에이전트 제거

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,3 @@
 !build/
 !build/libs/
 !build/libs/KONECT_API.jar
-!opentelemetry-javaagent.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN addgroup -g 1000 -S konect \
  && chmod 755 /app /app/logs
 
 COPY --chown=1000:1000 build/libs/KONECT_API.jar KONECT_API.jar
-COPY --chown=1000:1000 opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 
 USER 1000:1000
 


### PR DESCRIPTION
### 🔍 개요

* main Dockerfile에 남아 있던 미사용 OpenTelemetry javaagent 복사 설정 때문에 prod 이미지 빌드가 실패하던 문제를 수정합니다.

---

### 🚀 주요 변경 내용

* Dockerfile에서 사용하지 않는 `opentelemetry-javaagent.jar` 복사 단계를 제거했습니다.
* `.dockerignore`에서 더 이상 필요 없는 `opentelemetry-javaagent.jar` 예외를 제거했습니다.

---

### 💬 참고 사항

* 서버나 `backup-db.sh` 설정 문제가 아니라 GitHub Actions Docker build context에 해당 파일이 없어서 발생한 실패입니다.
* 수정 후 Dockerfile/.dockerignore는 develop 브랜치와 동일한 상태입니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)