### PR TITLE
feat: 대학 검색 초성 및 약칭 지원

### DIFF
--- a/src/main/java/gg/agit/konect/domain/university/controller/UniversityApi.java
+++ b/src/main/java/gg/agit/konect/domain/university/controller/UniversityApi.java
@@ -3,6 +3,7 @@ package gg.agit.konect.domain.university.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import gg.agit.konect.domain.university.dto.UniversitiesResponse;
 
@@ -10,14 +11,17 @@ import gg.agit.konect.global.auth.annotation.PublicApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "(Normal) University: 대학", description = "대학 API")
+@Tag(name = "(Normal) University: 대학교", description = "대학교 API")
 @RequestMapping("/universities")
 public interface UniversityApi {
 
-    @Operation(summary = "대학 리스트를 조회한다.", description = """
-        - 응답값은 이름 기준 오름차순 정렬됩니다
+    @Operation(summary = "대학교 리스트를 조회한다.", description = """
+        - 응답값은 이름 기준 오름차순 정렬됩니다.
+        - query 파라미터로 대학교 이름, 초성, 약칭 검색을 지원합니다.
         """)
     @GetMapping
     @PublicApi
-    ResponseEntity<UniversitiesResponse> getUniversities();
+    ResponseEntity<UniversitiesResponse> getUniversities(
+        @RequestParam(name = "query", required = false) String query
+    );
 }

--- a/src/main/java/gg/agit/konect/domain/university/controller/UniversityController.java
+++ b/src/main/java/gg/agit/konect/domain/university/controller/UniversityController.java
@@ -16,8 +16,8 @@ public class UniversityController implements UniversityApi {
     private final UniversityService universityService;
 
     @Override
-    public ResponseEntity<UniversitiesResponse> getUniversities() {
-        UniversitiesResponse response = universityService.getUniversities();
+    public ResponseEntity<UniversitiesResponse> getUniversities(String query) {
+        UniversitiesResponse response = universityService.getUniversities(query);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
@@ -1,5 +1,6 @@
 package gg.agit.konect.domain.university.service;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,7 +102,7 @@ public class UniversitySearchMatcher {
     private Set<String> getDefaultAliases(String universityName) {
         String withoutWhitespace = universityName.replaceAll("\\s", "");
         String withoutCampus = withoutWhitespace.replaceAll("(서울|세종|글로벌|ERICA|WISE)캠퍼스$", "");
-        Set<String> aliases = new java.util.HashSet<>();
+        Set<String> aliases = new HashSet<>();
 
         aliases.add(withoutWhitespace);
         aliases.add(withoutCampus);

--- a/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
@@ -1,0 +1,157 @@
+package gg.agit.konect.domain.university.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import gg.agit.konect.domain.university.model.University;
+
+@Component
+public class UniversitySearchMatcher {
+
+    private static final int HANGUL_SYLLABLE_START = 0xAC00;
+    private static final int HANGUL_SYLLABLE_END = 0xD7A3;
+    private static final int HANGUL_SYLLABLE_INTERVAL = 588;
+    private static final int UNIVERSITY_SUFFIX_LENGTH = "대학교".length();
+
+    private static final List<String> CHOSEONG = List.of(
+        "ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ", "ㅅ",
+        "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"
+    );
+
+    private static final Map<String, String> COMPATIBILITY_JAMO_CLUSTERS = Map.ofEntries(
+        Map.entry("ㄳ", "ㄱㅅ"),
+        Map.entry("ㄵ", "ㄴㅈ"),
+        Map.entry("ㄶ", "ㄴㅎ"),
+        Map.entry("ㄺ", "ㄹㄱ"),
+        Map.entry("ㄻ", "ㄹㅁ"),
+        Map.entry("ㄼ", "ㄹㅂ"),
+        Map.entry("ㄽ", "ㄹㅅ"),
+        Map.entry("ㄾ", "ㄹㅌ"),
+        Map.entry("ㄿ", "ㄹㅍ"),
+        Map.entry("ㅀ", "ㄹㅎ"),
+        Map.entry("ㅄ", "ㅂㅅ")
+    );
+
+    private static final Map<String, List<String>> UNIVERSITY_ALIASES = Map.ofEntries(
+        Map.entry("가톨릭대학교", List.of("가대")),
+        Map.entry("건국대학교", List.of("건대")),
+        Map.entry("경북대학교", List.of("경대", "경북대")),
+        Map.entry("경희대학교", List.of("경희대")),
+        Map.entry("고려대학교", List.of("고대")),
+        Map.entry("광주과학기술원", List.of("광주과기원", "지스트", "gist")),
+        Map.entry("단국대학교", List.of("단대")),
+        Map.entry("대구경북과학기술원", List.of("대경과기원", "디지스트", "dgist")),
+        Map.entry("동국대학교", List.of("동대")),
+        Map.entry("부산대학교", List.of("부대", "부산대")),
+        Map.entry("서강대학교", List.of("서강대")),
+        Map.entry("서울과학기술대학교", List.of("과기대", "서울과기대")),
+        Map.entry("서울대학교", List.of("설대", "서울대")),
+        Map.entry("서울시립대학교", List.of("시립대", "서울시립대")),
+        Map.entry("성균관대학교", List.of("성대")),
+        Map.entry("연세대학교", List.of("연대")),
+        Map.entry("울산과학기술원", List.of("울산과기원", "유니스트", "unist")),
+        Map.entry("육군사관학교", List.of("육사")),
+        Map.entry("이화여자대학교", List.of("이대", "이화여대")),
+        Map.entry("전남대학교", List.of("전대", "전남대")),
+        Map.entry("중앙대학교", List.of("중대")),
+        Map.entry("충남대학교", List.of("충대", "충남대")),
+        Map.entry("충북대학교", List.of("충북대")),
+        Map.entry("포항공과대학교", List.of("포공", "포스텍", "postech")),
+        Map.entry("한국공학대학교", List.of("한공대", "한국공대")),
+        Map.entry("한국과학기술원", List.of("카이스트", "kaist")),
+        Map.entry("한국교통대학교", List.of("교통대", "한국교통대")),
+        Map.entry("한국기술교육대학교", List.of("한기대", "코리아텍", "koreatech")),
+        Map.entry("한국외국어대학교", List.of("외대", "한국외대")),
+        Map.entry("한국체육대학교", List.of("한체대")),
+        Map.entry("한국항공대학교", List.of("항공대", "한국항공대")),
+        Map.entry("한국해양대학교", List.of("해양대", "한국해양대")),
+        Map.entry("해군사관학교", List.of("해사")),
+        Map.entry("홍익대학교", List.of("홍대"))
+    );
+
+    public boolean matches(University university, String query) {
+        if (!StringUtils.hasText(query)) {
+            return true;
+        }
+
+        String normalizedQuery = normalize(query);
+        return getSearchTokens(university.getKoreanName())
+            .anyMatch(token -> token.contains(normalizedQuery));
+    }
+
+    private Stream<String> getSearchTokens(String universityName) {
+        Set<String> aliases = getDefaultAliases(universityName);
+        aliases.addAll(UNIVERSITY_ALIASES.getOrDefault(universityName, List.of()));
+
+        List<String> normalizedAliases = aliases.stream()
+            .map(this::normalize)
+            .toList();
+
+        return Stream.concat(
+            normalizedAliases.stream(),
+            normalizedAliases.stream().map(this::getChoseong)
+        ).distinct();
+    }
+
+    private Set<String> getDefaultAliases(String universityName) {
+        String withoutWhitespace = universityName.replaceAll("\\s", "");
+        String withoutCampus = withoutWhitespace.replaceAll("(서울|세종|글로벌|ERICA|WISE)캠퍼스$", "");
+        Set<String> aliases = new java.util.HashSet<>();
+
+        aliases.add(withoutWhitespace);
+        aliases.add(withoutCampus);
+
+        if (withoutCampus.endsWith("대학교")) {
+            aliases.add(withoutCampus.substring(0, withoutCampus.length() - UNIVERSITY_SUFFIX_LENGTH) + "대");
+        }
+
+        if (withoutCampus.startsWith("국립")) {
+            String withoutNational = withoutCampus.substring(2);
+            aliases.add(withoutNational);
+
+            if (withoutNational.endsWith("대학교")) {
+                aliases.add(withoutNational.substring(0, withoutNational.length() - UNIVERSITY_SUFFIX_LENGTH) + "대");
+            }
+        }
+
+        return aliases;
+    }
+
+    private String normalize(String value) {
+        return expandCompatibilityJamoClusters(value)
+            .replaceAll("\\s", "")
+            .toLowerCase();
+    }
+
+    private String expandCompatibilityJamoClusters(String value) {
+        StringBuilder builder = new StringBuilder();
+
+        value.codePoints()
+            .mapToObj(Character::toString)
+            .forEach(character -> builder.append(COMPATIBILITY_JAMO_CLUSTERS.getOrDefault(character, character)));
+
+        return builder.toString();
+    }
+
+    private String getChoseong(String value) {
+        StringBuilder builder = new StringBuilder();
+
+        value.codePoints()
+            .forEach(codePoint -> builder.append(toChoseong(codePoint)));
+
+        return builder.toString();
+    }
+
+    private String toChoseong(int codePoint) {
+        if (codePoint < HANGUL_SYLLABLE_START || codePoint > HANGUL_SYLLABLE_END) {
+            return Character.toString(codePoint);
+        }
+
+        return CHOSEONG.get((codePoint - HANGUL_SYLLABLE_START) / HANGUL_SYLLABLE_INTERVAL);
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/university/service/UniversityService.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversityService.java
@@ -17,9 +17,14 @@ import lombok.RequiredArgsConstructor;
 public class UniversityService {
 
     private final UniversityRepository universityRepository;
+    private final UniversitySearchMatcher universitySearchMatcher;
 
-    public UniversitiesResponse getUniversities() {
+    public UniversitiesResponse getUniversities(String query) {
         List<University> universities = universityRepository.findAllByOrderByKoreanNameAsc();
-        return UniversitiesResponse.from(universities);
+        List<University> filteredUniversities = universities.stream()
+            .filter(university -> universitySearchMatcher.matches(university, query))
+            .toList();
+
+        return UniversitiesResponse.from(filteredUniversities);
     }
 }

--- a/src/test/java/gg/agit/konect/integration/domain/university/UniversityApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/university/UniversityApiTest.java
@@ -48,7 +48,7 @@ class UniversityApiTest extends IntegrationTestSupport {
         }
 
         @Test
-        @DisplayName("동일한 이름이라도 캠퍼스가 다르면 각각 조회된다")
+        @DisplayName("동일한 이름이라도 캠퍼스가 다르면 각각 조회한다")
         void getUniversitiesWithSameNameDifferentCampus() throws Exception {
             // given
             persist(UniversityFixture.create("한국기술교육대학교", Campus.SECOND));
@@ -61,6 +61,58 @@ class UniversityApiTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.universities", hasSize(2)))
                 .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"))
                 .andExpect(jsonPath("$.universities[1].name").value("한국기술교육대학교"));
+        }
+
+        @Test
+        @DisplayName("query가 대학교 이름 초성이면 일치하는 대학 목록을 조회한다")
+        void getUniversitiesByChoseongQuery() throws Exception {
+            // given
+            persist(UniversityFixture.create("한국기술교육대학교", Campus.MAIN));
+            persist(UniversityFixture.create("서울과학기술대학교", Campus.MAIN));
+            persist(UniversityFixture.create("서울대학교", Campus.MAIN));
+            clearPersistenceContext();
+
+            // when & then
+            performGet(UNIVERSITIES_ENDPOINT + "?query=ㅎㄱㄱㅅㄱㅇㄷㅎㄱ")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.universities", hasSize(1)))
+                .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"));
+        }
+
+        @Test
+        @DisplayName("query 초성에 겹자음이 포함되어도 풀어서 검색한다")
+        void getUniversitiesByChoseongQueryWithCompatibilityJamoCluster() throws Exception {
+            // given
+            persist(UniversityFixture.create("한국기술교육대학교", Campus.MAIN));
+            persist(UniversityFixture.create("서울과학기술대학교", Campus.MAIN));
+            clearPersistenceContext();
+
+            // when & then
+            performGet(UNIVERSITIES_ENDPOINT + "?query=ㅎㄱㄳㄱㅇㄷㅎㄱ")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.universities", hasSize(1)))
+                .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"));
+        }
+
+        @Test
+        @DisplayName("query가 대학교 약칭이면 일치하는 대학 목록을 조회한다")
+        void getUniversitiesByAliasQuery() throws Exception {
+            // given
+            persist(UniversityFixture.create("한국기술교육대학교", Campus.MAIN));
+            persist(UniversityFixture.create("서울과학기술대학교", Campus.MAIN));
+            persist(UniversityFixture.create("서울대학교", Campus.MAIN));
+            clearPersistenceContext();
+
+            // when & then
+            performGet(UNIVERSITIES_ENDPOINT + "?query=한기대")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.universities", hasSize(1)))
+                .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"));
+
+            performGet(UNIVERSITIES_ENDPOINT + "?query=과기대")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.universities", hasSize(1)))
+                .andExpect(jsonPath("$.universities[0].name").value("서울과학기술대학교"));
         }
     }
 }


### PR DESCRIPTION
### 📝 개요

* 대학교 목록 조회 API에서 검색어(query)로 학교명뿐 아니라 초성 및 주요 약칭을 검색할 수 있도록 개선했습니다.


---

### 🔍 주요 변경 내용

* `/universities` API에 optional `query` 파라미터를 추가했습니다.
* `UniversitySearchMatcher`를 추가해 학교명 정규화, 초성 생성, 겹자음 초성 입력 보정, 약칭 매칭을 처리했습니다.
* `한국기술교육대학교`의 `ㅎㄱㄱㅅㄱㅇㄷㅎㄱ`, `ㅎㄱㄳㄱㅇㄷㅎㄱ`, `한기대` 검색과 `서울과학기술대학교`의 `과기대` 검색 통합 테스트를 추가했습니다.


---

### 💬 참고 사항

* 기존 `/universities` 전체 조회 동작은 query가 없을 때 그대로 유지됩니다.
* 검증: `./gradlew.bat test --tests "gg.agit.konect.integration.domain.university.UniversityApiTest"`, `./gradlew.bat compileJava`, `./gradlew.bat checkstyleMain` 통과했습니다.
* `./gradlew.bat build`는 기존 테스트 영역의 `checkstyleTest` LineLength 위반과 `SlackNotificationServiceTest` 2건 실패로 실패했습니다. 이번 변경 범위 테스트는 통과했습니다.


---

### ✅Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)