### PR TITLE
feat: GROUP 채팅방 멤버 초대 API 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
@@ -296,12 +296,12 @@ public interface ChatApi {
     @Operation(summary = "채팅방 멤버 목록 조회", description = """
         ## 설명
         - 특정 채팅방의 모든 멤버 목록을 조회합니다.
-
+        
         ## 로직
         - 채팅방에 참여 중인 멤버만 조회할 수 있습니다.
         - 나간 멤버(leftAt이 설정된 멤버)는 목록에 포함되지 않습니다.
         - 각 멤버의 userId, 이름, 프로필 이미지, 방장 여부, 참여 시간을 반환합니다.
-
+        
         ## 에러
         - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다.
         - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다.

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatApi.java
@@ -16,6 +16,7 @@ import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersInviteRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomMembersResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
@@ -249,6 +250,28 @@ public interface ChatApi {
     ResponseEntity<Void> kickMember(
         @PathVariable(value = "chatRoomId") Integer chatRoomId,
         @PathVariable(value = "targetUserId") Integer targetUserId,
+        @UserId Integer userId
+    );
+
+    @Operation(summary = "그룹 채팅방에 멤버를 초대한다.", description = """
+        ## 설명
+        - 일반 그룹 채팅방의 기존 멤버가 여러 유저를 추가 초대합니다.
+        
+        ## 로직
+        - 방장 여부와 관계없이 현재 참여 중인 멤버라면 초대할 수 있습니다.
+        - 1:1 채팅방과 동아리 채팅방에는 초대할 수 없습니다.
+        - 이미 참여 중인 멤버, 요청자 자신, 중복 userId는 무시합니다.
+        
+        ## 에러
+        - NOT_FOUND_CHAT_ROOM (404): 채팅방을 찾을 수 없습니다.
+        - FORBIDDEN_CHAT_ROOM_ACCESS (403): 채팅방에 접근할 권한이 없습니다.
+        - CANNOT_INVITE_IN_NON_GROUP_ROOM (400): 일반 그룹 채팅방에서만 초대할 수 있습니다.
+        - NOT_FOUND_USER (404): 유저를 찾을 수 없습니다.
+        """)
+    @PostMapping("/rooms/{chatRoomId}/members")
+    ResponseEntity<Void> inviteMembers(
+        @PathVariable(value = "chatRoomId") Integer chatRoomId,
+        @Valid @RequestBody ChatRoomMembersInviteRequest request,
         @UserId Integer userId
     );
 

--- a/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
+++ b/src/main/java/gg/agit/konect/domain/chat/controller/ChatController.java
@@ -15,6 +15,7 @@ import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersInviteRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomMembersResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
@@ -140,6 +141,16 @@ public class ChatController implements ChatApi {
         @UserId Integer userId
     ) {
         chatService.kickMember(userId, chatRoomId, targetUserId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> inviteMembers(
+        @PathVariable(value = "chatRoomId") Integer chatRoomId,
+        @Valid @RequestBody ChatRoomMembersInviteRequest request,
+        @UserId Integer userId
+    ) {
+        chatService.inviteMembers(userId, chatRoomId, request);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMembersInviteRequest.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMembersInviteRequest.java
@@ -1,0 +1,15 @@
+package gg.agit.konect.domain.chat.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record ChatRoomMembersInviteRequest(
+    @NotEmpty(message = "초대할 유저 ID 목록은 필수입니다.")
+    @Schema(description = "초대할 유저 ID 목록", example = "[10, 11, 12]", requiredMode = REQUIRED)
+    List<Integer> userIds
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMembersInviteRequest.java
+++ b/src/main/java/gg/agit/konect/domain/chat/dto/ChatRoomMembersInviteRequest.java
@@ -6,10 +6,11 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record ChatRoomMembersInviteRequest(
     @NotEmpty(message = "초대할 유저 ID 목록은 필수입니다.")
     @Schema(description = "초대할 유저 ID 목록", example = "[10, 11, 12]", requiredMode = REQUIRED)
-    List<Integer> userIds
+    List<@NotNull Integer> userIds
 ) {
 }

--- a/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/gg/agit/konect/domain/chat/repository/ChatRoomMemberRepository.java
@@ -133,6 +133,18 @@ public interface ChatRoomMemberRepository extends Repository<ChatRoomMember, Cha
     );
 
     @Query("""
+        SELECT crm.id.userId
+        FROM ChatRoomMember crm
+        WHERE crm.id.chatRoomId = :chatRoomId
+          AND crm.id.userId IN :userIds
+          AND crm.leftAt IS NULL
+        """)
+    List<Integer> findActiveUserIdsByChatRoomIdAndUserIdIn(
+        @Param("chatRoomId") Integer chatRoomId,
+        @Param("userIds") List<Integer> userIds
+    );
+
+    @Query("""
         SELECT crm
         FROM ChatRoomMember crm
         JOIN FETCH crm.user

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
@@ -11,7 +11,9 @@ import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -83,10 +85,13 @@ public class ChatRoomMemberCommandService {
             throw CustomException.of(NOT_FOUND_USER);
         }
 
+        Set<Integer> existingActiveUserIds = new LinkedHashSet<>(
+            chatRoomMemberRepository.findActiveUserIdsByChatRoomIdAndUserIdIn(roomId, requestedUserIds)
+        );
         LocalDateTime joinedAt = LocalDateTime.now();
         requestedUsers.stream()
             .filter(user -> !user.getId().equals(requesterId))
-            .filter(user -> !chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, user.getId()))
+            .filter(user -> !existingActiveUserIds.contains(user.getId()))
             .forEach(user -> chatRoomMembershipService.ensureMember(room, user, joinedAt));
     }
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
@@ -11,9 +11,7 @@ import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,8 +75,10 @@ public class ChatRoomMemberCommandService {
         validateGroupRoomForInvite(room);
         validateActiveRequester(roomId, requesterId);
 
-        Set<Integer> requestedUserIds = new LinkedHashSet<>(userIds);
-        List<User> requestedUsers = userRepository.findAllByIdIn(List.copyOf(requestedUserIds));
+        List<Integer> requestedUserIds = userIds.stream()
+            .distinct()
+            .toList();
+        List<User> requestedUsers = userRepository.findAllByIdIn(requestedUserIds);
         if (requestedUsers.size() != requestedUserIds.size()) {
             throw CustomException.of(NOT_FOUND_USER);
         }

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
@@ -11,7 +11,6 @@ import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -77,16 +76,16 @@ public class ChatRoomMemberCommandService {
         validateGroupRoomForInvite(room);
         validateActiveRequester(roomId, requesterId);
 
-        List<Integer> requestedUserIds = userIds.stream()
+        List<Integer> distinctUserIds = userIds.stream()
             .distinct()
             .toList();
-        List<User> requestedUsers = userRepository.findAllByIdIn(requestedUserIds);
-        if (requestedUsers.size() != requestedUserIds.size()) {
+        List<User> requestedUsers = userRepository.findAllByIdIn(distinctUserIds);
+        if (requestedUsers.size() != distinctUserIds.size()) {
             throw CustomException.of(NOT_FOUND_USER);
         }
 
-        Set<Integer> existingActiveUserIds = new LinkedHashSet<>(
-            chatRoomMemberRepository.findActiveUserIdsByChatRoomIdAndUserIdIn(roomId, requestedUserIds)
+        Set<Integer> existingActiveUserIds = Set.copyOf(
+            chatRoomMemberRepository.findActiveUserIdsByChatRoomIdAndUserIdIn(roomId, distinctUserIds)
         );
         LocalDateTime joinedAt = LocalDateTime.now();
         requestedUsers.stream()

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatRoomMemberCommandService.java
@@ -3,11 +3,17 @@ package gg.agit.konect.domain.chat.service;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_IN_NON_GROUP_ROOM;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_ROOM_OWNER;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_KICK_SELF;
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_INVITE_IN_NON_GROUP_ROOM;
 import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_LEAVE_GROUP_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
 import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_KICK;
 import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CHAT_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +22,8 @@ import gg.agit.konect.domain.chat.model.ChatRoom;
 import gg.agit.konect.domain.chat.model.ChatRoomMember;
 import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
 import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
 import gg.agit.konect.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +34,8 @@ public class ChatRoomMemberCommandService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomMembershipService chatRoomMembershipService;
 
     public void leaveChatRoom(Integer userId, Integer roomId) {
         ChatRoom room = chatRoomRepository.findById(roomId)
@@ -60,6 +70,26 @@ public class ChatRoomMemberCommandService {
         chatRoomMemberRepository.deleteByChatRoomIdAndUserId(roomId, targetUserId);
     }
 
+    public void inviteMembers(Integer requesterId, Integer roomId, List<Integer> userIds) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CHAT_ROOM));
+
+        validateGroupRoomForInvite(room);
+        validateActiveRequester(roomId, requesterId);
+
+        Set<Integer> requestedUserIds = new LinkedHashSet<>(userIds);
+        List<User> requestedUsers = userRepository.findAllByIdIn(List.copyOf(requestedUserIds));
+        if (requestedUsers.size() != requestedUserIds.size()) {
+            throw CustomException.of(NOT_FOUND_USER);
+        }
+
+        LocalDateTime joinedAt = LocalDateTime.now();
+        requestedUsers.stream()
+            .filter(user -> !user.getId().equals(requesterId))
+            .filter(user -> !chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, user.getId()))
+            .forEach(user -> chatRoomMembershipService.ensureMember(room, user, joinedAt));
+    }
+
     private ChatRoomMember getRoomMember(Integer roomId, Integer userId) {
         return ChatRoomMemberLookup.getRoomMember(chatRoomMemberRepository, roomId, userId);
     }
@@ -67,6 +97,18 @@ public class ChatRoomMemberCommandService {
     private void validateGroupRoomForKick(ChatRoom room) {
         if (!room.isGroupRoom() || room.isClubGroupRoom()) {
             throw CustomException.of(CANNOT_KICK_IN_NON_GROUP_ROOM);
+        }
+    }
+
+    private void validateGroupRoomForInvite(ChatRoom room) {
+        if (!room.isGroupRoom() || room.isClubGroupRoom()) {
+            throw CustomException.of(CANNOT_INVITE_IN_NON_GROUP_ROOM);
+        }
+    }
+
+    private void validateActiveRequester(Integer roomId, Integer requesterId) {
+        if (!chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, requesterId)) {
+            throw CustomException.of(FORBIDDEN_CHAT_ROOM_ACCESS);
         }
     }
 

--- a/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
+++ b/src/main/java/gg/agit/konect/domain/chat/service/ChatService.java
@@ -23,6 +23,7 @@ import gg.agit.konect.domain.chat.dto.ChatMessagePageResponse;
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatMuteResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersInviteRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomResponse;
 import gg.agit.konect.domain.chat.dto.ChatRoomSummaryResponse;
@@ -103,6 +104,11 @@ public class ChatService {
     @Transactional
     public void kickMember(Integer requesterId, Integer roomId, Integer targetUserId) {
         chatRoomMemberCommandService.kickMember(requesterId, roomId, targetUserId);
+    }
+
+    @Transactional
+    public void inviteMembers(Integer requesterId, Integer roomId, ChatRoomMembersInviteRequest request) {
+        chatRoomMemberCommandService.inviteMembers(requesterId, roomId, request.userIds());
     }
 
     public ChatRoomsSummaryResponse getChatRooms(Integer userId) {

--- a/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
+++ b/src/main/java/gg/agit/konect/global/code/ApiResponseCode.java
@@ -25,6 +25,7 @@ public enum ApiResponseCode {
     CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST, "자기 자신을 강퇴할 수 없습니다."),
     CANNOT_KICK_ROOM_OWNER(HttpStatus.BAD_REQUEST, "방장은 강퇴할 수 없습니다."),
     CANNOT_KICK_IN_NON_GROUP_ROOM(HttpStatus.BAD_REQUEST, "그룹 채팅방에서만 강퇴할 수 있습니다."),
+    CANNOT_INVITE_IN_NON_GROUP_ROOM(HttpStatus.BAD_REQUEST, "일반 그룹 채팅방에서만 초대할 수 있습니다."),
     INVALID_CHAT_ROOM_CREATE_REQUEST(HttpStatus.BAD_REQUEST, "clubId 또는 targetUserId 중 하나만 전달해야 합니다."),
     CANNOT_CHANGE_OWN_POSITION(HttpStatus.BAD_REQUEST, "자기 자신의 직책은 변경할 수 없습니다."),
     CANNOT_DELETE_CLUB_PRESIDENT(HttpStatus.BAD_REQUEST, "동아리 회장인 경우 회장을 양도하고 탈퇴해야 합니다."),

--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -1729,6 +1729,21 @@ class ChatApiTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("userIds에 null이 포함되면 validation 에러를 반환한다")
+        void inviteMembersWithNullUserIdFails() throws Exception {
+            mockLoginUser(memberUser.getId());
+            List<Integer> userIds = new ArrayList<>();
+            userIds.add(null);
+
+            performPost(
+                "/chats/rooms/" + groupRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(userIds)
+            )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST_BODY"));
+        }
+
+        @Test
         @DisplayName("이미 참여 중인 멤버와 자기 자신과 중복 userId는 무시한다")
         void inviteMembersIgnoresExistingSelfAndDuplicateUsers() throws Exception {
             mockLoginUser(memberUser.getId());

--- a/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/chat/ChatApiTest.java
@@ -32,6 +32,7 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import gg.agit.konect.domain.chat.dto.ChatMessageSendRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomCreateRequest;
+import gg.agit.konect.domain.chat.dto.ChatRoomMembersInviteRequest;
 import gg.agit.konect.domain.chat.dto.ChatRoomNameUpdateRequest;
 import gg.agit.konect.domain.chat.enums.ChatType;
 import gg.agit.konect.domain.chat.model.ChatMessage;
@@ -1602,6 +1603,151 @@ class ChatApiTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.senderName").value(normalUser.getName()))
                 .andExpect(jsonPath("$.content").value("그룹방 첫 메시지"))
                 .andExpect(jsonPath("$.isMine").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /chats/rooms/{chatRoomId}/members - 그룹 채팅방 멤버 초대")
+    class InviteMembers {
+
+        private User ownerUser;
+        private User memberUser;
+        private User newMemberA;
+        private User newMemberB;
+        private ChatRoom groupRoom;
+
+        @BeforeEach
+        void setUpInviteFixture() {
+            ownerUser = createUser("초대방장", "2021136101");
+            memberUser = createUser("초대멤버", "2021136102");
+            newMemberA = createUser("새멤버A", "2021136103");
+            newMemberB = createUser("새멤버B", "2021136104");
+            groupRoom = createGroupChatRoomWithOwner(ownerUser, memberUser);
+            clearPersistenceContext();
+        }
+
+        @Test
+        @DisplayName("GROUP active 멤버가 여러 명을 초대한다")
+        void inviteMembersSuccess() throws Exception {
+            mockLoginUser(memberUser.getId());
+
+            performPost(
+                "/chats/rooms/" + groupRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(List.of(newMemberA.getId(), newMemberB.getId()))
+            )
+                .andExpect(status().isNoContent());
+
+            clearPersistenceContext();
+            assertThat(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId()))
+                .extracting(ChatRoomMember::getUserId)
+                .containsExactlyInAnyOrder(
+                    ownerUser.getId(),
+                    memberUser.getId(),
+                    newMemberA.getId(),
+                    newMemberB.getId()
+                );
+        }
+
+        @Test
+        @DisplayName("방장이 아닌 active 멤버도 초대할 수 있다")
+        void nonOwnerMemberCanInviteMembers() throws Exception {
+            mockLoginUser(memberUser.getId());
+
+            performPost(
+                "/chats/rooms/" + groupRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(List.of(newMemberA.getId()))
+            )
+                .andExpect(status().isNoContent());
+
+            clearPersistenceContext();
+            ChatRoomMember invitedMember = chatRoomMemberRepository
+                .findByChatRoomIdAndUserId(groupRoom.getId(), newMemberA.getId())
+                .orElseThrow();
+            assertThat(invitedMember.isOwner()).isFalse();
+        }
+
+        @Test
+        @DisplayName("채팅방 멤버가 아니면 초대할 수 없다")
+        void inviteMembersByOutsiderFails() throws Exception {
+            User outsider = createUser("외부사용자", "2021136105");
+            mockLoginUser(outsider.getId());
+
+            performPost(
+                "/chats/rooms/" + groupRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(List.of(newMemberA.getId()))
+            )
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN_CHAT_ROOM_ACCESS"));
+        }
+
+        @Test
+        @DisplayName("DIRECT 채팅방에는 멤버를 초대할 수 없다")
+        void inviteMembersToDirectRoomFails() throws Exception {
+            ChatRoom directRoom = createDirectChatRoom(ownerUser, memberUser);
+            mockLoginUser(ownerUser.getId());
+
+            performPost(
+                "/chats/rooms/" + directRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(List.of(newMemberA.getId()))
+            )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("CANNOT_INVITE_IN_NON_GROUP_ROOM"));
+        }
+
+        @Test
+        @DisplayName("CLUB_GROUP 채팅방에는 멤버를 초대할 수 없다")
+        void inviteMembersToClubGroupRoomFails() throws Exception {
+            Club inviteClub = persist(ClubFixture.create(university, "초대 테스트 동아리"));
+            ChatRoom clubGroupRoom = persist(ChatRoom.clubGroupOf(inviteClub));
+            addRoomMember(clubGroupRoom, ownerUser);
+            mockLoginUser(ownerUser.getId());
+
+            performPost(
+                "/chats/rooms/" + clubGroupRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(List.of(newMemberA.getId()))
+            )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("CANNOT_INVITE_IN_NON_GROUP_ROOM"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId가 포함되면 전체 요청을 실패시킨다")
+        void inviteMembersWithMissingUserFails() throws Exception {
+            mockLoginUser(memberUser.getId());
+
+            performPost(
+                "/chats/rooms/" + groupRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(List.of(newMemberA.getId(), 99999))
+            )
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND_USER"));
+
+            clearPersistenceContext();
+            assertThat(chatRoomMemberRepository.findByChatRoomIdAndUserId(
+                groupRoom.getId(), newMemberA.getId()
+            )).isEmpty();
+        }
+
+        @Test
+        @DisplayName("이미 참여 중인 멤버와 자기 자신과 중복 userId는 무시한다")
+        void inviteMembersIgnoresExistingSelfAndDuplicateUsers() throws Exception {
+            mockLoginUser(memberUser.getId());
+
+            performPost(
+                "/chats/rooms/" + groupRoom.getId() + "/members",
+                new ChatRoomMembersInviteRequest(List.of(
+                    memberUser.getId(),
+                    ownerUser.getId(),
+                    newMemberA.getId(),
+                    newMemberA.getId()
+                ))
+            )
+                .andExpect(status().isNoContent());
+
+            clearPersistenceContext();
+            assertThat(chatRoomMemberRepository.findByChatRoomId(groupRoom.getId()))
+                .extracting(ChatRoomMember::getUserId)
+                .containsExactlyInAnyOrder(ownerUser.getId(), memberUser.getId(), newMemberA.getId());
         }
     }
 

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMemberCommandServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMemberCommandServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
@@ -34,6 +35,7 @@ import gg.agit.konect.domain.user.repository.UserRepository;
 import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
 import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.ClubFixture;
 import gg.agit.konect.support.fixture.UniversityFixture;
 import gg.agit.konect.support.fixture.UserFixture;
 
@@ -69,10 +71,10 @@ class ChatRoomMemberCommandServiceTest extends ServiceTestSupport {
         given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, requesterId)).willReturn(true);
         given(userRepository.findAllByIdIn(List.of(requesterId, existingMember.getId(), newMember.getId())))
             .willReturn(List.of(requester, existingMember, newMember));
-        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, existingMember.getId()))
-            .willReturn(true);
-        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, newMember.getId()))
-            .willReturn(false);
+        given(chatRoomMemberRepository.findActiveUserIdsByChatRoomIdAndUserIdIn(
+            roomId,
+            List.of(requesterId, existingMember.getId(), newMember.getId())
+        )).willReturn(List.of(requesterId, existingMember.getId()));
 
         // when
         chatRoomMemberCommandService.inviteMembers(
@@ -82,7 +84,8 @@ class ChatRoomMemberCommandServiceTest extends ServiceTestSupport {
         );
 
         // then
-        verify(chatRoomMembershipService).ensureMember(eq(room), eq(newMember), any(LocalDateTime.class));
+        verify(chatRoomMembershipService, times(1))
+            .ensureMember(eq(room), eq(newMember), any(LocalDateTime.class));
         verify(chatRoomMembershipService, never()).ensureMember(eq(room), eq(requester), any(LocalDateTime.class));
         verify(chatRoomMembershipService, never()).ensureMember(eq(room), eq(existingMember), any(LocalDateTime.class));
     }
