### PR TITLE
fix: 웹사이트 대학 검색 초성 및 약칭 적용

### DIFF
--- a/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
@@ -76,12 +76,16 @@ public class UniversitySearchMatcher {
     );
 
     public boolean matches(University university, String query) {
+        return matches(university.getKoreanName(), query);
+    }
+
+    public boolean matches(String universityName, String query) {
         if (!StringUtils.hasText(query)) {
             return true;
         }
 
         String normalizedQuery = normalize(query);
-        return getSearchTokens(university.getKoreanName())
+        return getSearchTokens(universityName)
             .anyMatch(token -> token.contains(normalizedQuery));
     }
 

--- a/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
+++ b/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.university.service.UniversitySearchMatcher;
 import gg.agit.konect.domain.website.dto.WebsiteClubDetailResponse;
 import gg.agit.konect.domain.website.dto.WebsiteClubListCondition;
 import gg.agit.konect.domain.website.dto.WebsiteClubsResponse;
@@ -30,9 +31,13 @@ import lombok.RequiredArgsConstructor;
 public class WebsiteService {
 
     private final WebsiteQueryRepository websiteQueryRepository;
+    private final UniversitySearchMatcher universitySearchMatcher;
 
     public WebsiteHomeResponse getHome(String query, UniversityRegion region) {
-        List<WebsiteUniversitySummary> summaries = websiteQueryRepository.findUniversitySummaries(query, region);
+        List<WebsiteUniversitySummary> summaries = websiteQueryRepository.findUniversitySummaries(null, region)
+            .stream()
+            .filter(summary -> universitySearchMatcher.matches(summary.name(), query))
+            .toList();
         return WebsiteHomeResponse.from(summaries);
     }
 

--- a/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
+++ b/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
@@ -34,6 +34,7 @@ public class WebsiteService {
     private final UniversitySearchMatcher universitySearchMatcher;
 
     public WebsiteHomeResponse getHome(String query, UniversityRegion region) {
+        // 초성/약칭 검색은 SQL로 표현하기 어려워 전체 대학을 조회한 뒤 UniversitySearchMatcher로 필터링한다.
         List<WebsiteUniversitySummary> summaries = websiteQueryRepository.findUniversitySummaries(null, region)
             .stream()
             .filter(summary -> universitySearchMatcher.matches(summary.name(), query))

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -73,6 +73,40 @@ class WebsiteApiTest extends IntegrationTestSupport {
             verify(loginCheckInterceptor, never()).preHandle(any(), any(), any());
             verify(authorizationInterceptor, never()).preHandle(any(), any(), any());
         }
+
+        @Test
+        @DisplayName("대학교 이름 초성과 약칭으로 웹사이트 대학 목록을 검색한다")
+        void getHomeSearchesUniversitiesByChoseongAndAlias() throws Exception {
+            // given
+            persist(WebUniversityFixture.create(
+                "한국기술교육대학교",
+                Campus.MAIN,
+                UniversityRegion.CHUNGCHEONG,
+                "https://example.com/koreatech-logo.png"
+            ));
+            persist(WebUniversityFixture.create(
+                "서울과학기술대학교",
+                Campus.MAIN,
+                UniversityRegion.SEOUL
+            ));
+            clearPersistenceContext();
+
+            // when & then
+            performGet("/konect/home?query=ㅎㄱㄳㄱㅇㄷㅎㄱ")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalUniversityCount").value(1))
+                .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"));
+
+            performGet("/konect/home?query=한기대")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalUniversityCount").value(1))
+                .andExpect(jsonPath("$.universities[0].name").value("한국기술교육대학교"));
+
+            performGet("/konect/home?query=과기대")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalUniversityCount").value(1))
+                .andExpect(jsonPath("$.universities[0].name").value("서울과학기술대학교"));
+        }
     }
 
     @Nested


### PR DESCRIPTION
### 📝 개요

* 공개 웹사이트 홈 API(`/konect/home`)에서도 대학명 초성 및 약칭 검색이 동작하도록 보완했습니다.


---

### 🔍 주요 변경 내용

* `WebsiteService.getHome`에서 대학 요약 목록에 `UniversitySearchMatcher`를 적용해 이름/초성/약칭 검색을 지원합니다.
* `UniversitySearchMatcher`가 `University` 엔티티뿐 아니라 대학명 문자열도 매칭할 수 있도록 오버로드를 추가했습니다.
* `/konect/home?query=ㅎㄱㄳㄱㅇㄷㅎㄱ`, `한기대`, `과기대` 검색 통합 테스트를 추가했습니다.


---

### 💬 참고 사항

* PR #648은 `/universities` API 검색만 포함하고 머지되어, 공개 웹사이트 API는 별도 PR로 보완합니다.
* 검증: `./gradlew.bat test --tests "gg.agit.konect.integration.domain.website.WebsiteApiTest"`, `./gradlew.bat checkstyleMain` 통과했습니다.
* push 전 pre-push hook에서 `checkstyleMain`, `compileJava` 통과했습니다.


---

### ✅Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)