### PR TITLE
fix: 예상 못한 예외의 요청 디버그 로그 정렬

### DIFF
--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -203,6 +203,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         );
 
         RUNTIME_ERROR_LOGGER.error(slackMessage);
+        requestDebugLogging(request);
 
         return buildErrorResponse(ApiResponseCode.UNEXPECTED_SERVER_ERROR);
     }
@@ -253,6 +254,10 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         String errorTraceId
     ) {
         log.warn("[{}] {} | errorTraceId={}", httpStatus, errorMessage, errorTraceId);
+        requestDebugLogging(request);
+    }
+
+    private void requestDebugLogging(HttpServletRequest request) {
         log.debug("Request: {} {}", request.getMethod(), request.getRequestURI());
         log.debug("Headers: {}", getHeaders(request));
         log.debug("Query String: {}", getQueryString(request));

--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package gg.agit.konect.global.exception;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.UUID;
 
 import org.apache.catalina.connector.ClientAbortException;
@@ -47,6 +50,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         "cookie",
         "proxy-authorization",
         "set-cookie"
+    );
+    private static final List<String> SENSITIVE_QUERY_PARAMETER_NAMES = List.of(
+        "access_token",
+        "client_secret",
+        "code",
+        "password",
+        "refresh_token",
+        "token"
     );
 
     @ExceptionHandler(CustomException.class)
@@ -301,7 +312,42 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         if (queryString == null) {
             return " - ";
         }
