### PR TITLE
feat: 웹 동아리 목록 정렬 옵션 추가

### DIFF
--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubListCondition.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubListCondition.java
@@ -21,14 +21,23 @@ public record WebsiteClubListCondition(
     String query,
 
     @Schema(description = "동아리 분과", example = "ACADEMIC", requiredMode = NOT_REQUIRED)
-    ClubCategory category
+    ClubCategory category,
+
+    @Schema(
+        description = "동아리 목록 정렬 기준 (NAME: 가나다, CATEGORY: 분과)",
+        example = "NAME",
+        requiredMode = NOT_REQUIRED
+    )
+    WebsiteClubSortBy sortBy
 ) {
 
     private static final int DEFAULT_PAGE = 1;
     private static final int DEFAULT_LIMIT = 12;
+    private static final WebsiteClubSortBy DEFAULT_SORT_BY = WebsiteClubSortBy.NAME;
 
     public WebsiteClubListCondition {
         page = page == null ? DEFAULT_PAGE : page;
         limit = limit == null ? DEFAULT_LIMIT : limit;
+        sortBy = sortBy == null ? DEFAULT_SORT_BY : sortBy;
     }
 }

--- a/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubSortBy.java
+++ b/src/main/java/gg/agit/konect/domain/website/dto/WebsiteClubSortBy.java
@@ -1,0 +1,6 @@
+package gg.agit.konect.domain.website.dto;
+
+public enum WebsiteClubSortBy {
+    NAME,
+    CATEGORY
+}

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebsiteQueryRepository.java
@@ -15,12 +15,15 @@ import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import gg.agit.konect.domain.club.enums.ClubCategory;
 import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.website.dto.WebsiteClubSortBy;
 import gg.agit.konect.domain.website.model.WebClub;
 import gg.agit.konect.domain.website.model.WebUniversity;
 import gg.agit.konect.domain.website.model.WebsiteUniversitySummary;
@@ -84,6 +87,7 @@ public class WebsiteQueryRepository {
         Integer universityId,
         String query,
         ClubCategory category,
+        WebsiteClubSortBy sortBy,
         PageRequest pageable
     ) {
         BooleanBuilder condition = createClubCondition(universityId, query, category);
@@ -92,7 +96,7 @@ public class WebsiteQueryRepository {
             .selectFrom(webClub)
             .join(webClub.university, webUniversity).fetchJoin()
             .where(condition)
-            .orderBy(webClub.name.asc(), webClub.id.asc())
+            .orderBy(createClubOrder(sortBy))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
@@ -104,6 +108,34 @@ public class WebsiteQueryRepository {
             .fetchOne();
 
         return new PageImpl<>(clubs, pageable, total == null ? 0 : total);
+    }
+
+    private OrderSpecifier<?>[] createClubOrder(WebsiteClubSortBy sortBy) {
+        if (sortBy == WebsiteClubSortBy.CATEGORY) {
+            return new OrderSpecifier<?>[] {
+                createCategoryOrder().asc(),
+                webClub.name.asc(),
+                webClub.id.asc()
+            };
+        }
+
+        return new OrderSpecifier<?>[] {
+            webClub.name.asc(),
+            webClub.id.asc()
+        };
+    }
+
+    private NumberExpression<Integer> createCategoryOrder() {
+        return new CaseBuilder()
+            .when(webClub.clubCategory.eq(ClubCategory.PERFORMANCE)).then(1)
+            .when(webClub.clubCategory.eq(ClubCategory.SOCIAL_SERVICE)).then(2)
+            .when(webClub.clubCategory.eq(ClubCategory.EXHIBITION_CREATION)).then(3)
+            .when(webClub.clubCategory.eq(ClubCategory.RELIGION)).then(4)
+            .when(webClub.clubCategory.eq(ClubCategory.SPORTS)).then(5)
+            .when(webClub.clubCategory.eq(ClubCategory.HOBBY)).then(6)
+            .when(webClub.clubCategory.eq(ClubCategory.ACADEMIC)).then(7)
+            .when(webClub.clubCategory.eq(ClubCategory.ETC)).then(8)
+            .otherwise(Integer.MAX_VALUE);
     }
 
     public Map<ClubCategory, Long> countClubCategories(Integer universityId, String query) {

--- a/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
+++ b/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
@@ -51,6 +51,7 @@ public class WebsiteService {
             universityId,
             condition.query(),
             condition.category(),
+            condition.sortBy(),
             pageable
         );
 

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -152,6 +152,33 @@ class WebsiteApiTest extends IntegrationTestSupport {
         }
 
         @Test
+        @DisplayName("sortBy=CATEGORY이면 분과 표시 순서와 동아리명 순서로 정렬한다")
+        void getUniversityClubsSortedByCategory() throws Exception {
+            // given
+            WebUniversity university = persist(WebUniversityFixture.create(
+                "Koreatech",
+                Campus.MAIN,
+                UniversityRegion.CHUNGCHEONG
+            ));
+            persist(WebClubFixture.create(university, "Zeta", ClubCategory.ACADEMIC));
+            persist(WebClubFixture.create(university, "Alpha", ClubCategory.ACADEMIC));
+            persist(WebClubFixture.create(university, "Runner", ClubCategory.SPORTS));
+            persist(WebClubFixture.create(university, "Band", ClubCategory.PERFORMANCE));
+            clearPersistenceContext();
+
+            // when & then
+            performGet("/konect/universities/" + university.getId() + "/clubs?sortBy=CATEGORY")
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubs[*].name", contains("Band", "Runner", "Alpha", "Zeta")))
+                .andExpect(jsonPath("$.clubs[*].category", contains(
+                    "PERFORMANCE",
+                    "SPORTS",
+                    "ACADEMIC",
+                    "ACADEMIC"
+                )));
+        }
+
+        @Test
         @DisplayName("존재하지 않는 대학이면 404를 반환한다")
         void getUniversityClubsNotFound() throws Exception {
             // when & then


### PR DESCRIPTION
### 📌 개요

* konect.space 공개 대학별 동아리 목록에서 가나다순과 분과순 정렬을 선택할 수 있도록 정렬 옵션을 추가했습니다.

---

### 🔧 주요 변경 내용

* `sortBy` 요청 파라미터를 추가하고 기본값을 기존 동작과 동일한 `NAME`으로 설정
* `sortBy=CATEGORY` 요청 시 분과 표시 순서 기준으로 정렬하고, 같은 분과 내에서는 동아리명 순으로 정렬
* 대학별 동아리 목록 API 통합 테스트에 분과 정렬 검증 케이스 추가

---

### 📝 참고 사항

* `compileJava compileTestJava`, 대상 통합 테스트, `checkstyleMain`을 통과했습니다.
* `checkstyleTest`는 기존 테스트 파일의 120자 초과 이슈로 실패했으며, 이번 변경 파일은 위반 목록에 포함되지 않았습니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)