### PR TITLE
fix: 업로드 시간당 총량 제한 적용

### DIFF
--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
@@ -13,6 +13,7 @@ import gg.agit.konect.domain.upload.enums.UploadTarget;
 import gg.agit.konect.global.auth.annotation.PublicApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 
 @Tag(name = "(Normal) Upload: 업로드", description = "업로드 API")
 @RequestMapping("/upload")
@@ -28,11 +29,13 @@ public interface UploadApi {
         - INVALID_REQUEST_BODY (400): 파일이 비어있거나 요청 형식이 올바르지 않은 경우
         - INVALID_FILE_CONTENT_TYPE (400): 지원하지 않는 Content-Type 인 경우
         - PAYLOAD_TOO_LARGE (413): 파일 크기가 제한을 초과한 경우
+        - TOO_MANY_REQUESTS (429): 업로드 요청 횟수가 제한을 초과한 경우
         - FAILED_UPLOAD_FILE (500): S3 업로드에 실패한 경우
         """)
     @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PublicApi
     ResponseEntity<ImageUploadResponse> uploadImage(
+        HttpServletRequest request,
         @RequestPart("file") MultipartFile file,
         @RequestParam(value = "target") UploadTarget target
     );

--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadApi.java
@@ -13,7 +13,6 @@ import gg.agit.konect.domain.upload.enums.UploadTarget;
 import gg.agit.konect.global.auth.annotation.PublicApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 
 @Tag(name = "(Normal) Upload: 업로드", description = "업로드 API")
 @RequestMapping("/upload")
@@ -35,7 +34,6 @@ public interface UploadApi {
     @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PublicApi
     ResponseEntity<ImageUploadResponse> uploadImage(
-        HttpServletRequest request,
         @RequestPart("file") MultipartFile file,
         @RequestParam(value = "target") UploadTarget target
     );

--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
@@ -8,7 +8,6 @@ import gg.agit.konect.domain.upload.dto.ImageUploadResponse;
 import gg.agit.konect.domain.upload.enums.UploadTarget;
 import gg.agit.konect.domain.upload.service.UploadService;
 import gg.agit.konect.global.ratelimit.annotation.RateLimit;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -18,10 +17,9 @@ public class UploadController implements UploadApi {
     private final UploadService uploadService;
 
     // 비로그인 공개 업로드는 계정 식별자가 없어 프록시가 복원한 클라이언트 IP 기준으로 시간당 총량을 제한한다.
-    @RateLimit(maxRequests = 60, timeWindowSeconds = 3600, keyExpression = "#request.remoteAddr")
+    @RateLimit(maxRequests = 60, timeWindowSeconds = 3600, keyExpression = "#clientIp")
     @Override
     public ResponseEntity<ImageUploadResponse> uploadImage(
-        HttpServletRequest request,
         MultipartFile file,
         UploadTarget target
     ) {

--- a/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
+++ b/src/main/java/gg/agit/konect/domain/upload/controller/UploadController.java
@@ -7,6 +7,8 @@ import org.springframework.web.multipart.MultipartFile;
 import gg.agit.konect.domain.upload.dto.ImageUploadResponse;
 import gg.agit.konect.domain.upload.enums.UploadTarget;
 import gg.agit.konect.domain.upload.service.UploadService;
+import gg.agit.konect.global.ratelimit.annotation.RateLimit;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -15,8 +17,11 @@ public class UploadController implements UploadApi {
 
     private final UploadService uploadService;
 
+    // 비로그인 공개 업로드는 계정 식별자가 없어 프록시가 복원한 클라이언트 IP 기준으로 시간당 총량을 제한한다.
+    @RateLimit(maxRequests = 60, timeWindowSeconds = 3600, keyExpression = "#request.remoteAddr")
     @Override
     public ResponseEntity<ImageUploadResponse> uploadImage(
+        HttpServletRequest request,
         MultipartFile file,
         UploadTarget target
     ) {

--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -10,9 +10,12 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import gg.agit.konect.global.ratelimit.annotation.RateLimit;
 import gg.agit.konect.global.ratelimit.exception.RateLimitExceededException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
@@ -103,6 +106,7 @@ public class RateLimitAspect {
         for (int i = 0; i < paramNames.length; i++) {
             context.setVariable(paramNames[i], args[i]);
         }
+        context.setVariable("clientIp", resolveClientIp());
 
         try {
             Object result = parser.parseExpression(keyExpression).getValue(context);
@@ -113,5 +117,14 @@ public class RateLimitAspect {
                 keyExpression, methodKey, e.getMessage());
             return RATE_LIMIT_KEY_PREFIX + methodKey;
         }
+    }
+
+    private String resolveClientIp() {
+        if (!(RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes attributes)) {
+            return "unknown";
+        }
+
+        HttpServletRequest request = attributes.getRequest();
+        return request.getRemoteAddr();
     }
 }

--- a/src/test/java/gg/agit/konect/integration/domain/upload/UploadApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/upload/UploadApiTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -320,6 +321,27 @@ class UploadApiTest extends IntegrationTestSupport {
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.code").value("FAILED_UPLOAD_FILE"));
         }
+
+        @Test
+        @DisplayName("같은 IP에서 1시간에 60개를 초과해 업로드하면 429를 반환한다")
+        void uploadImageRateLimitExceededFails() throws Exception {
+            // given
+            String clientIp = "203.0.113.10";
+            byte[] pngBytes = createPngBytes(8, 8);
+
+            // when
+            for (int i = 0; i < 60; i++) {
+                uploadImage(imageFile("club.png", "image/png", pngBytes), UploadTarget.CLUB, clientIp)
+                    .andExpect(status().isOk());
+            }
+
+            // then
+            uploadImage(imageFile("club.png", "image/png", pngBytes), UploadTarget.CLUB, clientIp)
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.code").value("TOO_MANY_REQUESTS"));
+
+            verify(s3Client, times(60)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        }
     }
 
     private ResultActions uploadImage(MockMultipartFile file, UploadTarget target) throws Exception {
@@ -331,6 +353,18 @@ class UploadApiTest extends IntegrationTestSupport {
             multipart("/upload/image")
                 .file(file)
                 .param("target", target)
+        );
+    }
+
+    private ResultActions uploadImage(MockMultipartFile file, UploadTarget target, String remoteAddr) throws Exception {
+        return mockMvc.perform(
+            multipart("/upload/image")
+                .file(file)
+                .param("target", target.name())
+                .with(request -> {
+                    request.setRemoteAddr(remoteAddr);
+                    return request;
+                })
         );
     }
 

--- a/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
@@ -19,8 +19,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import gg.agit.konect.global.code.ApiResponseCode;
 import gg.agit.konect.global.exception.CustomException;
@@ -151,6 +154,43 @@ class RateLimitAspectTest {
             eq(Collections.singletonList("ratelimit:test.method")),
             any(String.class)
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("clientIp 표현식 사용 시 현재 요청 IP로 키를 생성한다")
+    void usesCurrentRequestRemoteAddrForClientIpExpression() throws Throwable {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("203.0.113.10");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        given(rateLimit.maxRequests()).willReturn(10);
+        given(rateLimit.timeWindowSeconds()).willReturn(60);
+        given(rateLimit.keyExpression()).willReturn("#clientIp");
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getDeclaringTypeName()).willReturn("test");
+        given(methodSignature.getName()).willReturn("method");
+        given(methodSignature.getParameterNames()).willReturn(new String[0]);
+        given(joinPoint.getArgs()).willReturn(new Object[0]);
+        given(joinPoint.proceed()).willReturn(null);
+
+        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
+            .thenReturn(1L);
+
+        try {
+            // when
+            rateLimitAspect.around(joinPoint, rateLimit);
+
+            // then
+            verify(redisTemplate).execute(
+                any(DefaultRedisScript.class),
+                eq(Collections.singletonList("ratelimit:test.method:203.0.113.10")),
+                any(String.class)
+            );
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
     }
 
 }


### PR DESCRIPTION
### 🔍 개요

* 비로그인 업로드가 열린 뒤에도 같은 IP가 1시간에 60개를 넘겨 계속 업로드할 수 없도록 서버 측 총량 제한을 적용했습니다.


---

### 🚀 주요 변경 내용

* 업로드 이미지 API에 Redis 기반 rate limit을 다시 적용했습니다.
* 로그인 사용자 ID 대신 프록시가 복원한 클라이언트 IP를 제한 키로 사용합니다.
* 1시간에 60개를 초과한 업로드 요청은 `TOO_MANY_REQUESTS` 429로 응답합니다.
* 같은 IP의 61번째 업로드가 차단되는 통합 테스트를 추가했습니다.


---

### 💬 참고 사항

* `server.forward-headers-strategy: framework` 설정이 있어 Nginx의 `X-Forwarded-For` 기반 클라이언트 IP 복원 흐름을 전제로 합니다.
* Nginx `limit_req`는 순간 폭주 방어로 남기고, 시간당 총량 제한은 애플리케이션 Redis 카운터가 담당합니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
