### PR TITLE
fix: 웹사이트 필터 목록을 표시명 순서로 정렬

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/enums/ClubCategory.java
+++ b/src/main/java/gg/agit/konect/domain/club/enums/ClubCategory.java
@@ -15,8 +15,7 @@ public enum ClubCategory {
     HOBBY("취미"),
     RELIGION("종교"),
     PERFORMANCE("공연"),
-    JUNIOR("준동아리")
-    ;
+    JUNIOR("준동아리");
 
     private final String description;
 

--- a/src/main/java/gg/agit/konect/domain/club/enums/ClubCategory.java
+++ b/src/main/java/gg/agit/konect/domain/club/enums/ClubCategory.java
@@ -1,5 +1,9 @@
 package gg.agit.konect.domain.club.enums;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -15,4 +19,16 @@ public enum ClubCategory {
     ;
 
     private final String description;
+
+    public static List<ClubCategory> sortedForDisplay() {
+        return Arrays.stream(values())
+            // 준동아리는 정식 동아리 분과가 아니므로 가나다 정렬과 무관하게 마지막에 노출한다.
+            .sorted(Comparator.comparing(ClubCategory::isJunior)
+                .thenComparing(ClubCategory::getDescription))
+            .toList();
+    }
+
+    private boolean isJunior() {
+        return this == JUNIOR;
+    }
 }

--- a/src/main/java/gg/agit/konect/domain/university/enums/UniversityRegion.java
+++ b/src/main/java/gg/agit/konect/domain/university/enums/UniversityRegion.java
@@ -1,5 +1,9 @@
 package gg.agit.konect.domain.university.enums;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -18,4 +22,16 @@ public enum UniversityRegion {
     ;
 
     private final String displayName;
+
+    public static List<UniversityRegion> sortedForDisplay() {
+        return Arrays.stream(values())
+            // 지역 미지정은 실제 지역 필터가 아니므로 가나다 정렬과 무관하게 마지막에 노출한다.
+            .sorted(Comparator.comparing(UniversityRegion::isUnknown)
+                .thenComparing(UniversityRegion::getDisplayName))
+            .toList();
+    }
+
+    private boolean isUnknown() {
+        return this == UNKNOWN;
+    }
 }

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
@@ -3,7 +3,6 @@ package gg.agit.konect.domain.website.dto;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -156,7 +155,7 @@ public record WebsiteClubsResponse(
     }
 
     private static List<CategoryCountResponse> createCategories(java.util.Map<ClubCategory, Long> categoryCounts) {
-        return Arrays.stream(ClubCategory.values())
+        return ClubCategory.sortedForDisplay().stream()
             .map(category -> CategoryCountResponse.of(category, categoryCounts.getOrDefault(category, 0L)))
             .toList();
     }

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteHomeResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteHomeResponse.java
@@ -12,9 +12,23 @@ public record WebsiteHomeResponse(
     @Schema(description = "검색 결과 대학 수", example = "28", requiredMode = REQUIRED)
     Integer totalUniversityCount,
 
+    @Schema(description = "지역 목록", requiredMode = REQUIRED)
+    List<RegionResponse> regions,
+
     @Schema(description = "대학 목록", requiredMode = REQUIRED)
     List<UniversityResponse> universities
 ) {
+    public record RegionResponse(
+        @Schema(description = "지역 코드", example = "CHUNGCHEONG", requiredMode = REQUIRED)
+        UniversityRegion region,
+
+        @Schema(description = "지역명", example = "충청도", requiredMode = REQUIRED)
+        String regionName
+    ) {
+        public static RegionResponse from(UniversityRegion region) {
+            return new RegionResponse(region, region.getDisplayName());
+        }
+    }
 
     @Schema(name = "WebsiteHomeUniversityResponse")
     public record UniversityResponse(
@@ -59,9 +73,16 @@ public record WebsiteHomeResponse(
     public static WebsiteHomeResponse from(List<WebsiteUniversitySummary> summaries) {
         return new WebsiteHomeResponse(
             summaries.size(),
+            createRegions(),
             summaries.stream()
                 .map(UniversityResponse::from)
                 .toList()
         );
+    }
+
+    private static List<RegionResponse> createRegions() {
+        return UniversityRegion.sortedForDisplay().stream()
+            .map(RegionResponse::from)
+            .toList();
     }
 }

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -53,6 +53,15 @@ class WebsiteApiTest extends IntegrationTestSupport {
             performGet("/konect/home?query=한국&region=CHUNGCHEONG")
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalUniversityCount").value(1))
+                .andExpect(jsonPath("$.regions", hasSize(8)))
+                .andExpect(jsonPath("$.regions[0].region").value("GANGWON"))
+                .andExpect(jsonPath("$.regions[1].region").value("GYEONGGI"))
+                .andExpect(jsonPath("$.regions[2].region").value("GYEONGSANG"))
+                .andExpect(jsonPath("$.regions[3].region").value("SEOUL"))
+                .andExpect(jsonPath("$.regions[4].region").value("JEOLLA"))
+                .andExpect(jsonPath("$.regions[5].region").value("JEJU"))
+                .andExpect(jsonPath("$.regions[6].region").value("CHUNGCHEONG"))
+                .andExpect(jsonPath("$.regions[7].region").value("UNKNOWN"))
                 .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"))
                 .andExpect(jsonPath("$.universities[0].campusName").value("본교"))
                 .andExpect(jsonPath("$.universities[0].region").value("CHUNGCHEONG"))
@@ -94,8 +103,13 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.totalCount").value(1))
                 .andExpect(jsonPath("$.clubs", hasSize(1)))
                 .andExpect(jsonPath("$.clubs[0].name").value("BCSD Lab"))
-                .andExpect(jsonPath("$.categories[0].category").value("ACADEMIC"))
-                .andExpect(jsonPath("$.categories[0].count").value(1));
+                .andExpect(jsonPath("$.categories[0].category").value("PERFORMANCE"))
+                .andExpect(jsonPath("$.categories[1].category").value("SPORTS"))
+                .andExpect(jsonPath("$.categories[2].category").value("RELIGION"))
+                .andExpect(jsonPath("$.categories[3].category").value("HOBBY"))
+                .andExpect(jsonPath("$.categories[4].category").value("ACADEMIC"))
+                .andExpect(jsonPath("$.categories[4].count").value(1))
+                .andExpect(jsonPath("$.categories[5].category").value("JUNIOR"));
         }
 
         @Test


### PR DESCRIPTION
### 🔍 개요

* 웹사이트 공개 API가 분과와 지역 필터 목록을 화면 표시명 기준 순서로 반환합니다.
* `준동아리`와 `지역 미지정`은 일반 필터 값과 섞이지 않도록 각각 목록의 마지막에 노출합니다.


---

### 🚀 주요 변경 내용

* `/konect/home` 응답에 가나다순으로 정렬된 `regions` 목록을 추가
* `/konect/universities/{universityId}/clubs`의 `categories`를 분과명 가나다순으로 반환
* 분과/지역 enum에 표시용 정렬 기준을 두어 응답 생성 로직에서 동일한 정책을 재사용
* 웹사이트 통합 테스트에서 분과와 지역 반환 순서를 고정


---

### 💬 참고 사항

* `./gradlew test --tests gg.agit.konect.integration.domain.website.WebsiteApiTest`로 웹사이트 API 응답 순서를 검증했습니다.
* `./gradlew compileJava checkstyleMain`과 pre-push hook의 formatter/checkstyle/compile 검증을 통과했습니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
