### PR TITLE
fix: 대학별 동아리 수를 대학 응답에 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
@@ -56,9 +56,12 @@ public record WebsiteClubsResponse(
             example = "https://example.com/koreatech-logo.png",
             requiredMode = REQUIRED
         )
-        String imageUrl
+        String imageUrl,
+
+        @Schema(description = "대학 전체 동아리 수", example = "28", requiredMode = REQUIRED)
+        Long clubCount
     ) {
-        public static UniversityResponse from(WebUniversity university) {
+        public static UniversityResponse of(WebUniversity university, Long clubCount) {
             if (university == null) {
                 return null;
             }
@@ -69,7 +72,8 @@ public record WebsiteClubsResponse(
                 university.getCampus().getDisplayName(),
                 university.getRegion(),
                 university.getRegion().getDisplayName(),
-                university.getImageUrl()
+                university.getImageUrl(),
+                clubCount
             );
         }
     }
@@ -127,10 +131,11 @@ public record WebsiteClubsResponse(
     public static WebsiteClubsResponse of(
         WebUniversity university,
         Page<WebClub> page,
+        Long universityClubCount,
         java.util.Map<ClubCategory, Long> categoryCounts
     ) {
         return new WebsiteClubsResponse(
-            UniversityResponse.from(university),
+            UniversityResponse.of(university, universityClubCount),
             page.getTotalElements(),
             page.getTotalPages(),
             page.getNumber() + 1,

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
@@ -126,7 +126,7 @@ public class WebsiteQueryRepository {
         Long count = jpaQueryFactory
             .select(webClub.count())
             .from(webClub)
-            .where(webClub.university.id.eq(universityId))
+            .where(createClubCondition(universityId, null, null))
             .fetchOne();
 
         return count == null ? 0 : count;

--- a/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
+++ b/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
@@ -51,6 +51,7 @@ public class WebsiteService {
         return WebsiteClubsResponse.of(
             university,
             clubs,
+            websiteQueryRepository.countClubsByUniversityId(universityId),
             websiteQueryRepository.countClubCategories(universityId, condition.query())
         );
     }

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -70,7 +70,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
     class GetUniversityClubs {
 
         @Test
-        @DisplayName("검색어와 분과로 동아리 목록을 조회하고 분과별 개수를 함께 반환한다")
+        @DisplayName("검색어와 분과로 동아리 목록을 조회하고 대학 전체 동아리 수를 함께 반환한다")
         void getUniversityClubsWithFilters() throws Exception {
             // given
             WebUniversity university = persist(WebUniversityFixture.create(
@@ -90,6 +90,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.university.name").value("한국기술교육대학교"))
                 .andExpect(jsonPath("$.university.imageUrl").value("https://example.com/koreatech-logo.png"))
+                .andExpect(jsonPath("$.university.clubCount").value(3))
                 .andExpect(jsonPath("$.totalCount").value(1))
                 .andExpect(jsonPath("$.clubs", hasSize(1)))
                 .andExpect(jsonPath("$.clubs[0].name").value("BCSD Lab"))


### PR DESCRIPTION
### 🔍 개요

* 대학별 동아리 목록에서 분과 필터를 선택해도 대학교 자체의 전체 동아리 수를 `university.clubCount`로 확인할 수 있도록 수정했습니다.


---

### 🚀 주요 변경 내용

* `totalCount`는 기존처럼 현재 검색어/분과 필터가 적용된 목록 개수로 유지했습니다.
* 필터와 무관한 대학 전체 동아리 수를 `university.clubCount` 필드로 분리했습니다.
* 대학 전체 동아리 수 조회는 기존 공통 동아리 조건을 재사용해 카운트 조건이 따로 drift되지 않도록 했습니다.


---

### 💬 참고 사항

* `./gradlew test --tests 'gg.agit.konect.integration.domain.website.WebsiteApiTest'` 통과했습니다.
* push 전 hook에서 `checkstyleMain`, `compileJava`가 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
