### PR TITLE
feat: 웹사이트 공개 정보 API 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/university/enums/UniversityRegion.java
+++ b/src/main/java/gg/agit/konect/domain/university/enums/UniversityRegion.java
@@ -1,0 +1,21 @@
+package gg.agit.konect.domain.university.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UniversityRegion {
+
+    SEOUL("서울"),
+    GYEONGGI("경기도"),
+    CHUNGCHEONG("충청도"),
+    JEOLLA("전라도"),
+    GYEONGSANG("경상도"),
+    GANGWON("강원도"),
+    JEJU("제주도"),
+    UNKNOWN("지역 미지정"),
+    ;
+
+    private final String displayName;
+}

--- a/src/main/java/gg/agit/konect/domain/university/model/University.java
+++ b/src/main/java/gg/agit/konect/domain/university/model/University.java
@@ -5,6 +5,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import gg.agit.konect.domain.university.enums.Campus;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -44,10 +45,16 @@ public class University {
     @Column(name = "campus", nullable = false)
     private Campus campus;
 
+    @NotNull
+    @Enumerated(value = STRING)
+    @Column(name = "region", nullable = false)
+    private UniversityRegion region;
+
     @Builder
-    private University(Integer id, String koreanName, Campus campus) {
+    private University(Integer id, String koreanName, Campus campus, UniversityRegion region) {
         this.id = id;
         this.koreanName = koreanName;
         this.campus = campus;
+        this.region = region;
     }
 }

--- a/src/main/java/gg/agit/konect/domain/website/controller/WebsiteApi.java
+++ b/src/main/java/gg/agit/konect/domain/website/controller/WebsiteApi.java
@@ -1,0 +1,60 @@
+package gg.agit.konect.domain.website.controller;
+
+import java.util.List;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.website.dto.WebsiteClubDetailResponse;
+import gg.agit.konect.domain.website.dto.WebsiteClubListCondition;
+import gg.agit.konect.domain.website.dto.WebsiteClubsResponse;
+import gg.agit.konect.domain.website.dto.WebsiteHomeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Public) Website: 웹사이트 공개 정보")
+@RequestMapping("/website")
+public interface WebsiteApi {
+
+    @Operation(summary = "웹사이트 메인 화면 정보를 조회한다.", description = """
+        로그인 없이 접근 가능한 웹사이트 메인 정보입니다.
+        대학 검색 결과와 대학별 등록 동아리 수를 반환합니다.
+        """)
+    @GetMapping("/home")
+    ResponseEntity<WebsiteHomeResponse> getHome(
+        @RequestParam(name = "query", required = false) String query,
+        @RequestParam(name = "region", required = false) UniversityRegion region
+    );
+
+    @Operation(summary = "웹사이트 대학별 동아리 목록을 조회한다.", description = """
+        로그인 없이 접근 가능한 대학별 동아리 목록입니다.
+        동아리명 검색, 분과 필터, 페이지네이션을 지원합니다.
+        """)
+    @GetMapping("/universities/{universityId}/clubs")
+    ResponseEntity<WebsiteClubsResponse> getUniversityClubs(
+        @PathVariable(name = "universityId") Integer universityId,
+        @Valid @ParameterObject @ModelAttribute WebsiteClubListCondition condition
+    );
+
+    @Operation(summary = "웹사이트 동아리 상세 정보를 조회한다.")
+    @GetMapping("/clubs/{clubId}")
+    ResponseEntity<WebsiteClubDetailResponse> getClubDetail(
+        @PathVariable(name = "clubId") Integer clubId
+    );
+
+    @Operation(summary = "최근 본 동아리 카드 정보를 조회한다.", description = """
+        프론트엔드가 로컬에 보관한 동아리 ID 목록을 전달하면 카드 표시용 정보를 반환합니다.
+        반환 순서는 요청한 clubIds 순서를 따릅니다.
+        """)
+    @GetMapping("/clubs/recent")
+    ResponseEntity<WebsiteClubsResponse> getRecentClubs(
+        @RequestParam(name = "clubIds") List<Integer> clubIds
+    );
+}

