### PR TITLE
fix: 요청 로그 매칭을 위해 requestId를 명시

### DIFF
--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -205,11 +205,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleException(HttpServletRequest request, Exception e) {
-        StackTraceElement origin = e.getStackTrace()[0];
-
         String uri = String.format("%s %s", request.getMethod(), request.getRequestURI());
         String exception = e.getClass().getSimpleName();
-        String location = String.format("%s:%d", origin.getFileName(), origin.getLineNumber());
+        String location = getExceptionLocation(e);
         String message = e.getMessage();
         String requestId = getRequestId();
 
@@ -228,6 +226,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         requestDebugLogging(request, requestId);
 
         return buildErrorResponse(ApiResponseCode.UNEXPECTED_SERVER_ERROR);
+    }
+
+    private String getExceptionLocation(Exception e) {
+        StackTraceElement[] stackTrace = e.getStackTrace();
+        if (stackTrace.length == 0) {
+            return "unknown:0";
+        }
+
+        StackTraceElement origin = stackTrace[0];
+        return String.format("%s:%d", origin.getFileName(), origin.getLineNumber());
     }
 
     private ResponseEntity<Object> buildErrorResponse(ApiResponseCode errorCode) {

--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 
 import org.apache.catalina.connector.ClientAbortException;
 import org.slf4j.Logger;
+import org.slf4j.MDC;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -44,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final Logger RUNTIME_ERROR_LOGGER = LoggerFactory.getLogger("runtime.error");
+    private static final String REQUEST_ID_MDC_KEY = "requestId";
     private static final String MASKED_HEADER_VALUE = "***";
     private static final List<String> SENSITIVE_HEADER_NAMES = List.of(
         "authorization",
@@ -209,19 +211,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         String exception = e.getClass().getSimpleName();
         String location = String.format("%s:%d", origin.getFileName(), origin.getLineNumber());
         String message = e.getMessage();
+        String requestId = getRequestId();
 
         String slackMessage = String.format(
             """
+                Request ID: `%s`
                 URI: `%s`
                 Location: `%s`
                 Exception: `%s`
                 ```%s```
                 """,
-            uri, location, exception, message
+            requestId, uri, location, exception, message
         );
 
         RUNTIME_ERROR_LOGGER.error(slackMessage);
-        requestDebugLogging(request);
+        requestDebugLogging(request, requestId);
 
         return buildErrorResponse(ApiResponseCode.UNEXPECTED_SERVER_ERROR);
     }
@@ -272,17 +276,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         String errorTraceId
     ) {
         log.warn("[{}] {} | errorTraceId={}", httpStatus, errorMessage, errorTraceId);
-        requestDebugLogging(request);
+        requestDebugLogging(request, getRequestId());
     }
 
