### PR TITLE
fix: 동아리 등록 요청 Slack 메시지에 요청값 전체 표시

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/event/ClubRegistrationRequestedEvent.java
+++ b/src/main/java/gg/agit/konect/domain/club/event/ClubRegistrationRequestedEvent.java
@@ -1,5 +1,7 @@
 package gg.agit.konect.domain.club.event;
 
+import java.util.List;
+
 import gg.agit.konect.domain.club.model.ClubRegistrationRequest;
 
 public record ClubRegistrationRequestedEvent(
@@ -10,7 +12,8 @@ public record ClubRegistrationRequestedEvent(
     String topic,
     String emoji,
     String description,
-    int imageCount
+    String fullIntroduction,
+    List<String> imageUrls
 ) {
 
     public static ClubRegistrationRequestedEvent from(ClubRegistrationRequest request) {
@@ -22,7 +25,14 @@ public record ClubRegistrationRequestedEvent(
             request.getClubTopic(),
             request.getClubEmoji(),
             request.getShortDescription(),
-            request.getImages().size()
+            request.getFullIntroduction(),
+            request.getImages().stream()
+                .map(image -> image.getImageUrl())
+                .toList()
         );
+    }
+
+    public int imageCount() {
+        return imageUrls.size();
     }
 }

--- a/src/main/java/gg/agit/konect/infrastructure/slack/enums/SlackMessageTemplate.java
+++ b/src/main/java/gg/agit/konect/infrastructure/slack/enums/SlackMessageTemplate.java
@@ -40,14 +40,21 @@ public enum SlackMessageTemplate {
     ),
     CLUB_REGISTRATION_REQUEST(
         """
-            *:new: 새로운 동아리 등록 요청이 들어왔습니다.*
-            요청 ID: %s
-            대학교: %s
-            동아리명: %s %s
-            분과: %s
-            주제: %s
-            한 줄 소개: %s
-            첨부 이미지 수: %d개
+            *:sparkles: 새 동아리 등록 요청이 도착했어요*
+            > `요청 #%s`  %s *%s*
+            
+            :school: *대학교*  %s
+            :label: *분과*  %s
+            :dart: *주제*  %s
+            
+            :memo: *한 줄 소개*
+            %s
+            
+            :page_facing_up: *상세 소개*
+            %s
+            
+            :paperclip: *첨부 이미지*  %d개
+            %s
             """
     ),
     ;

--- a/src/main/java/gg/agit/konect/infrastructure/slack/listener/ClubRegistrationRequestSlackListener.java
+++ b/src/main/java/gg/agit/konect/infrastructure/slack/listener/ClubRegistrationRequestSlackListener.java
@@ -30,7 +30,8 @@ public class ClubRegistrationRequestSlackListener {
                 event.topic(),
                 event.emoji(),
                 event.description(),
-                event.imageCount()
+                event.fullIntroduction(),
+                event.imageUrls()
             );
         } catch (RuntimeException e) {
             log.warn("Failed to send club registration request Slack notification. requestId={}", event.requestId(), e);

--- a/src/main/java/gg/agit/konect/infrastructure/slack/service/SlackNotificationService.java
+++ b/src/main/java/gg/agit/konect/infrastructure/slack/service/SlackNotificationService.java
@@ -7,6 +7,8 @@ import static gg.agit.konect.infrastructure.slack.enums.SlackMessageTemplate.SHE
 import static gg.agit.konect.infrastructure.slack.enums.SlackMessageTemplate.USER_REGISTER;
 import static gg.agit.konect.infrastructure.slack.enums.SlackMessageTemplate.USER_WITHDRAWAL;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import gg.agit.konect.domain.club.event.SheetSyncFailedEvent;
@@ -60,18 +62,42 @@ public class SlackNotificationService {
         String topic,
         String emoji,
         String description,
-        int imageCount
+        String fullIntroduction,
+        List<String> imageUrls
     ) {
         String message = CLUB_REGISTRATION_REQUEST.format(
             requestId,
-            universityName,
+            emoji,
             clubName,
+            universityName,
             category,
             topic,
-            emoji,
-            description,
-            imageCount
+            formatBlockQuote(description),
+            formatBlockQuote(fullIntroduction),
+            imageUrls.size(),
+            formatImageUrls(imageUrls)
         );
         slackClient.sendMessage(message, slackProperties.webhooks().event());
+    }
+
+    private String formatBlockQuote(String text) {
+        return "> " + text.replace(System.lineSeparator(), System.lineSeparator() + "> ");
+    }
+
+    private String formatImageUrls(List<String> imageUrls) {
+        if (imageUrls.isEmpty()) {
+            return "> 없음";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            builder.append("> ")
+                .append(i + 1)
+                .append(". ")
+                .append(imageUrls.get(i));
+            if (i < imageUrls.size() - 1) {
+                builder.append(System.lineSeparator());
+            }
+        }
+        return builder.toString();
     }
 }

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubRegistrationRequestServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubRegistrationRequestServiceTest.java
@@ -74,6 +74,11 @@ class ClubRegistrationRequestServiceTest extends ServiceTestSupport {
         assertThat(event.universityName()).isEqualTo(request.universityName());
         assertThat(event.clubName()).isEqualTo(request.clubName());
         assertThat(event.category()).isEqualTo(request.clubCategory().getDescription());
+        assertThat(event.topic()).isEqualTo(request.clubTopic());
+        assertThat(event.emoji()).isEqualTo(request.clubEmoji());
+        assertThat(event.description()).isEqualTo(request.shortDescription());
+        assertThat(event.fullIntroduction()).isEqualTo(request.fullIntroduction());
+        assertThat(event.imageUrls()).containsExactlyElementsOf(request.imageUrls());
         assertThat(event.imageCount()).isEqualTo(1);
     }
 }

