### PR TITLE
refactor: 웹 동아리 분과 이모지 컬럼명 변경

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/event/ClubInformationUpdateRequestedEvent.java
+++ b/src/main/java/gg/agit/konect/domain/club/event/ClubInformationUpdateRequestedEvent.java
@@ -19,7 +19,7 @@ public record ClubInformationUpdateRequestedEvent(
     String requestedDescription,
     String currentFullIntroduction,
     String requestedFullIntroduction,
-    String currentImageUrl,
+    String currentCategoryEmoji,
     List<String> requestedImageUrls
 ) {
 
@@ -39,7 +39,7 @@ public record ClubInformationUpdateRequestedEvent(
             request.getShortDescription(),
             request.getClub().getIntroduce(),
             request.getFullIntroduction(),
-            request.getClub().getImageUrl(),
+            request.getClub().getCategoryEmoji(),
             request.getImages().stream()
                 .map(image -> image.getImageUrl())
                 .toList()

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubDetailResponse.java
@@ -15,8 +15,8 @@ public record WebsiteClubDetailResponse(
     @Schema(description = "동아리명", example = "BCSD Lab", requiredMode = REQUIRED)
     String name,
 
-    @Schema(description = "동아리 로고 이미지 URL", requiredMode = REQUIRED)
-    String imageUrl,
+    @Schema(description = "동아리 분과 이모지", requiredMode = REQUIRED)
+    String categoryEmoji,
 
     @Schema(description = "분과 코드", example = "ACADEMIC", requiredMode = REQUIRED)
     ClubCategory category,
@@ -71,7 +71,7 @@ public record WebsiteClubDetailResponse(
         return new WebsiteClubDetailResponse(
             club.getId(),
             club.getName(),
-            club.getImageUrl(),
+            club.getCategoryEmoji(),
             club.getClubCategory(),
             club.getClubCategory().getDescription(),
             club.getTopic(),

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubsResponse.java
@@ -99,8 +99,8 @@ public record WebsiteClubsResponse(
         @Schema(description = "동아리명", example = "BCSD Lab", requiredMode = REQUIRED)
         String name,
 
-        @Schema(description = "동아리 로고 이미지 URL", requiredMode = REQUIRED)
-        String imageUrl,
+        @Schema(description = "동아리 분과 이모지", requiredMode = REQUIRED)
+        String categoryEmoji,
 
         @Schema(description = "분과 코드", example = "ACADEMIC", requiredMode = REQUIRED)
         ClubCategory category,
@@ -118,7 +118,7 @@ public record WebsiteClubsResponse(
             return new ClubResponse(
                 club.getId(),
                 club.getName(),
-                club.getImageUrl(),
+                club.getCategoryEmoji(),
                 club.getClubCategory(),
                 club.getClubCategory().getDescription(),
                 club.getTopic(),

--- a/src/main/java/gg/agit/konect/domain/website/model/WebClub.java
+++ b/src/main/java/gg/agit/konect/domain/website/model/WebClub.java
@@ -52,8 +52,8 @@ public class WebClub extends BaseEntity {
     @Column(name = "introduce", columnDefinition = "TEXT", nullable = false)
     private String introduce;
 
-    @Column(name = "image_url", length = 255, nullable = false)
-    private String imageUrl;
+    @Column(name = "category_emoji", length = 255, nullable = false)
+    private String categoryEmoji;
 
     @Builder
     private WebClub(
@@ -64,7 +64,7 @@ public class WebClub extends BaseEntity {
         String topic,
         String description,
         String introduce,
-        String imageUrl
+        String categoryEmoji
     ) {
         this.id = id;
         this.clubCategory = clubCategory;
@@ -73,6 +73,6 @@ public class WebClub extends BaseEntity {
         this.topic = topic;
         this.description = description;
         this.introduce = introduce;
-        this.imageUrl = imageUrl;
+        this.categoryEmoji = categoryEmoji;
     }
 }

--- a/src/main/java/gg/agit/konect/infrastructure/slack/listener/ClubRegistrationRequestSlackListener.java
+++ b/src/main/java/gg/agit/konect/infrastructure/slack/listener/ClubRegistrationRequestSlackListener.java
@@ -58,7 +58,7 @@ public class ClubRegistrationRequestSlackListener {
                 event.requestedDescription(),
                 event.currentFullIntroduction(),
                 event.requestedFullIntroduction(),
-                event.currentImageUrl(),
+                event.currentCategoryEmoji(),
                 event.requestedImageUrls()
             );
         } catch (RuntimeException e) {

--- a/src/main/java/gg/agit/konect/infrastructure/slack/service/SlackNotificationService.java
+++ b/src/main/java/gg/agit/konect/infrastructure/slack/service/SlackNotificationService.java
@@ -96,7 +96,7 @@ public class SlackNotificationService {
         String requestedDescription,
         String currentFullIntroduction,
         String requestedFullIntroduction,
-        String currentImageUrl,
+        String currentCategoryEmoji,
         List<String> requestedImageUrls
     ) {
         String message = CLUB_INFORMATION_UPDATE_REQUEST.format(
@@ -108,7 +108,7 @@ public class SlackNotificationService {
             formatInlineChange(currentTopic, requestedTopic),
             formatBlockChange(currentDescription, requestedDescription),
             formatBlockChange(currentFullIntroduction, requestedFullIntroduction),
-            formatBlockChange(currentImageUrl, formatImageUrls(requestedImageUrls))
+            formatBlockChange(currentCategoryEmoji, formatImageUrls(requestedImageUrls))
         );
         slackClient.sendMessage(message, slackProperties.webhooks().event());
     }

--- a/src/main/resources/db/migration/V85__rename_web_club_image_url_to_category_emoji.sql
+++ b/src/main/resources/db/migration/V85__rename_web_club_image_url_to_category_emoji.sql
@@ -1,0 +1,2 @@
+ALTER TABLE web_club
+    CHANGE COLUMN image_url category_emoji VARCHAR(255) NOT NULL;

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -138,6 +138,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 .andExpect(jsonPath("$.totalCount").value(1))
                 .andExpect(jsonPath("$.clubs", hasSize(1)))
                 .andExpect(jsonPath("$.clubs[0].name").value("BCSD Lab"))
+                .andExpect(jsonPath("$.clubs[0].categoryEmoji").value("📚"))
                 .andExpect(jsonPath("$.categories[0].category").value("PERFORMANCE"))
                 .andExpect(jsonPath("$.categories[1].category").value("SOCIAL_SERVICE"))
                 .andExpect(jsonPath("$.categories[2].category").value("EXHIBITION_CREATION"))
@@ -181,6 +182,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
             performGet("/konect/clubs/" + club.getId())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("ZEST"))
+                .andExpect(jsonPath("$.categoryEmoji").value("📚"))
                 .andExpect(jsonPath("$.categoryName").value("공연"))
                 .andExpect(jsonPath("$.topic").value("코딩"))
                 .andExpect(jsonPath("$.university.name").value("한국기술교육대학교"))
@@ -212,6 +214,7 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.clubs", hasSize(2)))
                 .andExpect(jsonPath("$.clubs[0].name").value("두 번째"))
+                .andExpect(jsonPath("$.clubs[0].categoryEmoji").value("📚"))
                 .andExpect(jsonPath("$.clubs[1].name").value("첫 번째"));
         }
 

--- a/src/test/java/gg/agit/konect/support/fixture/WebClubFixture.java
+++ b/src/test/java/gg/agit/konect/support/fixture/WebClubFixture.java
@@ -18,7 +18,7 @@ public class WebClubFixture {
             .name(name)
             .description("한 줄 소개")
             .introduce("상세 소개입니다.")
-            .imageUrl("https://example.com/" + name + ".png")
+            .categoryEmoji("📚")
             .clubCategory(category)
             .topic("코딩")
             .build();

--- a/src/test/java/gg/agit/konect/unit/domain/club/service/ClubRegistrationRequestServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/club/service/ClubRegistrationRequestServiceTest.java
@@ -154,7 +154,7 @@ class ClubRegistrationRequestServiceTest extends ServiceTestSupport {
         assertThat(event.requestedDescription()).isEqualTo(request.shortDescription());
         assertThat(event.currentFullIntroduction()).isEqualTo(club.getIntroduce());
         assertThat(event.requestedFullIntroduction()).isEqualTo(request.fullIntroduction());
-        assertThat(event.currentImageUrl()).isEqualTo(club.getImageUrl());
+        assertThat(event.currentCategoryEmoji()).isEqualTo(club.getCategoryEmoji());
         assertThat(event.requestedImageUrls()).containsExactlyElementsOf(request.imageUrls());
     }
 }

--- a/src/test/java/gg/agit/konect/unit/infrastructure/slack/listener/ClubRegistrationRequestSlackListenerTest.java
+++ b/src/test/java/gg/agit/konect/unit/infrastructure/slack/listener/ClubRegistrationRequestSlackListenerTest.java
@@ -97,7 +97,7 @@ class ClubRegistrationRequestSlackListenerTest extends ServiceTestSupport {
             event.requestedDescription(),
             event.currentFullIntroduction(),
             event.requestedFullIntroduction(),
-            event.currentImageUrl(),
+            event.currentCategoryEmoji(),
             event.requestedImageUrls()
         );
     }
@@ -124,7 +124,7 @@ class ClubRegistrationRequestSlackListenerTest extends ServiceTestSupport {
                 event.requestedDescription(),
                 event.currentFullIntroduction(),
                 event.requestedFullIntroduction(),
-                event.currentImageUrl(),
+                event.currentCategoryEmoji(),
                 event.requestedImageUrls()
             );
 


### PR DESCRIPTION
### 🔍 개요

* `web_club.image_url` 컬럼이 실제 이미지 URL이 아니라 분과별 이모지 값을 담게 되어, DB 컬럼명과 웹사이트 API 응답 필드명을 의미에 맞게 변경했습니다.


---

### 🚀 주요 변경 내용

* `WebClub` 엔티티의 `imageUrl` 필드를 `categoryEmoji`로 변경하고, DB 컬럼을 `category_emoji`로 매핑했습니다.
* `V85__rename_web_club_image_url_to_category_emoji.sql` 마이그레이션을 추가해 기존 `web_club.image_url` 컬럼을 `category_emoji`로 rename합니다.
* 웹사이트 동아리 목록/상세 응답의 동아리 필드를 `imageUrl`에서 `categoryEmoji`로 변경했습니다.
* 동아리 정보 수정 요청 이벤트와 Slack 알림에서 현재 동아리 이모지 값을 `currentCategoryEmoji`로 전달하도록 정리했습니다.
* 관련 fixture 및 웹사이트/서비스/Slack listener 테스트의 기대 필드를 `categoryEmoji` 기준으로 수정했습니다.


---

### 💬 참고 사항

* 대학 로고를 담는 `web_university.image_url` 및 일반 동아리 이미지 URL 필드는 실제 URL 의미를 유지하므로 변경하지 않았습니다.
* `emoji`보다 `category_emoji`가 분과 기준 이모지라는 의미를 더 명확하게 드러내므로 해당 이름을 선택했습니다.
* 실제 stage/prod DB 마이그레이션 실행은 자동 수행 금지 항목이라 PR에는 Flyway 파일만 포함했습니다.
* Copilot reviewer는 GitHub App 제약으로 API 지정이 불가해 PR 페이지에서 직접 Request가 필요합니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)