@@ -93,6 +96,23 @@ class ChatRoomMemberCommandServiceTest extends ServiceTestSupport {
         // given
         Integer roomId = 10;
         ChatRoom room = createRoom(roomId, ChatType.DIRECT);
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+
+        // when & then
+        assertErrorCode(
+            () -> chatRoomMemberCommandService.inviteMembers(100, roomId, List.of(200)),
+            CANNOT_INVITE_IN_NON_GROUP_ROOM
+        );
+
+        verify(userRepository, never()).findAllByIdIn(any());
+    }
+
+    @Test
+    @DisplayName("CLUB_GROUP 채팅방에는 초대할 수 없다")
+    void inviteMembersToClubGroupRoomFails() {
+        // given
+        Integer roomId = 10;
+        ChatRoom room = createRoom(roomId, ChatType.CLUB_GROUP);
         given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
 
         // when & then
@@ -149,7 +169,9 @@ class ChatRoomMemberCommandServiceTest extends ServiceTestSupport {
         ChatRoom room = switch (type) {
             case DIRECT -> ChatRoom.directOf();
             case GROUP -> ChatRoom.groupOf();
-            case CLUB_GROUP -> throw new IllegalArgumentException("Use fixture for CLUB_GROUP");
+            case CLUB_GROUP -> ChatRoom.clubGroupOf(
+                ClubFixture.createWithId(UniversityFixture.createWithId(1), 77, "BCSD")
+            );
         };
         ReflectionTestUtils.setField(room, "id", id);
         return room;

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMemberCommandServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMemberCommandServiceTest.java
@@ -1,0 +1,170 @@
+package gg.agit.konect.unit.domain.chat.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.CANNOT_INVITE_IN_NON_GROUP_ROOM;
+import static gg.agit.konect.global.code.ApiResponseCode.FORBIDDEN_CHAT_ROOM_ACCESS;
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import gg.agit.konect.domain.chat.enums.ChatType;
+import gg.agit.konect.domain.chat.model.ChatRoom;
+import gg.agit.konect.domain.chat.repository.ChatRoomMemberRepository;
+import gg.agit.konect.domain.chat.repository.ChatRoomRepository;
+import gg.agit.konect.domain.chat.service.ChatRoomMemberCommandService;
+import gg.agit.konect.domain.chat.service.ChatRoomMembershipService;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.domain.user.repository.UserRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.support.ServiceTestSupport;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class ChatRoomMemberCommandServiceTest extends ServiceTestSupport {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatRoomMembershipService chatRoomMembershipService;
+
+    @InjectMocks
+    private ChatRoomMemberCommandService chatRoomMemberCommandService;
+
+    @Test
+    @DisplayName("초대 요청은 중복 userId와 요청자 자신과 기존 멤버를 제외하고 새 멤버만 추가한다")
+    void inviteMembersAddsOnlyNewUsers() {
+        // given
+        Integer roomId = 10;
+        Integer requesterId = 100;
+        User requester = createUser(requesterId, "요청자");
+        User existingMember = createUser(200, "기존멤버");
+        User newMember = createUser(300, "새멤버");
+        ChatRoom room = createRoom(roomId, ChatType.GROUP);
+
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, requesterId)).willReturn(true);
+        given(userRepository.findAllByIdIn(List.of(requesterId, existingMember.getId(), newMember.getId())))
+            .willReturn(List.of(requester, existingMember, newMember));
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, existingMember.getId()))
+            .willReturn(true);
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, newMember.getId()))
+            .willReturn(false);
+
+        // when
+        chatRoomMemberCommandService.inviteMembers(
+            requesterId,
+            roomId,
+            List.of(requesterId, existingMember.getId(), newMember.getId(), newMember.getId())
+        );
+
+        // then
+        verify(chatRoomMembershipService).ensureMember(any(ChatRoom.class), any(User.class), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("일반 GROUP이 아니면 초대할 수 없다")
+    void inviteMembersToNonGroupRoomFails() {
+        // given
+        Integer roomId = 10;
+        ChatRoom room = createRoom(roomId, ChatType.DIRECT);
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+
+        // when & then
+        assertErrorCode(
+            () -> chatRoomMemberCommandService.inviteMembers(100, roomId, List.of(200)),
+            CANNOT_INVITE_IN_NON_GROUP_ROOM
+        );
+
+        verify(userRepository, never()).findAllByIdIn(any());
+    }
+
+    @Test
+    @DisplayName("요청자가 active 멤버가 아니면 초대할 수 없다")
+    void inviteMembersByInactiveRequesterFails() {
+        // given
+        Integer roomId = 10;
+        Integer requesterId = 100;
+        ChatRoom room = createRoom(roomId, ChatType.GROUP);
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, requesterId)).willReturn(false);
+
+        // when & then
+        assertErrorCode(
+            () -> chatRoomMemberCommandService.inviteMembers(requesterId, roomId, List.of(200)),
+            FORBIDDEN_CHAT_ROOM_ACCESS
+        );
+
+        verify(userRepository, never()).findAllByIdIn(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 있으면 전체 요청을 실패시킨다")
+    void inviteMembersWithMissingUserFails() {
+        // given
+        Integer roomId = 10;
+        Integer requesterId = 100;
+        ChatRoom room = createRoom(roomId, ChatType.GROUP);
+        User foundUser = createUser(200, "존재사용자");
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(room));
+        given(chatRoomMemberRepository.existsActiveByChatRoomIdAndUserId(roomId, requesterId)).willReturn(true);
+        given(userRepository.findAllByIdIn(List.of(foundUser.getId(), 99999)))
+            .willReturn(List.of(foundUser));
+
+        // when & then
+        assertErrorCode(
+            () -> chatRoomMemberCommandService.inviteMembers(requesterId, roomId, List.of(foundUser.getId(), 99999)),
+            NOT_FOUND_USER
+        );
+
+        verify(chatRoomMembershipService, never()).ensureMember(any(), any(), any());
+    }
+
+    private ChatRoom createRoom(Integer id, ChatType type) {
+        ChatRoom room = switch (type) {
+            case DIRECT -> ChatRoom.directOf();
+            case GROUP -> ChatRoom.groupOf();
+            case CLUB_GROUP -> throw new IllegalArgumentException("Use fixture for CLUB_GROUP");
+        };
+        ReflectionTestUtils.setField(room, "id", id);
+        return room;
+    }
+
+    private User createUser(Integer id, String name) {
+        return UserFixture.createUserWithId(
+            UniversityFixture.create(),
+            id,
+            name,
+            "2024" + String.format("%04d", id),
+            UserRole.USER
+        );
+    }
+
+    private void assertErrorCode(ThrowingCallable callable, ApiResponseCode errorCode) {
+        assertThatThrownBy(callable)
+            .isInstanceOf(CustomException.class)
+            .satisfies(exception -> assertThat(((CustomException)exception).getErrorCode()).isEqualTo(errorCode));
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMemberCommandServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatRoomMemberCommandServiceTest.java
@@ -6,6 +6,7 @@ import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -81,7 +82,9 @@ class ChatRoomMemberCommandServiceTest extends ServiceTestSupport {
         );
 
         // then
-        verify(chatRoomMembershipService).ensureMember(any(ChatRoom.class), any(User.class), any(LocalDateTime.class));
+        verify(chatRoomMembershipService).ensureMember(eq(room), eq(newMember), any(LocalDateTime.class));
+        verify(chatRoomMembershipService, never()).ensureMember(eq(room), eq(requester), any(LocalDateTime.class));
+        verify(chatRoomMembershipService, never()).ensureMember(eq(room), eq(existingMember), any(LocalDateTime.class));
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/chat/service/ChatServiceTest.java
@@ -152,7 +152,9 @@ class ChatServiceTest extends ServiceTestSupport {
         );
         ChatRoomMemberCommandService chatRoomMemberCommandService = new ChatRoomMemberCommandService(
             chatRoomRepository,
-            chatRoomMemberRepository
+            chatRoomMemberRepository,
+            userRepository,
+            chatRoomMembershipService
         );
         ChatRoomMembershipService chatRoomMembershipForCreation = new ChatRoomMembershipService(
             chatRoomRepository,


### PR DESCRIPTION
### 🔍 개요

* 기존 GROUP 채팅방에 멤버를 추가로 초대할 수 있는 API를 추가했습니다.
* 방장 여부와 관계없이 GROUP 채팅방의 active 멤버라면 여러 사용자를 한 번에 초대할 수 있습니다.


---

### 🚀 주요 변경 내용

* `POST /chats/rooms/{chatRoomId}/members` 엔드포인트와 요청 DTO를 추가했습니다.
* 일반 GROUP 채팅방만 초대 대상이 되도록 하고, DIRECT / CLUB_GROUP은 초대를 차단했습니다.
* 요청자 자신, 이미 참여 중인 멤버, 중복 userId는 무시해 중복 멤버십 row가 생기지 않도록 했습니다.
* 존재하지 않는 userId가 포함되면 전체 요청이 실패하도록 처리했습니다.
* 통합 테스트와 command service 단위 테스트로 성공/권한/타입/누락 사용자/중복 입력 케이스를 검증했습니다.


---

### 💬 참고 사항

* Closes BCSDLab/KONECT_BACK_END#618
* 검증 완료: `CI=true ./gradlew test --tests 'gg.agit.konect.integration.domain.chat.ChatApiTest$InviteMembers' --tests 'gg.agit.konect.unit.domain.chat.service.ChatRoomMemberCommandServiceTest' --rerun-tasks`
* push 전 hook에서 `checkstyleMain`과 `compileJava`가 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)