--- a/src/main/java/gg/agit/konect/domain/website/controller/WebsiteApi.java
+++ b/src/main/java/gg/agit/konect/domain/website/controller/WebsiteApi.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,7 +19,9 @@ import gg.agit.konect.domain.website.dto.WebsiteHomeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 
+@Validated
 @Tag(name = "(Public) Website: 웹사이트 공개 정보")
 @RequestMapping("/website")
 public interface WebsiteApi {
@@ -55,6 +58,6 @@ public interface WebsiteApi {
         """)
     @GetMapping("/clubs/recent")
     ResponseEntity<WebsiteClubsResponse> getRecentClubs(
-        @RequestParam(name = "clubIds") List<Integer> clubIds
+        @RequestParam(name = "clubIds") @Size(min = 1, max = 100) List<Integer> clubIds
     );
 }

--- a/src/main/java/gg/agit/konect/domain/website/controller/WebsiteController.java
+++ b/src/main/java/gg/agit/konect/domain/website/controller/WebsiteController.java
@@ -1,0 +1,60 @@
+package gg.agit.konect.domain.website.controller;
+
+import java.util.List;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.website.dto.WebsiteClubDetailResponse;
+import gg.agit.konect.domain.website.dto.WebsiteClubListCondition;
+import gg.agit.konect.domain.website.dto.WebsiteClubsResponse;
+import gg.agit.konect.domain.website.dto.WebsiteHomeResponse;
+import gg.agit.konect.domain.website.service.WebsiteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class WebsiteController implements WebsiteApi {
+
+    private final WebsiteService websiteService;
+
+    @Override
+    public ResponseEntity<WebsiteHomeResponse> getHome(
+        @RequestParam(name = "query", required = false) String query,
+        @RequestParam(name = "region", required = false) UniversityRegion region
+    ) {
+        WebsiteHomeResponse response = websiteService.getHome(query, region);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<WebsiteClubsResponse> getUniversityClubs(
+        @PathVariable(name = "universityId") Integer universityId,
+        @Valid @ParameterObject @ModelAttribute WebsiteClubListCondition condition
+    ) {
+        WebsiteClubsResponse response = websiteService.getUniversityClubs(universityId, condition);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<WebsiteClubDetailResponse> getClubDetail(
+        @PathVariable(name = "clubId") Integer clubId
+    ) {
+        WebsiteClubDetailResponse response = websiteService.getClubDetail(clubId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<WebsiteClubsResponse> getRecentClubs(
+        @RequestParam(name = "clubIds") List<Integer> clubIds
+    ) {
+        WebsiteClubsResponse response = websiteService.getRecentClubs(clubIds);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/website/controller/WebsiteController.java
+++ b/src/main/java/gg/agit/konect/domain/website/controller/WebsiteController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,6 +20,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 public class WebsiteController implements WebsiteApi {
 

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
@@ -1,0 +1,119 @@
+package gg.agit.konect.domain.website.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.time.LocalDateTime;
+
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.club.model.ClubRecruitment;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WebsiteClubDetailResponse(
+    @Schema(description = "동아리 고유 ID", example = "1", requiredMode = REQUIRED)
+    Integer id,
+
+    @Schema(description = "동아리명", example = "BCSD Lab", requiredMode = REQUIRED)
+    String name,
+
+    @Schema(description = "동아리 로고 이미지 URL", requiredMode = REQUIRED)
+    String imageUrl,
+
+    @Schema(description = "분과 코드", example = "ACADEMIC", requiredMode = REQUIRED)
+    ClubCategory category,
+
+    @Schema(description = "분과명", example = "학술", requiredMode = REQUIRED)
+    String categoryName,
+
+    @Schema(description = "한 줄 소개", example = "테스트 동아리 소개", requiredMode = REQUIRED)
+    String description,
+
+    @Schema(description = "상세 소개", requiredMode = REQUIRED)
+    String introduce,
+
+    @Schema(description = "활동 위치", example = "학생회관 101호", requiredMode = REQUIRED)
+    String location,
+
+    @Schema(description = "등록 회원 수", example = "31", requiredMode = REQUIRED)
+    Long memberCount,
+
+    @Schema(description = "대학 정보", requiredMode = REQUIRED)
+    University university,
+
+    @Schema(description = "모집 정보", requiredMode = REQUIRED)
+    Recruitment recruitment
+) {
+
+    public record University(
+        @Schema(description = "대학 고유 ID", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "대학명", example = "한국기술교육대학교", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "캠퍼스명", example = "본교", requiredMode = REQUIRED)
+        String campusName,
+
+        @Schema(description = "지역 코드", example = "CHUNGCHEONG", requiredMode = REQUIRED)
+        UniversityRegion region,
+
+        @Schema(description = "지역명", example = "충청도", requiredMode = REQUIRED)
+        String regionName
+    ) {
+    }
+
+    public record Recruitment(
+        @Schema(description = "모집 활성화 여부", example = "true", requiredMode = REQUIRED)
+        Boolean isRecruitmentEnabled,
+
+        @Schema(description = "상시 모집 여부", example = "false", requiredMode = REQUIRED)
+        Boolean isAlwaysRecruiting,
+
+        @Schema(description = "모집 시작 일시", requiredMode = REQUIRED)
+        LocalDateTime startAt,
+
+        @Schema(description = "모집 마감 일시", requiredMode = REQUIRED)
+        LocalDateTime endAt,
+
+        @Schema(description = "모집 공고 내용", requiredMode = REQUIRED)
+        String content
+    ) {
+        private static Recruitment from(Club club) {
+            ClubRecruitment recruitment = club.getClubRecruitment();
+            if (recruitment == null) {
+                return new Recruitment(club.getIsRecruitmentEnabled(), false, null, null, null);
+            }
+
+            return new Recruitment(
+                club.getIsRecruitmentEnabled(),
+                recruitment.getIsAlwaysRecruiting(),
+                recruitment.getStartAt(),
+                recruitment.getEndAt(),
+                recruitment.getContent()
+            );
+        }
+    }
+
+    public static WebsiteClubDetailResponse of(Club club, Long memberCount) {
+        return new WebsiteClubDetailResponse(
+            club.getId(),
+            club.getName(),
+            club.getImageUrl(),
+            club.getClubCategory(),
+            club.getClubCategory().getDescription(),
+            club.getDescription(),
+            club.getIntroduce(),
+            club.getLocation(),
+            memberCount,
+            new University(
+                club.getUniversity().getId(),
+                club.getUniversity().getKoreanName(),
+                club.getUniversity().getCampus().getDisplayName(),
+                club.getUniversity().getRegion(),
+                club.getUniversity().getRegion().getDisplayName()
+            ),
+            Recruitment.from(club)
+        );
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubListCondition.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubListCondition.java
@@ -1,0 +1,35 @@
+package gg.agit.konect.domain.website.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record WebsiteClubListCondition(
+    @Schema(description = "페이지 번호", example = "1", requiredMode = REQUIRED)
+    @Min(1)
+    Integer page,
+
+    @Schema(description = "페이지 크기", example = "12", requiredMode = REQUIRED)
+    @Min(1)
+    @Max(100)
+    Integer limit,
+
+    @Schema(description = "동아리명 검색어", example = "BCSD", requiredMode = NOT_REQUIRED)
+    String query,
+
+    @Schema(description = "동아리 분과", example = "ACADEMIC", requiredMode = NOT_REQUIRED)
+    ClubCategory category
+) {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_LIMIT = 12;
+
+    public WebsiteClubListCondition {
+        page = page == null ? DEFAULT_PAGE : page;
+        limit = limit == null ? DEFAULT_LIMIT : limit;
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubListCondition.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubListCondition.java
@@ -1,7 +1,6 @@
 package gg.agit.konect.domain.website.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import gg.agit.konect.domain.club.enums.ClubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,11 +8,11 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 public record WebsiteClubListCondition(
-    @Schema(description = "페이지 번호", example = "1", requiredMode = REQUIRED)
+    @Schema(description = "페이지 번호", example = "1", requiredMode = NOT_REQUIRED)
     @Min(1)
     Integer page,
 
-    @Schema(description = "페이지 크기", example = "12", requiredMode = REQUIRED)
+    @Schema(description = "페이지 크기", example = "12", requiredMode = NOT_REQUIRED)
     @Min(1)
     @Max(100)
     Integer limit,

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
@@ -1,0 +1,156 @@
+package gg.agit.konect.domain.website.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.university.model.University;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WebsiteClubsResponse(
+    @Schema(description = "대학 정보", requiredMode = REQUIRED)
+    UniversityResponse university,
+
+    @Schema(description = "전체 동아리 수", example = "28", requiredMode = REQUIRED)
+    Long totalCount,
+
+    @Schema(description = "전체 페이지 수", example = "3", requiredMode = REQUIRED)
+    Integer totalPage,
+
+    @Schema(description = "현재 페이지 번호", example = "1", requiredMode = REQUIRED)
+    Integer currentPage,
+
+    @Schema(description = "분과별 동아리 수", requiredMode = REQUIRED)
+    List<CategoryCountResponse> categories,
+
+    @Schema(description = "동아리 목록", requiredMode = REQUIRED)
+    List<ClubResponse> clubs
+) {
+
+    public record UniversityResponse(
+        @Schema(description = "대학 고유 ID", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "대학명", example = "한국기술교육대학교", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "캠퍼스명", example = "본교", requiredMode = REQUIRED)
+        String campusName,
+
+        @Schema(description = "지역 코드", example = "CHUNGCHEONG", requiredMode = REQUIRED)
+        UniversityRegion region,
+
+        @Schema(description = "지역명", example = "충청도", requiredMode = REQUIRED)
+        String regionName
+    ) {
+        public static UniversityResponse from(University university) {
+            if (university == null) {
+                return null;
+            }
+
+            return new UniversityResponse(
+                university.getId(),
+                university.getKoreanName(),
+                university.getCampus().getDisplayName(),
+                university.getRegion(),
+                university.getRegion().getDisplayName()
+            );
+        }
+    }
+
+    public record CategoryCountResponse(
+        @Schema(description = "분과 코드", example = "ACADEMIC", requiredMode = REQUIRED)
+        ClubCategory category,
+
+        @Schema(description = "분과명", example = "학술", requiredMode = REQUIRED)
+        String categoryName,
+
+        @Schema(description = "동아리 수", example = "5", requiredMode = REQUIRED)
+        Long count
+    ) {
+        public static CategoryCountResponse of(ClubCategory category, Long count) {
+            return new CategoryCountResponse(category, category.getDescription(), count);
+        }
+    }
+
+    public record ClubResponse(
+        @Schema(description = "동아리 고유 ID", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "동아리명", example = "BCSD Lab", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "동아리 로고 이미지 URL", requiredMode = REQUIRED)
+        String imageUrl,
+
+        @Schema(description = "분과 코드", example = "ACADEMIC", requiredMode = REQUIRED)
+        ClubCategory category,
+
+        @Schema(description = "분과명", example = "학술", requiredMode = REQUIRED)
+        String categoryName,
+
+        @Schema(description = "한 줄 소개", example = "테스트 동아리 소개", requiredMode = REQUIRED)
+        String description,
+
+        @Schema(description = "등록 회원 수", example = "31", requiredMode = REQUIRED)
+        Long memberCount
+    ) {
+        public static ClubResponse of(Club club, Long memberCount) {
+            return new ClubResponse(
+                club.getId(),
+                club.getName(),
+                club.getImageUrl(),
+                club.getClubCategory(),
+                club.getClubCategory().getDescription(),
+                club.getDescription(),
+                memberCount
+            );
+        }
+    }
+
+    public static WebsiteClubsResponse of(
+        University university,
+        Page<Club> page,
+        Map<Integer, Long> memberCounts,
+        Map<ClubCategory, Long> categoryCounts
+    ) {
+        return new WebsiteClubsResponse(
+            UniversityResponse.from(university),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.getNumber() + 1,
+            createCategories(categoryCounts),
+            createClubs(page.getContent(), memberCounts)
+        );
+    }
+
+    public static WebsiteClubsResponse recent(List<Club> clubs, Map<Integer, Long> memberCounts) {
+        return new WebsiteClubsResponse(
+            null,
+            (long)clubs.size(),
+            1,
+            1,
+            List.of(),
+            createClubs(clubs, memberCounts)
+        );
+    }
+
+    private static List<CategoryCountResponse> createCategories(Map<ClubCategory, Long> categoryCounts) {
+        return Arrays.stream(ClubCategory.values())
+            .map(category -> CategoryCountResponse.of(category, categoryCounts.getOrDefault(category, 0L)))
+            .toList();
+    }
+
+    private static List<ClubResponse> createClubs(List<Club> clubs, Map<Integer, Long> memberCounts) {
+        return clubs.stream()
+            .map(club -> ClubResponse.of(club, memberCounts.getOrDefault(club.getId(), 0L)))
+            .toList();
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteHomeResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteHomeResponse.java
@@ -1,0 +1,58 @@
+package gg.agit.konect.domain.website.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import java.util.List;
+
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.website.model.WebsiteUniversitySummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WebsiteHomeResponse(
+    @Schema(description = "대학 수", example = "28", requiredMode = REQUIRED)
+    Integer totalUniversityCount,
+
+    @Schema(description = "대학 목록", requiredMode = REQUIRED)
+    List<UniversityResponse> universities
+) {
+
+    public record UniversityResponse(
+        @Schema(description = "대학 고유 ID", example = "1", requiredMode = REQUIRED)
+        Integer id,
+
+        @Schema(description = "대학명", example = "한국기술교육대학교", requiredMode = REQUIRED)
+        String name,
+
+        @Schema(description = "캠퍼스명", example = "본교", requiredMode = REQUIRED)
+        String campusName,
+
+        @Schema(description = "지역 코드", example = "CHUNGCHEONG", requiredMode = REQUIRED)
+        UniversityRegion region,
+
+        @Schema(description = "지역명", example = "충청도", requiredMode = REQUIRED)
+        String regionName,
+
+        @Schema(description = "등록 동아리 수", example = "31", requiredMode = REQUIRED)
+        Long clubCount
+    ) {
+        public static UniversityResponse from(WebsiteUniversitySummary summary) {
+            return new UniversityResponse(
+                summary.id(),
+                summary.name(),
+                summary.campusName(),
+                summary.region(),
+                summary.regionName(),
+                summary.clubCount()
+            );
+        }
+    }
+
+    public static WebsiteHomeResponse from(List<WebsiteUniversitySummary> summaries) {
+        return new WebsiteHomeResponse(
+            summaries.size(),
+            summaries.stream()
+                .map(UniversityResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteHomeResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteHomeResponse.java
@@ -9,7 +9,7 @@ import gg.agit.konect.domain.website.model.WebsiteUniversitySummary;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record WebsiteHomeResponse(
-    @Schema(description = "대학 수", example = "28", requiredMode = REQUIRED)
+    @Schema(description = "검색 결과 대학 수", example = "28", requiredMode = REQUIRED)
     Integer totalUniversityCount,
 
     @Schema(description = "대학 목록", requiredMode = REQUIRED)

--- a/src/main/java/gg/agit/konect/domain/website/model/WebsiteUniversitySummary.java
+++ b/src/main/java/gg/agit/konect/domain/website/model/WebsiteUniversitySummary.java
@@ -1,0 +1,13 @@
+package gg.agit.konect.domain.website.model;
+
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+
+public record WebsiteUniversitySummary(
+    Integer id,
+    String name,
+    String campusName,
+    UniversityRegion region,
+    String regionName,
+    Long clubCount
+) {
+}

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
@@ -26,7 +26,6 @@ import gg.agit.konect.domain.club.model.Club;
 import gg.agit.konect.domain.university.enums.UniversityRegion;
 import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.domain.website.model.WebsiteUniversitySummary;
-import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -168,11 +167,12 @@ public class WebsiteQueryRepository {
     }
 
     private void addUniversitySearchCondition(BooleanBuilder condition, String query) {
-        if (StringUtils.isEmpty(query)) {
+        if (query == null || query.isBlank()) {
             return;
         }
 
-        condition.and(university.koreanName.lower().contains(query.trim().toLowerCase()));
+        String normalizedQuery = query.trim().toLowerCase();
+        condition.and(university.koreanName.lower().contains(normalizedQuery));
     }
 
     private void addUniversityRegionCondition(BooleanBuilder condition, UniversityRegion region) {
@@ -184,11 +184,12 @@ public class WebsiteQueryRepository {
     }
 
     private void addClubSearchCondition(BooleanBuilder condition, String query) {
-        if (StringUtils.isEmpty(query)) {
+        if (query == null || query.isBlank()) {
             return;
         }
 
-        BooleanExpression nameContains = club.name.lower().contains(query.trim().toLowerCase());
+        String normalizedQuery = query.trim().toLowerCase();
+        BooleanExpression nameContains = club.name.lower().contains(normalizedQuery);
         condition.and(nameContains);
     }
 }

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
@@ -143,7 +143,10 @@ public class WebsiteQueryRepository {
         List<Tuple> rows = jpaQueryFactory
             .select(clubMember.club.id, memberCount)
             .from(clubMember)
-            .where(clubMember.club.id.in(clubIds))
+            .where(
+                clubMember.club.id.in(clubIds),
+                clubMember.user.deletedAt.isNull()
+            )
             .groupBy(clubMember.club.id)
             .fetch();
 

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
@@ -1,0 +1,191 @@
+package gg.agit.konect.domain.website.repository;
+
+import static gg.agit.konect.domain.club.model.QClub.club;
+import static gg.agit.konect.domain.club.model.QClubMember.clubMember;
+import static gg.agit.konect.domain.club.model.QClubRecruitment.clubRecruitment;
+import static gg.agit.konect.domain.university.model.QUniversity.university;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.university.model.University;
+import gg.agit.konect.domain.website.model.WebsiteUniversitySummary;
+import io.micrometer.common.util.StringUtils;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class WebsiteQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<WebsiteUniversitySummary> findUniversitySummaries(String query, UniversityRegion region) {
+        BooleanBuilder condition = new BooleanBuilder();
+        addUniversitySearchCondition(condition, query);
+        addUniversityRegionCondition(condition, region);
+        NumberExpression<Long> clubCount = club.id.countDistinct();
+
+        List<Tuple> rows = jpaQueryFactory
+            .select(university.id, university.koreanName, university.campus, university.region, clubCount)
+            .from(university)
+            .leftJoin(club).on(club.university.id.eq(university.id))
+            .where(condition)
+            .groupBy(university.id, university.koreanName, university.campus, university.region)
+            .orderBy(university.koreanName.asc(), university.campus.asc())
+            .fetch();
+
+        return rows.stream()
+            .map(row -> new WebsiteUniversitySummary(
+                row.get(university.id),
+                row.get(university.koreanName),
+                row.get(university.campus).getDisplayName(),
+                row.get(university.region),
+                row.get(university.region).getDisplayName(),
+                row.get(clubCount)
+            ))
+            .toList();
+    }
+
+    public Optional<University> findUniversity(Integer universityId) {
+        return Optional.ofNullable(jpaQueryFactory
+            .selectFrom(university)
+            .where(university.id.eq(universityId))
+            .fetchOne());
+    }
+
+    public Page<Club> findClubs(
+        Integer universityId,
+        String query,
+        ClubCategory category,
+        PageRequest pageable
+    ) {
+        BooleanBuilder condition = createClubCondition(universityId, query, category);
+
+        List<Club> clubs = jpaQueryFactory
+            .selectFrom(club)
+            .join(club.university, university).fetchJoin()
+            .leftJoin(club.clubRecruitment, clubRecruitment).fetchJoin()
+            .where(condition)
+            .orderBy(club.name.asc(), club.id.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long total = jpaQueryFactory
+            .select(club.count())
+            .from(club)
+            .where(condition)
+            .fetchOne();
+
+        return new PageImpl<>(clubs, pageable, total == null ? 0 : total);
+    }
+
+    public Map<ClubCategory, Long> countClubCategories(Integer universityId, String query) {
+        BooleanBuilder condition = createClubCondition(universityId, query, null);
+        NumberExpression<Long> clubCount = club.count();
+
+        List<Tuple> rows = jpaQueryFactory
+            .select(club.clubCategory, clubCount)
+            .from(club)
+            .where(condition)
+            .groupBy(club.clubCategory)
+            .fetch();
+
+        Map<ClubCategory, Long> categoryCounts = new LinkedHashMap<>();
+        rows.forEach(row -> categoryCounts.put(row.get(club.clubCategory), row.get(clubCount)));
+        return categoryCounts;
+    }
+
+    public Optional<Club> findClub(Integer clubId) {
+        return Optional.ofNullable(jpaQueryFactory
+            .selectFrom(club)
+            .join(club.university, university).fetchJoin()
+            .leftJoin(club.clubRecruitment, clubRecruitment).fetchJoin()
+            .where(club.id.eq(clubId))
+            .fetchOne());
+    }
+
+    public List<Club> findClubs(List<Integer> clubIds) {
+        if (clubIds.isEmpty()) {
+            return List.of();
+        }
+
+        return jpaQueryFactory
+            .selectFrom(club)
+            .join(club.university, university).fetchJoin()
+            .leftJoin(club.clubRecruitment, clubRecruitment).fetchJoin()
+            .where(club.id.in(clubIds))
+            .fetch();
+    }
+
+    public Map<Integer, Long> countMembersByClubIds(List<Integer> clubIds) {
+        if (clubIds.isEmpty()) {
+            return Map.of();
+        }
+        NumberExpression<Long> memberCount = clubMember.count();
+
+        List<Tuple> rows = jpaQueryFactory
+            .select(clubMember.club.id, memberCount)
+            .from(clubMember)
+            .where(clubMember.club.id.in(clubIds))
+            .groupBy(clubMember.club.id)
+            .fetch();
+
+        Map<Integer, Long> memberCounts = new LinkedHashMap<>();
+        rows.forEach(row -> memberCounts.put(row.get(clubMember.club.id), row.get(memberCount)));
+        return memberCounts;
+    }
+
+    private BooleanBuilder createClubCondition(Integer universityId, String query, ClubCategory category) {
+        BooleanBuilder condition = new BooleanBuilder();
+
+        condition.and(club.university.id.eq(universityId));
+        addClubSearchCondition(condition, query);
+        if (category != null) {
+            condition.and(club.clubCategory.eq(category));
+        }
+
+        return condition;
+    }
+
+    private void addUniversitySearchCondition(BooleanBuilder condition, String query) {
+        if (StringUtils.isEmpty(query)) {
+            return;
+        }
+
+        condition.and(university.koreanName.lower().contains(query.trim().toLowerCase()));
+    }
+
+    private void addUniversityRegionCondition(BooleanBuilder condition, UniversityRegion region) {
+        if (region == null) {
+            return;
+        }
+
+        condition.and(university.region.eq(region));
+    }
+
+    private void addClubSearchCondition(BooleanBuilder condition, String query) {
+        if (StringUtils.isEmpty(query)) {
+            return;
+        }
+
+        BooleanExpression nameContains = club.name.lower().contains(query.trim().toLowerCase());
+        condition.and(nameContains);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
+++ b/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
@@ -1,0 +1,94 @@
+package gg.agit.konect.domain.website.service;
+
+import static gg.agit.konect.global.code.ApiResponseCode.NOT_FOUND_CLUB;
+import static gg.agit.konect.global.code.ApiResponseCode.UNIVERSITY_NOT_FOUND;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.university.model.University;
+import gg.agit.konect.domain.website.dto.WebsiteClubDetailResponse;
+import gg.agit.konect.domain.website.dto.WebsiteClubListCondition;
+import gg.agit.konect.domain.website.dto.WebsiteClubsResponse;
+import gg.agit.konect.domain.website.dto.WebsiteHomeResponse;
+import gg.agit.konect.domain.website.model.WebsiteUniversitySummary;
+import gg.agit.konect.domain.website.repository.WebsiteQueryRepository;
+import gg.agit.konect.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WebsiteService {
+
+    private final WebsiteQueryRepository websiteQueryRepository;
+
+    public WebsiteHomeResponse getHome(String query, UniversityRegion region) {
+        List<WebsiteUniversitySummary> summaries = websiteQueryRepository.findUniversitySummaries(query, region);
+        return WebsiteHomeResponse.from(summaries);
+    }
+
+    public WebsiteClubsResponse getUniversityClubs(Integer universityId, WebsiteClubListCondition condition) {
+        University university = websiteQueryRepository.findUniversity(universityId)
+            .orElseThrow(() -> CustomException.of(UNIVERSITY_NOT_FOUND));
+        PageRequest pageable = PageRequest.of(condition.page() - 1, condition.limit());
+
+        Page<Club> clubs = websiteQueryRepository.findClubs(
+            universityId,
+            condition.query(),
+            condition.category(),
+            pageable
+        );
+        List<Integer> clubIds = clubs.getContent().stream()
+            .map(Club::getId)
+            .toList();
+
+        return WebsiteClubsResponse.of(
+            university,
+            clubs,
+            websiteQueryRepository.countMembersByClubIds(clubIds),
+            websiteQueryRepository.countClubCategories(universityId, condition.query())
+        );
+    }
+
+    public WebsiteClubDetailResponse getClubDetail(Integer clubId) {
+        Club club = websiteQueryRepository.findClub(clubId)
+            .orElseThrow(() -> CustomException.of(NOT_FOUND_CLUB));
+        Long memberCount = websiteQueryRepository.countMembersByClubIds(List.of(clubId)).getOrDefault(clubId, 0L);
+
+        return WebsiteClubDetailResponse.of(club, memberCount);
+    }
+
+    public WebsiteClubsResponse getRecentClubs(List<Integer> clubIds) {
+        List<Integer> distinctClubIds = clubIds.stream()
+            .distinct()
+            .toList();
+        List<Club> clubs = websiteQueryRepository.findClubs(distinctClubIds);
+        Map<Integer, Integer> order = createOrder(clubIds);
+
+        List<Club> sortedClubs = clubs.stream()
+            .sorted(Comparator.comparingInt(club -> order.getOrDefault(club.getId(), Integer.MAX_VALUE)))
+            .toList();
+
+        return WebsiteClubsResponse.recent(
+            sortedClubs,
+            websiteQueryRepository.countMembersByClubIds(distinctClubIds)
+        );
+    }
+
+    private Map<Integer, Integer> createOrder(List<Integer> clubIds) {
+        Map<Integer, Integer> order = new java.util.LinkedHashMap<>();
+        for (int i = 0; i < clubIds.size(); i++) {
+            order.putIfAbsent(clubIds.get(i), i);
+        }
+        return order;
+    }
+}

--- a/src/main/java/gg/agit/konect/global/config/SecurityPaths.java
+++ b/src/main/java/gg/agit/konect/global/config/SecurityPaths.java
@@ -11,7 +11,8 @@ public final class SecurityPaths {
         "/swagger-resources/**",
         "/error",
         "/slack/events",
-        "/auth/oauth/google/drive/callback"
+        "/auth/oauth/google/drive/callback",
+        "/website/**"
     };
 
     public static final String[] DENY_PATHS = {};

--- a/src/main/resources/db/migration/V72__add_region_to_university.sql
+++ b/src/main/resources/db/migration/V72__add_region_to_university.sql
@@ -1,0 +1,2 @@
+ALTER TABLE university
+    ADD COLUMN region VARCHAR(50) NOT NULL DEFAULT 'UNKNOWN' AFTER campus;

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -7,6 +7,10 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -81,6 +85,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
             persist(createClub(university, "ZEST", ClubCategory.PERFORMANCE));
             persistMember(bcsd, "회원1", "2024000001");
             persistMember(bcsd, "회원2", "2024000002");
+            withdraw(persistMember(bcsd, "탈퇴회원", "2024000004"));
             persistMember(study, "회원3", "2024000003");
             clearPersistenceContext();
 
@@ -161,6 +166,19 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.clubs[0].name").value("두 번째"))
                 .andExpect(jsonPath("$.clubs[1].name").value("첫 번째"));
         }
+
+        @Test
+        @DisplayName("최근 본 동아리 ID가 100개를 초과하면 400을 반환한다")
+        void getRecentClubsRejectsTooManyClubIds() throws Exception {
+            // given
+            String clubIds = IntStream.rangeClosed(1, 101)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.joining(","));
+
+            // when & then
+            performGet("/website/clubs/recent?clubIds=" + clubIds)
+                .andExpect(status().isBadRequest());
+        }
     }
 
     private Club createClub(University university, String name, ClubCategory category) {
@@ -178,8 +196,13 @@ class WebsiteApiTest extends IntegrationTestSupport {
             .build();
     }
 
-    private void persistMember(Club club, String name, String studentNumber) {
+    private User persistMember(Club club, String name, String studentNumber) {
         User user = persist(UserFixture.createUser(club.getUniversity(), name, studentNumber));
         persist(ClubMemberFixture.createMember(club, user));
+        return user;
+    }
+
+    private void withdraw(User user) {
+        user.withdraw(LocalDateTime.now());
     }
 }

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -179,6 +179,22 @@ class WebsiteApiTest extends IntegrationTestSupport {
             performGet("/website/clubs/recent?clubIds=" + clubIds)
                 .andExpect(status().isBadRequest());
         }
+
+        @Test
+        @DisplayName("최근 본 동아리 ID가 비어 있으면 400을 반환한다")
+        void getRecentClubsRejectsEmptyClubIds() throws Exception {
+            // when & then
+            performGet("/website/clubs/recent?clubIds=")
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("최근 본 동아리 ID가 없으면 400을 반환한다")
+        void getRecentClubsRejectsMissingClubIds() throws Exception {
+            // when & then
+            performGet("/website/clubs/recent")
+                .andExpect(status().isBadRequest());
+        }
     }
 
     private Club createClub(University university, String name, ClubCategory category) {

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -1,0 +1,185 @@
+package gg.agit.konect.integration.domain.website;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import gg.agit.konect.domain.club.model.Club;
+import gg.agit.konect.domain.university.enums.Campus;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.university.model.University;
+import gg.agit.konect.domain.user.model.User;
+import gg.agit.konect.support.IntegrationTestSupport;
+import gg.agit.konect.support.fixture.ClubMemberFixture;
+import gg.agit.konect.support.fixture.ClubRecruitmentFixture;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UserFixture;
+
+class WebsiteApiTest extends IntegrationTestSupport {
+
+    @Nested
+    @DisplayName("GET /website/home - 웹사이트 메인")
+    class GetHome {
+
+        @Test
+        @DisplayName("로그인 없이 대학 목록과 등록 동아리 수를 조회한다")
+        void getHomeWithoutLogin() throws Exception {
+            // given
+            University koreatech = persist(UniversityFixture.create(
+                "한국기술교육대학교",
+                Campus.MAIN,
+                UniversityRegion.CHUNGCHEONG
+            ));
+            University seoul = persist(UniversityFixture.create(
+                "서울대학교",
+                Campus.MAIN,
+                UniversityRegion.SEOUL
+            ));
+            persist(createClub(koreatech, "BCSD Lab", ClubCategory.ACADEMIC));
+            persist(createClub(koreatech, "COK", ClubCategory.SPORTS));
+            persist(createClub(seoul, "서울 동아리", ClubCategory.HOBBY));
+            clearPersistenceContext();
+
+            // when & then
+            performGet("/website/home?query=한국&region=CHUNGCHEONG")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalUniversityCount").value(1))
+                .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"))
+                .andExpect(jsonPath("$.universities[0].campusName").value("본교"))
+                .andExpect(jsonPath("$.universities[0].region").value("CHUNGCHEONG"))
+                .andExpect(jsonPath("$.universities[0].regionName").value("충청도"))
+                .andExpect(jsonPath("$.universities[0].clubCount").value(2));
+
+            verify(loginCheckInterceptor, never()).preHandle(any(), any(), any());
+            verify(authorizationInterceptor, never()).preHandle(any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /website/universities/{universityId}/clubs - 대학별 동아리")
+    class GetUniversityClubs {
+
+        @Test
+        @DisplayName("검색어와 분과로 동아리 목록을 조회하고 분과별 개수를 함께 반환한다")
+        void getUniversityClubsWithFilters() throws Exception {
+            // given
+            University university = persist(UniversityFixture.create(
+                "한국기술교육대학교",
+                Campus.MAIN,
+                UniversityRegion.CHUNGCHEONG
+            ));
+            Club bcsd = persist(createClub(university, "BCSD Lab", ClubCategory.ACADEMIC));
+            Club study = persist(createClub(university, "경영전략연구회", ClubCategory.ACADEMIC));
+            persist(createClub(university, "ZEST", ClubCategory.PERFORMANCE));
+            persistMember(bcsd, "회원1", "2024000001");
+            persistMember(bcsd, "회원2", "2024000002");
+            persistMember(study, "회원3", "2024000003");
+            clearPersistenceContext();
+
+            // when & then
+            performGet("/website/universities/" + university.getId()
+                + "/clubs?page=1&limit=10&query=BCSD&category=ACADEMIC")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.university.name").value("한국기술교육대학교"))
+                .andExpect(jsonPath("$.totalCount").value(1))
+                .andExpect(jsonPath("$.clubs", hasSize(1)))
+                .andExpect(jsonPath("$.clubs[0].name").value("BCSD Lab"))
+                .andExpect(jsonPath("$.clubs[0].memberCount").value(2))
+                .andExpect(jsonPath("$.categories[0].category").value("ACADEMIC"))
+                .andExpect(jsonPath("$.categories[0].count").value(1));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 대학이면 404를 반환한다")
+        void getUniversityClubsNotFound() throws Exception {
+            // when & then
+            performGet("/website/universities/99999/clubs")
+                .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /website/clubs/{clubId} - 동아리 상세")
+    class GetClubDetail {
+
+        @Test
+        @DisplayName("동아리 상세 소개와 모집 정보를 조회한다")
+        void getClubDetailSuccess() throws Exception {
+            // given
+            University university = persist(UniversityFixture.create(
+                "한국기술교육대학교",
+                Campus.MAIN,
+                UniversityRegion.CHUNGCHEONG
+            ));
+            Club club = persist(createClub(university, "ZEST", ClubCategory.PERFORMANCE));
+            persist(ClubRecruitmentFixture.createAlwaysRecruiting(club));
+            persistMember(club, "회장", "2024000004");
+            clearPersistenceContext();
+
+            // when & then
+            performGet("/website/clubs/" + club.getId())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("ZEST"))
+                .andExpect(jsonPath("$.categoryName").value("공연"))
+                .andExpect(jsonPath("$.university.name").value("한국기술교육대학교"))
+                .andExpect(jsonPath("$.university.region").value("CHUNGCHEONG"))
+                .andExpect(jsonPath("$.memberCount").value(1))
+                .andExpect(jsonPath("$.recruitment.isAlwaysRecruiting").value(true))
+                .andExpect(jsonPath("$.recruitment.content").value("상시 모집 공고 내용입니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /website/clubs/recent - 최근 본 동아리")
+    class GetRecentClubs {
+
+        @Test
+        @DisplayName("요청한 동아리 ID 순서대로 카드 정보를 반환한다")
+        void getRecentClubsKeepsRequestOrder() throws Exception {
+            // given
+            University university = persist(UniversityFixture.create(
+                "한국기술교육대학교",
+                Campus.MAIN,
+                UniversityRegion.CHUNGCHEONG
+            ));
+            Club first = persist(createClub(university, "첫 번째", ClubCategory.ACADEMIC));
+            Club second = persist(createClub(university, "두 번째", ClubCategory.SPORTS));
+            clearPersistenceContext();
+
+            // when & then
+            performGet("/website/clubs/recent?clubIds=" + second.getId() + "," + first.getId())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubs", hasSize(2)))
+                .andExpect(jsonPath("$.clubs[0].name").value("두 번째"))
+                .andExpect(jsonPath("$.clubs[1].name").value("첫 번째"));
+        }
+    }
+
+    private Club createClub(University university, String name, ClubCategory category) {
+        return Club.builder()
+            .university(university)
+            .name(name)
+            .description("한 줄 소개")
+            .introduce("상세 소개입니다.")
+            .imageUrl("https://example.com/" + name + ".png")
+            .location("학생회관 101호")
+            .clubCategory(category)
+            .isRecruitmentEnabled(false)
+            .isApplicationEnabled(false)
+            .isFeeRequired(false)
+            .build();
+    }
+
+    private void persistMember(Club club, String name, String studentNumber) {
+        User user = persist(UserFixture.createUser(club.getUniversity(), name, studentNumber));
+        persist(ClubMemberFixture.createMember(club, user));
+    }
+}

--- a/src/test/java/gg/agit/konect/support/fixture/UniversityFixture.java
+++ b/src/test/java/gg/agit/konect/support/fixture/UniversityFixture.java
@@ -3,6 +3,7 @@ package gg.agit.konect.support.fixture;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import gg.agit.konect.domain.university.enums.Campus;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
 import gg.agit.konect.domain.university.model.University;
 
 public class UniversityFixture {
@@ -12,9 +13,14 @@ public class UniversityFixture {
     }
 
     public static University create(String koreanName, Campus campus) {
+        return create(koreanName, campus, UniversityRegion.CHUNGCHEONG);
+    }
+
+    public static University create(String koreanName, Campus campus, UniversityRegion region) {
         return University.builder()
             .koreanName(koreanName)
             .campus(campus)
+            .region(region)
             .build();
     }
 

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberManagementServiceBatchTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubMemberManagementServiceBatchTest.java
@@ -27,6 +27,7 @@ import gg.agit.konect.domain.club.repository.ClubRepository;
 import gg.agit.konect.domain.club.service.ClubMemberManagementService;
 import gg.agit.konect.domain.club.service.ClubPermissionValidator;
 import gg.agit.konect.domain.university.enums.Campus;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
 import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.domain.user.repository.UserRepository;
 import gg.agit.konect.global.code.ApiResponseCode;
@@ -70,6 +71,7 @@ class ClubMemberManagementServiceBatchTest {
             .id(1)
             .koreanName("Test University")
             .campus(Campus.MAIN)
+            .region(UniversityRegion.CHUNGCHEONG)
             .build();
 
         club = Club.builder()


### PR DESCRIPTION
### 🔍 개요

* 로그인 없이 접근하는 웹사이트에서 학교와 동아리 정보를 조회할 수 있도록 공개 API를 추가했습니다.
* 기존 앱용 로그인 기반 동아리 API와 분리된 `/website/**` 경로로 구성해 기존 기능의 인증 흐름과 응답 계약을 건드리지 않았습니다.

---

### 🚀 주요 변경 내용

* 웹사이트 메인 화면에서 대학명 검색과 지역 필터로 학교 목록 및 등록 동아리 수를 조회할 수 있습니다.
* 학교 선택 후 동아리 목록, 분과 필터, 동아리명 검색, 동아리 상세, 최근 본 동아리 카드 조회를 지원합니다.
* `UniversityRegion` enum과 `university.region` 컬럼을 추가해 학교별 지역 필터 기준을 명시했습니다.
* `/website/**`를 공개 경로로 등록하고, 로그인/권한 인터셉터 없이 조회되는 통합 테스트를 추가했습니다.

---

### 💬 참고 사항

* 기존 대학 데이터의 `region` 값은 마이그레이션에서 `UNKNOWN`으로 채워집니다. 실제 지역 필터를 운영에 쓰려면 대학별 지역값 보정이 필요합니다.
* 검증: `CI=true ./gradlew test --tests gg.agit.konect.integration.domain.website.WebsiteApiTest --rerun-tasks`
* 검증: `./gradlew checkstyleMain --rerun-tasks`

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---
