### PR TITLE
fix: 대학 기본 이미지 URL 갱신

### DIFF
--- a/src/main/resources/db/migration/V74__update_university_image_url_default.sql
+++ b/src/main/resources/db/migration/V74__update_university_image_url_default.sql
@@ -1,0 +1,7 @@
+ALTER TABLE university
+    MODIFY COLUMN image_url VARCHAR(255) NOT NULL DEFAULT 'https://stage-static.koreatech.in/konect/university/university_logo_sample.webp' AFTER region;
+
+UPDATE university
+SET image_url = 'https://stage-static.koreatech.in/konect/university/university_logo_sample.webp'
+WHERE image_url IS NULL
+   OR image_url = 'https://stage-static.koreatech.in/konect/user/university_logo_sample.png';

--- a/src/test/java/gg/agit/konect/support/fixture/UniversityFixture.java
+++ b/src/test/java/gg/agit/konect/support/fixture/UniversityFixture.java
@@ -9,7 +9,7 @@ import gg.agit.konect.domain.university.model.University;
 public class UniversityFixture {
 
     private static final String DEFAULT_IMAGE_URL =
-        "https://stage-static.koreatech.in/konect/user/university_logo_sample.png";
+        "https://stage-static.koreatech.in/konect/university/university_logo_sample.webp";
 
     public static University create() {
         return create("한국기술교육대학교", Campus.MAIN);


### PR DESCRIPTION
### 🔍 개요

* 대학교 로고 기본 이미지가 `user` 경로의 png 샘플 대신 `university` 경로의 webp 샘플을 사용하도록 보정합니다.


---

### 🚀 주요 변경 내용

* `university.image_url` 컬럼의 DB 기본값을 새 샘플 이미지 URL로 지정했습니다.
* 기존 샘플 URL 또는 `NULL` 값만 새 URL로 갱신해 커스텀 이미지 값은 유지했습니다.
* 테스트 fixture의 기본 이미지 URL도 DB 기본값과 동일하게 맞췄습니다.


---

### 💬 참고 사항

* 검증: `./gradlew test --tests gg.agit.konect.integration.domain.university.UniversityApiTest`
* 푸시 전 hook에서 `checkstyleMain`, `compileJava`가 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
