### PR TITLE
fix: 비로그인 업로드 API 허용

### DIFF
--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
@@ -10,7 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import gg.agit.konect.domain.upload.dto.ImageUploadResponse;
 import gg.agit.konect.domain.upload.enums.UploadTarget;
-import gg.agit.konect.global.auth.annotation.UserId;
+import gg.agit.konect.global.auth.annotation.PublicApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -25,15 +25,14 @@ public interface UploadApi {
         - 응답의 fileUrl을 기존 도메인 API의 imageUrl로 사용합니다.
         
         ## 에러
-        - MISSING_ACCESS_TOKEN (401): 액세스 토큰이 필요합니다.
         - INVALID_REQUEST_BODY (400): 파일이 비어있거나 요청 형식이 올바르지 않은 경우
         - INVALID_FILE_CONTENT_TYPE (400): 지원하지 않는 Content-Type 인 경우
         - PAYLOAD_TOO_LARGE (413): 파일 크기가 제한을 초과한 경우
         - FAILED_UPLOAD_FILE (500): S3 업로드에 실패한 경우
         """)
     @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PublicApi
     ResponseEntity<ImageUploadResponse> uploadImage(
-        @UserId Integer userId,
         @RequestPart("file") MultipartFile file,
         @RequestParam(value = "target") UploadTarget target
     );

--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
@@ -7,8 +7,6 @@ import org.springframework.web.multipart.MultipartFile;
 import gg.agit.konect.domain.upload.dto.ImageUploadResponse;
 import gg.agit.konect.domain.upload.enums.UploadTarget;
 import gg.agit.konect.domain.upload.service.UploadService;
-import gg.agit.konect.global.auth.annotation.UserId;
-import gg.agit.konect.global.ratelimit.annotation.RateLimit;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -17,10 +15,8 @@ public class UploadController implements UploadApi {
 
     private final UploadService uploadService;
 
-    @RateLimit(maxRequests = 20, timeWindowSeconds = 60, keyExpression = "#userId")
     @Override
     public ResponseEntity<ImageUploadResponse> uploadImage(
-        @UserId Integer userId,
         MultipartFile file,
         UploadTarget target
     ) {

--- a/src/test/java/gg/agit/konect/integration/domain/upload/UploadApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/upload/UploadApiTest.java
@@ -14,7 +14,6 @@ import java.io.ByteArrayOutputStream;
 
 import javax.imageio.ImageIO;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,24 +35,18 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 
 class UploadApiTest extends IntegrationTestSupport {
 
-    private static final int LOGIN_USER_ID = 2024001001;
     private static final int MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
 
     @MockitoBean
     private S3Client s3Client;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        mockLoginUser(LOGIN_USER_ID);
-    }
 
     @Nested
     @DisplayName("POST /upload/image - 이미지 업로드")
     class UploadImage {
 
         @Test
-        @DisplayName("지원하는 이미지를 업로드하면 원본 확장자로 key와 CDN URL을 반환한다")
-        void uploadImageSuccess() throws Exception {
+        @DisplayName("로그인 없이 지원하는 이미지를 업로드하면 원본 확장자로 key와 CDN URL을 반환한다")
+        void uploadImageWithoutLoginSuccess() throws Exception {
             // given
             byte[] pngBytes = createPngBytes(8, 8);
             MockMultipartFile file = imageFile("club.png", "image/png", pngBytes);


### PR DESCRIPTION
### 🔍 개요

* 웹사이트에서 로그인 전 사용자도 이미지 업로드 단계에서 401로 막히지 않고 `/upload/image`를 호출할 수 있습니다.


---

### 🚀 주요 변경 내용

* 업로드 이미지 엔드포인트를 공개 API로 전환했습니다.
* 공개 API 처리 중 `@UserId` 인자 리졸버가 다시 액세스 토큰을 요구하지 않도록 인증 의존 인자를 제거했습니다.
* 사용자 ID 기반 업로드 rate limit은 비로그인 키 정책이 정해지기 전까지 제거했습니다.
* 로그인 mock 없이 업로드 성공을 검증하도록 통합 테스트를 조정했습니다.


---

### 💬 참고 사항

* 추후 시간당 제한을 다시 붙일 때는 사용자 ID 대신 IP, 세션, 클라이언트 식별자 등 비로그인 요청에 사용할 제한 키 정책을 먼저 정해야 합니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
