### PR TITLE
fix: 웹사이트 전용 API 경로를 konect로 변경

### DIFF
--- a/src/main/java/gg/agit/konect/domain/website/controller/WebsiteApi.java
+++ b/src/main/java/gg/agit/konect/domain/website/controller/WebsiteApi.java
@@ -23,7 +23,7 @@ import jakarta.validation.constraints.Size;
 
 @Validated
 @Tag(name = "(Public) Website: 웹사이트 공개 정보")
-@RequestMapping("/website")
+@RequestMapping("/konect")
 public interface WebsiteApi {
 
     @Operation(summary = "웹사이트 메인 화면 정보를 조회한다.", description = """

--- a/src/main/java/gg/agit/konect/global/config/SecurityPaths.java
+++ b/src/main/java/gg/agit/konect/global/config/SecurityPaths.java
@@ -12,7 +12,7 @@ public final class SecurityPaths {
         "/error",
         "/slack/events",
         "/auth/oauth/google/drive/callback",
-        "/website/**"
+        "/konect/**"
     };
 
     public static final String[] DENY_PATHS = {};

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -30,7 +30,7 @@ import gg.agit.konect.support.fixture.UserFixture;
 class WebsiteApiTest extends IntegrationTestSupport {
 
     @Nested
-    @DisplayName("GET /website/home - 웹사이트 메인")
+    @DisplayName("GET /konect/home - 웹사이트 메인")
     class GetHome {
 
         @Test
@@ -53,7 +53,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
             clearPersistenceContext();
 
             // when & then
-            performGet("/website/home?query=한국&region=CHUNGCHEONG")
+            performGet("/konect/home?query=한국&region=CHUNGCHEONG")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalUniversityCount").value(1))
                 .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"))
@@ -68,7 +68,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("GET /website/universities/{universityId}/clubs - 대학별 동아리")
+    @DisplayName("GET /konect/universities/{universityId}/clubs - 대학별 동아리")
     class GetUniversityClubs {
 
         @Test
@@ -90,7 +90,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
             clearPersistenceContext();
 
             // when & then
-            performGet("/website/universities/" + university.getId()
+            performGet("/konect/universities/" + university.getId()
                 + "/clubs?page=1&limit=10&query=BCSD&category=ACADEMIC")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.university.name").value("한국기술교육대학교"))
@@ -106,13 +106,13 @@ class WebsiteApiTest extends IntegrationTestSupport {
         @DisplayName("존재하지 않는 대학이면 404를 반환한다")
         void getUniversityClubsNotFound() throws Exception {
             // when & then
-            performGet("/website/universities/99999/clubs")
+            performGet("/konect/universities/99999/clubs")
                 .andExpect(status().isNotFound());
         }
     }
 
     @Nested
-    @DisplayName("GET /website/clubs/{clubId} - 동아리 상세")
+    @DisplayName("GET /konect/clubs/{clubId} - 동아리 상세")
     class GetClubDetail {
 
         @Test
@@ -130,7 +130,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
             clearPersistenceContext();
 
             // when & then
-            performGet("/website/clubs/" + club.getId())
+            performGet("/konect/clubs/" + club.getId())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("ZEST"))
                 .andExpect(jsonPath("$.categoryName").value("공연"))
@@ -143,7 +143,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("GET /website/clubs/recent - 최근 본 동아리")
+    @DisplayName("GET /konect/clubs/recent - 최근 본 동아리")
     class GetRecentClubs {
 
         @Test
@@ -160,7 +160,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
             clearPersistenceContext();
 
             // when & then
-            performGet("/website/clubs/recent?clubIds=" + second.getId() + "," + first.getId())
+            performGet("/konect/clubs/recent?clubIds=" + second.getId() + "," + first.getId())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.clubs", hasSize(2)))
                 .andExpect(jsonPath("$.clubs[0].name").value("두 번째"))
@@ -176,7 +176,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 .collect(Collectors.joining(","));
 
             // when & then
-            performGet("/website/clubs/recent?clubIds=" + clubIds)
+            performGet("/konect/clubs/recent?clubIds=" + clubIds)
                 .andExpect(status().isBadRequest());
         }
 
@@ -184,7 +184,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
         @DisplayName("최근 본 동아리 ID가 비어 있으면 400을 반환한다")
         void getRecentClubsRejectsEmptyClubIds() throws Exception {
             // when & then
-            performGet("/website/clubs/recent?clubIds=")
+            performGet("/konect/clubs/recent?clubIds=")
                 .andExpect(status().isBadRequest());
         }
 
@@ -192,7 +192,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
         @DisplayName("최근 본 동아리 ID가 없으면 400을 반환한다")
         void getRecentClubsRejectsMissingClubIds() throws Exception {
             // when & then
-            performGet("/website/clubs/recent")
+            performGet("/konect/clubs/recent")
                 .andExpect(status().isBadRequest());
         }
     }


### PR DESCRIPTION
### 🔍 개요

* 공개 웹사이트 API의 base path를 `/website`에서 `/konect`로 변경합니다.


---

### 🚀 주요 변경 내용

* `WebsiteApi`의 `@RequestMapping`을 `/konect`로 변경
* 로그인 없이 접근 가능한 보안 예외 경로를 `/konect/**`로 변경
* 웹사이트 공개 API 통합 테스트 요청 URL을 `/konect` 기준으로 변경


---

### 💬 참고 사항

* `develop` 최신 상태에서 새 브랜치를 생성해 작업했습니다.
* 내부 패키지명과 DTO/서비스 이름의 `website`는 API URL 계약과 무관한 도메인 명칭이라 유지했습니다.
* `checkstyleTest`는 기존 unrelated 테스트 파일 3개의 line length 위반으로 실패합니다. 이번 변경 파일과는 무관하며, `checkstyleMain`과 전체 테스트는 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)