--- a/src/test/java/gg/agit/konect/unit/infrastructure/slack/listener/ClubRegistrationRequestSlackListenerTest.java
+++ b/src/test/java/gg/agit/konect/unit/infrastructure/slack/listener/ClubRegistrationRequestSlackListenerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -40,7 +42,8 @@ class ClubRegistrationRequestSlackListenerTest extends ServiceTestSupport {
             event.topic(),
             event.emoji(),
             event.description(),
-            event.imageCount()
+            event.fullIntroduction(),
+            event.imageUrls()
         );
     }
 
@@ -59,7 +62,8 @@ class ClubRegistrationRequestSlackListenerTest extends ServiceTestSupport {
                 event.topic(),
                 event.emoji(),
                 event.description(),
-                event.imageCount()
+                event.fullIntroduction(),
+                event.imageUrls()
             );
 
         // when & then
@@ -76,7 +80,8 @@ class ClubRegistrationRequestSlackListenerTest extends ServiceTestSupport {
             "코딩",
             "💻",
             "코딩 동아리입니다.",
-            1
+            "상세한 동아리 소개 내용입니다.",
+            List.of("https://example.com/image1.jpg")
         );
     }
 }

--- a/src/test/java/gg/agit/konect/unit/infrastructure/slack/service/SlackNotificationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/infrastructure/slack/service/SlackNotificationServiceTest.java
@@ -1,0 +1,81 @@
+package gg.agit.konect.unit.infrastructure.slack.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import gg.agit.konect.infrastructure.slack.client.SlackClient;
+import gg.agit.konect.infrastructure.slack.config.SlackProperties;
+import gg.agit.konect.infrastructure.slack.service.SlackNotificationService;
+import gg.agit.konect.support.ServiceTestSupport;
+
+class SlackNotificationServiceTest extends ServiceTestSupport {
+
+    private static final String ERROR_WEBHOOK_URL = "https://hooks.slack.com/error";
+    private static final String EVENT_WEBHOOK_URL = "https://hooks.slack.com/event";
+
+    @Mock
+    private SlackClient slackClient;
+
+    private SlackNotificationService slackNotificationService;
+
+    @BeforeEach
+    void setUp() {
+        SlackProperties slackProperties = new SlackProperties(
+            new SlackProperties.Webhooks(ERROR_WEBHOOK_URL, EVENT_WEBHOOK_URL),
+            "signing-secret",
+            "bot-token"
+        );
+        slackNotificationService = new SlackNotificationService(slackProperties, slackClient);
+    }
+
+    @Test
+    @DisplayName("동아리 등록 요청 Slack 메시지를 마크다운과 이모지로 구성한다")
+    void notifyClubRegistrationRequestFormatsSlackMessageWithMarkdownAndEmoji() {
+        // when
+        slackNotificationService.notifyClubRegistrationRequest(
+            1,
+            "한국기술교육대학교",
+            "BCSD Lab",
+            "학술",
+            "코딩",
+            "💻",
+            "코딩 동아리입니다.",
+            "상세한 동아리 소개 내용입니다.",
+            List.of("https://example.com/image1.jpg", "https://example.com/image2.jpg")
+        );
+
+        // then
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(slackClient).sendMessage(messageCaptor.capture(), eq(EVENT_WEBHOOK_URL));
+        assertThat(messageCaptor.getValue()).isEqualTo(
+            """
+                *:sparkles: 새 동아리 등록 요청이 도착했어요*
+                > `요청 #1`  💻 *BCSD Lab*
+                
+                :school: *대학교*  한국기술교육대학교
+                :label: *분과*  학술
+                :dart: *주제*  코딩
+                
+                :memo: *한 줄 소개*
+                > 코딩 동아리입니다.
+                
+                :page_facing_up: *상세 소개*
+                > 상세한 동아리 소개 내용입니다.
+                
+                :paperclip: *첨부 이미지*  2개
+                > 1. https://example.com/image1.jpg
+                > 2. https://example.com/image2.jpg
+                """
+        );
+    }
+
+}


### PR DESCRIPTION
### 🔍 개요

* 동아리 등록 요청 Slack 알림에서 운영자가 요청 본문 전체를 바로 확인할 수 있도록 개선했습니다.
* 기존에는 일부 요약값만 보여서 상세 소개와 첨부 URL을 확인하려면 별도 조회가 필요했지만, 이제 등록 요청 값이 Slack 메시지 안에 함께 표시됩니다.

---

### 🚀 주요 변경 내용

* 등록 요청 이벤트에 `fullIntroduction`과 `imageUrls`를 포함해 Slack 알림까지 전달되도록 확장했습니다.
* Slack 메시지를 마크다운과 이모지 기반으로 정리하고, 한 줄 소개/상세 소개/첨부 이미지 목록을 읽기 쉬운 quote 형태로 표시합니다.
* 이미지가 없는 요청도 `없음`으로 명확히 표시해 운영자가 누락과 미첨부를 구분할 수 있게 했습니다.
* Slack 메시지 포맷과 이벤트 payload 전달 범위를 단위 테스트로 고정했습니다.

---

### 💬 참고 사항

* Slack webhook 전송은 외부 운영 채널 의존이므로 PR 본문에는 별도 데모 캡처를 첨부하지 않았습니다.
* 검증은 등록 요청 이벤트, Slack 리스너, Slack 알림 서비스 단위 테스트와 pre-push hook의 `checkstyleMain`, `compileJava`로 확인했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
