### PR TITLE
feat: 동아리 상세에 대학 요약 정보 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
@@ -45,6 +45,7 @@ public record WebsiteClubDetailResponse(
     Recruitment recruitment
 ) {
 
+    @Schema(name = "WebsiteClubDetailUniversityResponse")
     public record University(
         @Schema(description = "대학 고유 ID", example = "1", requiredMode = REQUIRED)
         Integer id,
@@ -59,7 +60,17 @@ public record WebsiteClubDetailResponse(
         UniversityRegion region,
 
         @Schema(description = "지역명", example = "충청도", requiredMode = REQUIRED)
-        String regionName
+        String regionName,
+
+        @Schema(
+            description = "대학 로고 이미지 URL",
+            example = "https://example.com/koreatech-logo.png",
+            requiredMode = REQUIRED
+        )
+        String imageUrl,
+
+        @Schema(description = "대학에 등록된 동아리 수", example = "28", requiredMode = REQUIRED)
+        Long clubCount
     ) {
     }
 
@@ -95,7 +106,7 @@ public record WebsiteClubDetailResponse(
         }
     }
 
-    public static WebsiteClubDetailResponse of(Club club, Long memberCount) {
+    public static WebsiteClubDetailResponse of(Club club, Long memberCount, Long universityClubCount) {
         return new WebsiteClubDetailResponse(
             club.getId(),
             club.getName(),
@@ -111,7 +122,9 @@ public record WebsiteClubDetailResponse(
                 club.getUniversity().getKoreanName(),
                 club.getUniversity().getCampus().getDisplayName(),
                 club.getUniversity().getRegion(),
-                club.getUniversity().getRegion().getDisplayName()
+                club.getUniversity().getRegion().getDisplayName(),
+                club.getUniversity().getImageUrl(),
+                universityClubCount
             ),
             Recruitment.from(club)
         );

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
@@ -125,6 +125,16 @@ public class WebsiteQueryRepository {
         return categoryCounts;
     }
 
+    public Long countClubsByUniversityId(Integer universityId) {
+        Long count = jpaQueryFactory
+            .select(club.count())
+            .from(club)
+            .where(club.university.id.eq(universityId))
+            .fetchOne();
+
+        return count == null ? 0 : count;
+    }
+
     public Optional<Club> findClub(Integer clubId) {
         return Optional.ofNullable(jpaQueryFactory
             .selectFrom(club)

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
@@ -129,7 +129,7 @@ public class WebsiteQueryRepository {
         Long count = jpaQueryFactory
             .select(club.count())
             .from(club)
-            .where(club.university.id.eq(universityId))
+            .where(createClubCondition(universityId, null, null))
             .fetchOne();
 
         return count == null ? 0 : count;

--- a/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
+++ b/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
@@ -63,8 +63,9 @@ public class WebsiteService {
         Club club = websiteQueryRepository.findClub(clubId)
             .orElseThrow(() -> CustomException.of(NOT_FOUND_CLUB));
         Long memberCount = websiteQueryRepository.countMembersByClubIds(List.of(clubId)).getOrDefault(clubId, 0L);
+        Long universityClubCount = websiteQueryRepository.countClubsByUniversityId(club.getUniversity().getId());
 
-        return WebsiteClubDetailResponse.of(club, memberCount);
+        return WebsiteClubDetailResponse.of(club, memberCount, universityClubCount);
     }
 
     public WebsiteClubsResponse getRecentClubs(List<Integer> clubIds) {

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -126,9 +126,11 @@ class WebsiteApiTest extends IntegrationTestSupport {
             University university = persist(UniversityFixture.create(
                 "한국기술교육대학교",
                 Campus.MAIN,
-                UniversityRegion.CHUNGCHEONG
+                UniversityRegion.CHUNGCHEONG,
+                "https://example.com/koreatech-logo.png"
             ));
             Club club = persist(createClub(university, "ZEST", ClubCategory.PERFORMANCE));
+            persist(createClub(university, "BCSD Lab", ClubCategory.ACADEMIC));
             persist(ClubRecruitmentFixture.createAlwaysRecruiting(club));
             persistMember(club, "회장", "2024000004");
             clearPersistenceContext();
@@ -140,6 +142,8 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.categoryName").value("공연"))
                 .andExpect(jsonPath("$.university.name").value("한국기술교육대학교"))
                 .andExpect(jsonPath("$.university.region").value("CHUNGCHEONG"))
+                .andExpect(jsonPath("$.university.imageUrl").value("https://example.com/koreatech-logo.png"))
+                .andExpect(jsonPath("$.university.clubCount").value(2))
                 .andExpect(jsonPath("$.memberCount").value(1))
                 .andExpect(jsonPath("$.recruitment.isAlwaysRecruiting").value(true))
                 .andExpect(jsonPath("$.recruitment.content").value("상시 모집 공고 내용입니다."));


### PR DESCRIPTION
### 🔍 개요

* `GET /konect/clubs/{clubId}` 응답에서 동아리 상세 화면이 대학 로고와 해당 대학의 전체 등록 동아리 수를 바로 사용할 수 있습니다.
* 기존 `memberCount`는 현재 동아리의 회원 수로 유지하고, 대학 단위 수치는 `university.clubCount`로 분리했습니다.


---

### 🚀 주요 변경 내용

* 동아리 상세 응답의 `university` 객체에 `imageUrl`, `clubCount` 필드를 추가했습니다.
* 상세 조회 시 동아리가 속한 대학의 전체 동아리 수를 별도 QueryDSL 카운트 쿼리로 계산합니다.
* `WebsiteApiTest`에서 대학 이미지 URL과 대학 등록 동아리 수 응답 계약을 검증했습니다.


---

### 💬 참고 사항

* 검증: `./gradlew test --tests gg.agit.konect.integration.domain.website.WebsiteApiTest`
* pre-push 훅에서 formatter, `checkstyleMain`, `compileJava`가 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
