### PR TITLE
fix: 웹 동아리 위치 필드 제거

### DIFF
--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
@@ -33,9 +33,6 @@ public record WebsiteClubDetailResponse(
     @Schema(description = "상세 소개", requiredMode = REQUIRED)
     String introduce,
 
-    @Schema(description = "활동 위치", example = "학생회관 101호", requiredMode = REQUIRED)
-    String location,
-
     @Schema(description = "대학 정보", requiredMode = REQUIRED)
     University university
 ) {
@@ -80,7 +77,6 @@ public record WebsiteClubDetailResponse(
             club.getTopic(),
             club.getDescription(),
             club.getIntroduce(),
-            club.getLocation(),
             new University(
                 university.getId(),
                 university.getKoreanName(),

--- a/src/main/java/gg/agit/konect/domain/website/model/WebClub.java
+++ b/src/main/java/gg/agit/konect/domain/website/model/WebClub.java
@@ -55,9 +55,6 @@ public class WebClub extends BaseEntity {
     @Column(name = "image_url", length = 255, nullable = false)
     private String imageUrl;
 
-    @Column(name = "location", length = 255, nullable = false)
-    private String location;
-
     @Builder
     private WebClub(
         Integer id,
@@ -67,8 +64,7 @@ public class WebClub extends BaseEntity {
         String topic,
         String description,
         String introduce,
-        String imageUrl,
-        String location
+        String imageUrl
     ) {
         this.id = id;
         this.clubCategory = clubCategory;
@@ -78,6 +74,5 @@ public class WebClub extends BaseEntity {
         this.description = description;
         this.introduce = introduce;
         this.imageUrl = imageUrl;
-        this.location = location;
     }
 }

--- a/src/main/resources/db/migration/V83__allow_null_location_in_web_club.sql
+++ b/src/main/resources/db/migration/V83__allow_null_location_in_web_club.sql
@@ -1,0 +1,2 @@
+ALTER TABLE web_club
+    MODIFY COLUMN location VARCHAR(255) NULL;

--- a/src/main/resources/db/migration/V83__drop_location_from_web_club.sql
+++ b/src/main/resources/db/migration/V83__drop_location_from_web_club.sql
@@ -1,2 +1,0 @@
-ALTER TABLE web_club
-    DROP COLUMN location;

--- a/src/main/resources/db/migration/V83__drop_location_from_web_club.sql
+++ b/src/main/resources/db/migration/V83__drop_location_from_web_club.sql
@@ -1,0 +1,2 @@
+ALTER TABLE web_club
+    DROP COLUMN location;

--- a/src/test/java/gg/agit/konect/support/fixture/WebClubFixture.java
+++ b/src/test/java/gg/agit/konect/support/fixture/WebClubFixture.java
@@ -19,7 +19,6 @@ public class WebClubFixture {
             .description("한 줄 소개")
             .introduce("상세 소개입니다.")
             .imageUrl("https://example.com/" + name + ".png")
-            .location("학생회관 101호")
             .clubCategory(category)
             .topic("코딩")
             .build();


### PR DESCRIPTION
### 📌 개요

* 웹 동아리 데이터에서 사용하지 않기로 한 `location` 필드를 제거합니다.


---

### ✅ 주요 변경 내용

* `WebClub` 엔티티에서 `location` 필드를 제거했습니다.
* 웹 동아리 상세 응답 `WebsiteClubDetailResponse`에서 `location` 필드를 제거했습니다.
* `web_club.location` 컬럼을 제거하는 Flyway 마이그레이션을 추가했습니다.
* `WebClubFixture`에서 제거된 builder 필드 사용을 정리했습니다.


---

### 🧾 참고 사항

* 기존에 배포된 `V76` 마이그레이션은 checksum mismatch 방지를 위해 수정하지 않고, 신규 `V83` 마이그레이션으로 컬럼 제거를 처리했습니다.
* 앱용 `club.location` 및 학생회 `location` 필드는 이번 변경 범위가 아니므로 유지했습니다.
* 기존 main 대상 PR #645는 기준 브랜치가 잘못되어 새 PR로 다시 올렸습니다.


---

### ✅Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)