### PR TITLE
feat: 대학교 이미지 업로드 target 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
@@ -21,7 +21,7 @@ public interface UploadApi {
     @Operation(summary = "이미지 파일을 업로드한다.", description = """
         서버가 multipart 파일을 받아 S3에 업로드합니다.
         
-        - target 쿼리파라미터로 이미지 저장 대상 도메인을 지정합니다. (CLUB, BANK, COUNCIL, USER)
+        - target 쿼리파라미터로 이미지 저장 대상 도메인을 지정합니다. (CLUB, BANK, COUNCIL, USER, UNIVERSITY)
         - 응답의 fileUrl을 기존 도메인 API의 imageUrl로 사용합니다.
         
         ## 에러

--- a/src/main/java/gg/agit/konect/domain/upload/enums/UploadTarget.java
+++ b/src/main/java/gg/agit/konect/domain/upload/enums/UploadTarget.java
@@ -10,6 +10,7 @@ public enum UploadTarget {
     BANK("은행"),
     COUNCIL("총학생회"),
     USER("사용자"),
+    UNIVERSITY("대학교"),
     ;
 
     private final String description;

--- a/src/test/java/gg/agit/konect/integration/domain/upload/UploadApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/upload/UploadApiTest.java
@@ -80,6 +80,26 @@ class UploadApiTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("대학교 이미지를 업로드하면 university 경로에 저장한다")
+        void uploadUniversityImageSuccess() throws Exception {
+            // given
+            byte[] pngBytes = createPngBytes(8, 8);
+            MockMultipartFile file = imageFile("university.png", "image/png", pngBytes);
+
+            // when
+            MvcResult result = uploadImage(file, UploadTarget.UNIVERSITY)
+                .andExpect(status().isOk())
+                .andReturn();
+
+            // then
+            String responseBody = result.getResponse().getContentAsString();
+            String key = JsonPath.read(responseBody, "$.key");
+
+            assertThat(key).startsWith("test/university/");
+            assertThat(key).endsWith(".png");
+        }
+
+        @Test
         @DisplayName("jpeg 이미지를 업로드하면 원본 형태로 저장한다")
         void uploadJpegImageSuccess() throws Exception {
             // given

--- a/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/upload/service/UploadServiceTest.java
@@ -105,6 +105,26 @@ class UploadServiceTest extends ServiceTestSupport {
     }
 
     @Test
+    @DisplayName("uploadImage는 UNIVERSITY target을 university 경로로 저장한다")
+    void uploadImageBuildsUniversityKeyPath() {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "university.png",
+            "image/png",
+            "png-data".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when
+        ImageUploadResponse response = uploadService.uploadImage(file, UploadTarget.UNIVERSITY);
+
+        // then
+        assertThat(response.key()).matches(
+            "konect/university/\\d{4}-\\d{2}-\\d{2}-[0-9a-f\\-]{36}\\.png"
+        );
+    }
+
+    @Test
     @DisplayName("uploadImage는 leading slash prefix를 제거하고 trailing slash를 보정한다")
     void uploadImageNormalizesPrefixWithLeadingSlash() {
         // given


### PR DESCRIPTION
### 🔍 개요

* 대학교 이미지도 공통 업로드 API의 target으로 받을 수 있게 했습니다. 이제 `target=UNIVERSITY` 요청은 기존 업로드 흐름을 그대로 사용하면서 `university` 경로에 파일을 저장합니다.


---

### 🚀 주요 변경 내용

* `UploadTarget`에 `UNIVERSITY`를 추가했습니다.
* 업로드 API 설명에 지원 target 목록으로 `UNIVERSITY`를 반영했습니다.
* unit/integration 테스트에서 `UNIVERSITY` target이 `university` 저장 경로를 생성하는지 검증했습니다.


---

### 💬 참고 사항

* 검증: `CI=true ./gradlew test --tests 'gg.agit.konect.unit.domain.upload.service.UploadServiceTest' --tests 'gg.agit.konect.integration.domain.upload.UploadApiTest' --rerun-tasks`
* pre-push hook에서 `checkstyleMain`, `compileJava`가 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