-        return queryString;
+        return getLoggableQueryString(queryString);
+    }
+
+    private String getLoggableQueryString(String queryString) {
+        StringJoiner loggableQueryString = new StringJoiner("&");
+        for (String parameter : queryString.split("&", -1)) {
+            loggableQueryString.add(getLoggableQueryParameter(parameter));
+        }
+        return loggableQueryString.toString();
+    }
+
+    private String getLoggableQueryParameter(String parameter) {
+        int delimiterIndex = parameter.indexOf('=');
+        String parameterName = delimiterIndex >= 0
+            ? parameter.substring(0, delimiterIndex)
+            : parameter;
+
+        if (!isSensitiveQueryParameter(parameterName)) {
+            return parameter;
+        }
+
+        return parameterName + "=" + MASKED_HEADER_VALUE;
+    }
+
+    private boolean isSensitiveQueryParameter(String parameterName) {
+        String decodedParameterName = decodeQueryParameterName(parameterName);
+        return SENSITIVE_QUERY_PARAMETER_NAMES.stream()
+            .anyMatch(sensitiveParameterName -> sensitiveParameterName.equalsIgnoreCase(decodedParameterName));
+    }
+
+    private String decodeQueryParameterName(String parameterName) {
+        try {
+            return URLDecoder.decode(parameterName, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return parameterName;
+        }
     }
 
     private String getRequestBody(HttpServletRequest request) {

--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -41,6 +41,13 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final Logger RUNTIME_ERROR_LOGGER = LoggerFactory.getLogger("runtime.error");
+    private static final String MASKED_HEADER_VALUE = "***";
+    private static final List<String> SENSITIVE_HEADER_NAMES = List.of(
+        "authorization",
+        "cookie",
+        "proxy-authorization",
+        "set-cookie"
+    );
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<Object> handleCustomException(
@@ -258,20 +265,35 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     private void requestDebugLogging(HttpServletRequest request) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
         log.debug("Request: {} {}", request.getMethod(), request.getRequestURI());
-        log.debug("Headers: {}", getHeaders(request));
+        log.debug("Headers: {}", getLoggableHeaders(request));
         log.debug("Query String: {}", getQueryString(request));
         log.debug("Body: {}", getRequestBody(request));
     }
 
-    private Map<String, Object> getHeaders(HttpServletRequest request) {
+    private Map<String, Object> getLoggableHeaders(HttpServletRequest request) {
         Map<String, Object> headerMap = new HashMap<>();
         Enumeration<String> headerArray = request.getHeaderNames();
         while (headerArray.hasMoreElements()) {
             String headerName = headerArray.nextElement();
-            headerMap.put(headerName, request.getHeader(headerName));
+            headerMap.put(headerName, getLoggableHeaderValue(request, headerName));
         }
         return headerMap;
+    }
+
+    private String getLoggableHeaderValue(HttpServletRequest request, String headerName) {
+        if (isSensitiveHeader(headerName)) {
+            return MASKED_HEADER_VALUE;
+        }
+        return request.getHeader(headerName);
+    }
+
+    private boolean isSensitiveHeader(String headerName) {
+        return SENSITIVE_HEADER_NAMES.stream()
+            .anyMatch(sensitiveHeaderName -> sensitiveHeaderName.equalsIgnoreCase(headerName));
     }
 
     private String getQueryString(HttpServletRequest httpRequest) {

--- a/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
@@ -46,6 +46,10 @@ class GlobalExceptionHandlerTest {
         request.addHeader("Authorization", "Bearer secret-token");
         request.addHeader("Cookie", "session=secret-cookie");
         request.addHeader("X-Request-ID", "request-1");
+        request.setQueryString(
+            "access%5Ftoken=encoded-query-secret&access_token=query-secret&code=oauth-code&name=KONECT"
+                + "&token=repeat-secret-one&token=repeat-secret-two"
+        );
         request.setContent("""
             {"name":"KONECT"}
             """.getBytes());
@@ -63,6 +67,14 @@ class GlobalExceptionHandlerTest {
             .contains("X-Request-ID=request-1")
             .doesNotContain("secret-token")
             .doesNotContain("secret-cookie")
+            .contains(
+                "Query String: access%5Ftoken=***&access_token=***&code=***&name=KONECT&token=***&token=***"
+            )
+            .doesNotContain("encoded-query-secret")
+            .doesNotContain("query-secret")
+            .doesNotContain("oauth-code")
+            .doesNotContain("repeat-secret-one")
+            .doesNotContain("repeat-secret-two")
             .contains("Body: {\"name\":\"KONECT\"}");
     }
 

--- a/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,60 @@
+package gg.agit.konect.unit.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+
+import gg.agit.konect.global.exception.GlobalExceptionHandler;
+
+@ExtendWith(OutputCaptureExtension.class)
+class GlobalExceptionHandlerTest {
+
+    private final Logger exceptionHandlerLogger = (Logger)LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private Level originalLevel;
+
+    @BeforeEach
+    void setUp() {
+        originalLevel = exceptionHandlerLogger.getLevel();
+        exceptionHandlerLogger.setLevel(Level.DEBUG);
+    }
+
+    @AfterEach
+    void tearDown() {
+        exceptionHandlerLogger.setLevel(originalLevel);
+    }
+
+    @Test
+    @DisplayName("예상하지 못한 예외도 디버그 로그에서 요청 본문을 확인할 수 있다")
+    void logsRequestBodyAtDebugLevelForUnexpectedException(CapturedOutput output) {
+        // given
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/clubs");
+        request.setContentType("application/json");
+        request.setContent("""
+            {"name":"KONECT"}
+            """.getBytes());
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+
+        // when
+        var response = handler.handleException(wrappedRequest, new RuntimeException("boom"));
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(output)
+            .contains("Request: POST /clubs")
+            .contains("Body: {\"name\":\"KONECT\"}");
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
@@ -43,6 +43,9 @@ class GlobalExceptionHandlerTest {
         GlobalExceptionHandler handler = new GlobalExceptionHandler();
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/clubs");
         request.setContentType("application/json");
+        request.addHeader("Authorization", "Bearer secret-token");
+        request.addHeader("Cookie", "session=secret-cookie");
+        request.addHeader("X-Request-ID", "request-1");
         request.setContent("""
             {"name":"KONECT"}
             """.getBytes());
@@ -55,6 +58,34 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(output)
             .contains("Request: POST /clubs")
+            .contains("Authorization=***")
+            .contains("Cookie=***")
+            .contains("X-Request-ID=request-1")
+            .doesNotContain("secret-token")
+            .doesNotContain("secret-cookie")
             .contains("Body: {\"name\":\"KONECT\"}");
+    }
+
+    @Test
+    @DisplayName("DEBUG 로그가 꺼져 있으면 요청 상세 정보를 계산하지 않는다")
+    void skipsRequestDetailLoggingWhenDebugIsDisabled(CapturedOutput output) {
+        // given
+        exceptionHandlerLogger.setLevel(Level.INFO);
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/clubs");
+        request.setContentType("application/json");
+        request.setContent("""
+            {"name":"KONECT"}
+            """.getBytes());
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+
+        // when
+        var response = handler.handleException(wrappedRequest, new RuntimeException("boom"));
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(output)
+            .doesNotContain("Request: POST /clubs")
+            .doesNotContain("Body: {\"name\":\"KONECT\"}");
     }
 }


### PR DESCRIPTION
### 🔍 개요

* 예상하지 못한 `Exception` 처리 경로에서도 요청 메타 정보와 본문을 DEBUG 로그에서 확인할 수 있도록 예외 로깅 흐름을 정렬합니다.
* 성능 개선 상위 이슈 BCSDLab/KONECT_BACK_END#445의 하위 작업입니다. Closes BCSDLab/KONECT_BACK_END#616


---

### 🚀 주요 변경 내용

* `handleException(HttpServletRequest, Exception)`에서 ERROR/Slack 로그와 별도로 요청 DEBUG 로그를 남기도록 변경했습니다.
* 기존 `CustomException` 계열 요청 로그와 동일하게 method, header, query string, body 확인 경로를 재사용합니다.
* 요청 body는 ERROR/Slack 메시지에는 포함하지 않고 DEBUG 로그에만 남기도록 범위를 제한했습니다.
* 예상하지 못한 예외에서도 request body가 DEBUG 로그에 남는지 단위 테스트를 추가했습니다.


---

### 💬 참고 사항

* 검증: `CI=true ./gradlew test --tests 'gg.agit.konect.unit.global.exception.GlobalExceptionHandlerTest' --rerun-tasks`
* 검증: `CI=true ./gradlew checkstyleMain`
* 참고: `CI=true ./gradlew checkstyleTest`는 기존 `ClubMemberManagementServiceTest`, `NotificationInboxServiceTest`, `ChatApiTest`의 line length 위반으로 실패했습니다. 이번 변경 파일의 위반은 아닙니다.
* 푸시 전 hook에서 `checkstyleMain`과 `compileJava`는 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---