-    private void requestDebugLogging(HttpServletRequest request) {
+    private void requestDebugLogging(HttpServletRequest request, String requestId) {
         if (!log.isDebugEnabled()) {
             return;
         }
-        log.debug("Request: {} {}", request.getMethod(), request.getRequestURI());
-        log.debug("Headers: {}", getLoggableHeaders(request));
-        log.debug("Query String: {}", getQueryString(request));
-        log.debug("Body: {}", getRequestBody(request));
+        log.debug("Request [requestId: {}]: {} {}", requestId, request.getMethod(), request.getRequestURI());
+        log.debug("Headers [requestId: {}]: {}", requestId, getLoggableHeaders(request));
+        log.debug("Query String [requestId: {}]: {}", requestId, getQueryString(request));
+        log.debug("Body [requestId: {}]: {}", requestId, getRequestBody(request));
+    }
+
+    private String getRequestId() {
+        String requestId = MDC.get(REQUEST_ID_MDC_KEY);
+        if (requestId == null) {
+            return " - ";
+        }
+        return requestId;
     }
 
     private Map<String, Object> getLoggableHeaders(HttpServletRequest request) {

--- a/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gg/agit/konect/global/exception/GlobalExceptionHandler.java
@@ -230,7 +230,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private String getExceptionLocation(Exception e) {
         StackTraceElement[] stackTrace = e.getStackTrace();
-        if (stackTrace.length == 0) {
+        if (stackTrace == null || stackTrace.length == 0) {
             return "unknown:0";
         }
 

--- a/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
@@ -125,4 +125,28 @@ class GlobalExceptionHandlerTest {
             .contains("Request ID: `request-empty-stack`")
             .contains("Location: `unknown:0`");
     }
+
+    @Test
+    @DisplayName("스택트레이스가 null인 예외도 2차 예외 없이 처리한다")
+    void handlesUnexpectedExceptionWithNullStackTrace(CapturedOutput output) {
+        // given
+        MDC.put("requestId", "request-null-stack");
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/clubs");
+        RuntimeException exception = new RuntimeException("boom") {
+            @Override
+            public StackTraceElement[] getStackTrace() {
+                return null;
+            }
+        };
+
+        // when
+        var response = handler.handleException(request, exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(output)
+            .contains("Request ID: `request-null-stack`")
+            .contains("Location: `unknown:0`");
+    }
 }

--- a/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
@@ -103,6 +103,26 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(output)
             .doesNotContain("Request [requestId:")
-            .doesNotContain("Body: {\"name\":\"KONECT\"}");
+            .doesNotContain("Body [requestId:");
+    }
+
+    @Test
+    @DisplayName("스택트레이스가 비어 있는 예외도 2차 예외 없이 처리한다")
+    void handlesUnexpectedExceptionWithoutStackTrace(CapturedOutput output) {
+        // given
+        MDC.put("requestId", "request-empty-stack");
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/clubs");
+        RuntimeException exception = new RuntimeException("boom");
+        exception.setStackTrace(new StackTraceElement[0]);
+
+        // when
+        var response = handler.handleException(request, exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(output)
+            .contains("Request ID: `request-empty-stack`")
+            .contains("Location: `unknown:0`");
     }
 }

--- a/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/exception/GlobalExceptionHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.HttpStatus;
@@ -34,12 +35,14 @@ class GlobalExceptionHandlerTest {
     @AfterEach
     void tearDown() {
         exceptionHandlerLogger.setLevel(originalLevel);
+        MDC.clear();
     }
 
     @Test
     @DisplayName("예상하지 못한 예외도 디버그 로그에서 요청 본문을 확인할 수 있다")
     void logsRequestBodyAtDebugLevelForUnexpectedException(CapturedOutput output) {
         // given
+        MDC.put("requestId", "request-123");
         GlobalExceptionHandler handler = new GlobalExceptionHandler();
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/clubs");
         request.setContentType("application/json");
@@ -61,21 +64,23 @@ class GlobalExceptionHandlerTest {
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(output)
-            .contains("Request: POST /clubs")
+            .contains("Request ID: `request-123`")
+            .contains("Request [requestId: request-123]: POST /clubs")
             .contains("Authorization=***")
             .contains("Cookie=***")
             .contains("X-Request-ID=request-1")
             .doesNotContain("secret-token")
             .doesNotContain("secret-cookie")
             .contains(
-                "Query String: access%5Ftoken=***&access_token=***&code=***&name=KONECT&token=***&token=***"
+                "Query String [requestId: request-123]: "
+                    + "access%5Ftoken=***&access_token=***&code=***&name=KONECT&token=***&token=***"
             )
             .doesNotContain("encoded-query-secret")
             .doesNotContain("query-secret")
             .doesNotContain("oauth-code")
             .doesNotContain("repeat-secret-one")
             .doesNotContain("repeat-secret-two")
-            .contains("Body: {\"name\":\"KONECT\"}");
+            .contains("Body [requestId: request-123]: {\"name\":\"KONECT\"}");
     }
 
     @Test
@@ -97,7 +102,7 @@ class GlobalExceptionHandlerTest {
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(output)
-            .doesNotContain("Request: POST /clubs")
+            .doesNotContain("Request [requestId:")
             .doesNotContain("Body: {\"name\":\"KONECT\"}");
     }
 }


### PR DESCRIPTION
### 🔍 개요

* PR #617에서 추가한 런타임 에러 DEBUG 요청 로그를 실제 에러 알림과 확정적으로 매칭할 수 있도록 보강합니다.
* Close #620

---

### 🚀 주요 변경 내용

* `runtime.error` Slack 알림 본문에 MDC `requestId`를 명시합니다.
* 요청 상세 DEBUG 로그의 Request, Headers, Query String, Body 라인에도 같은 `requestId`를 명시합니다.
* 예상하지 못한 예외 경로에서 Slack 에러 알림과 DEBUG 요청 로그가 같은 `requestId`를 공유하는지 테스트로 고정합니다.

---

### 💬 참고 사항

* 콘솔/파일 로그 패턴에는 이미 `requestId`가 포함되어 있었지만, `runtime.error` 로거는 별도 Slack appender를 사용하고 `additivity=false`라 Slack 알림 자체에는 식별자가 남지 않았습니다.
* DEBUG 비활성화 시 요청 상세 로그를 계산하지 않는 기존 동작은 유지했습니다.
* 검증: `CI=true ./gradlew test --tests 'gg.agit.konect.unit.global.exception.GlobalExceptionHandlerTest' --rerun-tasks`, `CI=true ./gradlew checkstyleMain`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
