### PR TITLE
fix: 동아리 등록 요청 Slack 메시지 형식 정리

### DIFF
--- a/src/main/java/gg/agit/konect/infrastructure/slack/enums/SlackMessageTemplate.java
+++ b/src/main/java/gg/agit/konect/infrastructure/slack/enums/SlackMessageTemplate.java
@@ -40,21 +40,22 @@ public enum SlackMessageTemplate {
     ),
     CLUB_REGISTRATION_REQUEST(
         """
-            *:sparkles: 새 동아리 등록 요청이 도착했어요*
-            > `요청 #%s`  %s *%s*
+            :sparkles: *새 동아리 등록 요청이 도착했어요*
             
-            :school: *대학교*  %s
-            :label: *분과*  %s
-            :dart: *주제*  %s
+            :school: *대학교* : *`%s`*
+            %s *동아리* : *`%s`*
+            :label: *분과* : *`%s`*
+            :dart: *주제* : *`%s`*
+            :art: *요청 이모지* : *`%s`*
             
             :memo: *한 줄 소개*
-            %s
+            ```%s```
             
             :page_facing_up: *상세 소개*
-            %s
+            ```%s```
             
-            :paperclip: *첨부 이미지*  %d개
-            %s
+            :paperclip: *첨부 이미지*
+            ```%s```
             """
     ),
     ;

--- a/src/main/java/gg/agit/konect/infrastructure/slack/service/SlackNotificationService.java
+++ b/src/main/java/gg/agit/konect/infrastructure/slack/service/SlackNotificationService.java
@@ -66,34 +66,26 @@ public class SlackNotificationService {
         List<String> imageUrls
     ) {
         String message = CLUB_REGISTRATION_REQUEST.format(
-            requestId,
+            universityName,
             emoji,
             clubName,
-            universityName,
             category,
             topic,
-            formatBlockQuote(description),
-            formatBlockQuote(fullIntroduction),
-            imageUrls.size(),
+            emoji,
+            description,
+            fullIntroduction,
             formatImageUrls(imageUrls)
         );
         slackClient.sendMessage(message, slackProperties.webhooks().event());
     }
 
-    private String formatBlockQuote(String text) {
-        return "> " + text.replace(System.lineSeparator(), System.lineSeparator() + "> ");
-    }
-
     private String formatImageUrls(List<String> imageUrls) {
         if (imageUrls.isEmpty()) {
-            return "> 없음";
+            return "없음";
         }
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < imageUrls.size(); i++) {
-            builder.append("> ")
-                .append(i + 1)
-                .append(". ")
-                .append(imageUrls.get(i));
+            builder.append(imageUrls.get(i));
             if (i < imageUrls.size() - 1) {
                 builder.append(System.lineSeparator());
             }

--- a/src/test/java/gg/agit/konect/unit/infrastructure/slack/service/SlackNotificationServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/infrastructure/slack/service/SlackNotificationServiceTest.java
@@ -58,22 +58,23 @@ class SlackNotificationServiceTest extends ServiceTestSupport {
         verify(slackClient).sendMessage(messageCaptor.capture(), eq(EVENT_WEBHOOK_URL));
         assertThat(messageCaptor.getValue()).isEqualTo(
             """
-                *:sparkles: 새 동아리 등록 요청이 도착했어요*
-                > `요청 #1`  💻 *BCSD Lab*
+                :sparkles: *새 동아리 등록 요청이 도착했어요*
                 
-                :school: *대학교*  한국기술교육대학교
-                :label: *분과*  학술
-                :dart: *주제*  코딩
+                :school: *대학교* : *`한국기술교육대학교`*
+                💻 *동아리* : *`BCSD Lab`*
+                :label: *분과* : *`학술`*
+                :dart: *주제* : *`코딩`*
+                :art: *요청 이모지* : *`💻`*
                 
                 :memo: *한 줄 소개*
-                > 코딩 동아리입니다.
+                ```코딩 동아리입니다.```
                 
                 :page_facing_up: *상세 소개*
-                > 상세한 동아리 소개 내용입니다.
+                ```상세한 동아리 소개 내용입니다.```
                 
-                :paperclip: *첨부 이미지*  2개
-                > 1. https://example.com/image1.jpg
-                > 2. https://example.com/image2.jpg
+                :paperclip: *첨부 이미지*
+                ```https://example.com/image1.jpg
+                https://example.com/image2.jpg```
                 """
         );
     }


### PR DESCRIPTION
### 🔍 개요

* 동아리 등록 요청 Slack 알림을 운영자가 요청값을 더 자연스럽게 읽을 수 있는 형태로 정리했습니다.
* 동아리명 앞에는 요청으로 들어온 동아리 이모지를 표시하고, 같은 이모지를 별도 필드로도 보여 입력값 확인이 가능하게 했습니다.

---

### 🚀 주요 변경 내용

* Slack 메시지 제목과 필드 구성을 요청한 예시 형식에 맞춰 라벨 중심으로 단순화했습니다.
* 한 줄 소개, 상세 소개, 첨부 이미지 URL을 quote/번호 없이 요청값에 가까운 형태로 표시합니다.
* Slack 메시지 포맷 단위 테스트를 새 템플릿에 맞게 갱신했습니다.

---

### 💬 참고 사항

* 이전 PR #638은 이미 merge되어, 최신 `develop` 기준의 별도 포맷 조정 PR로 분리했습니다.
* 검증은 대상 단위 테스트와 pre-push hook의 `checkstyleMain`, `compileJava`로 확인했습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
