### PR TITLE
refactor: 대학 검색 약칭 관리 분리

### DIFF
--- a/src/main/java/gg/agit/konect/domain/university/enums/UniversitySearchKeywordType.java
+++ b/src/main/java/gg/agit/konect/domain/university/enums/UniversitySearchKeywordType.java
@@ -1,0 +1,6 @@
+package gg.agit.konect.domain.university.enums;
+
+public enum UniversitySearchKeywordType {
+    ALIAS,
+    ENGLISH_ALIAS
+}

--- a/src/main/java/gg/agit/konect/domain/university/model/UniversitySearchKeyword.java
+++ b/src/main/java/gg/agit/konect/domain/university/model/UniversitySearchKeyword.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Getter
@@ -40,6 +41,7 @@ public class UniversitySearchKeyword extends BaseEntity {
     private Integer id;
 
     @NotNull
+    @ToString.Exclude
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "university_id", nullable = false)
     private University university;

--- a/src/main/java/gg/agit/konect/domain/university/model/UniversitySearchKeyword.java
+++ b/src/main/java/gg/agit/konect/domain/university/model/UniversitySearchKeyword.java
@@ -1,0 +1,74 @@
+package gg.agit.konect.domain.university.model;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import gg.agit.konect.domain.university.enums.UniversitySearchKeywordType;
+import gg.agit.konect.global.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(
+    name = "university_search_keyword",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uq_university_search_keyword_university_keyword",
+            columnNames = {"university_id", "normalized_keyword"}
+        ),
+    })
+@NoArgsConstructor(access = PROTECTED)
+public class UniversitySearchKeyword extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false, unique = true)
+    private Integer id;
+
+    @NotNull
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "university_id", nullable = false)
+    private University university;
+
+    @NotNull
+    @Column(name = "keyword", length = 100, nullable = false)
+    private String keyword;
+
+    @NotNull
+    @Column(name = "normalized_keyword", length = 100, nullable = false)
+    private String normalizedKeyword;
+
+    @NotNull
+    @Enumerated(value = STRING)
+    @Column(name = "keyword_type", length = 50, nullable = false)
+    private UniversitySearchKeywordType keywordType;
+
+    @Builder
+    private UniversitySearchKeyword(
+        Integer id,
+        University university,
+        String keyword,
+        String normalizedKeyword,
+        UniversitySearchKeywordType keywordType
+    ) {
+        this.id = id;
+        this.university = university;
+        this.keyword = keyword;
+        this.normalizedKeyword = normalizedKeyword;
+        this.keywordType = keywordType;
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/university/repository/UniversitySearchKeywordRepository.java
+++ b/src/main/java/gg/agit/konect/domain/university/repository/UniversitySearchKeywordRepository.java
@@ -1,0 +1,23 @@
+package gg.agit.konect.domain.university.repository;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import gg.agit.konect.domain.university.model.UniversitySearchKeyword;
+
+public interface UniversitySearchKeywordRepository extends Repository<UniversitySearchKeyword, Integer> {
+
+    @Query("""
+        SELECT keyword
+        FROM UniversitySearchKeyword keyword
+        JOIN FETCH keyword.university university
+        WHERE university.koreanName IN :universityNames
+        """)
+    List<UniversitySearchKeyword> findAllByUniversityNames(
+        @Param("universityNames") Collection<String> universityNames
+    );
+}

--- a/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchKeywordReader.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchKeywordReader.java
@@ -1,0 +1,34 @@
+package gg.agit.konect.domain.university.service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import gg.agit.konect.domain.university.model.UniversitySearchKeyword;
+import gg.agit.konect.domain.university.repository.UniversitySearchKeywordRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UniversitySearchKeywordReader {
+
+    private final UniversitySearchKeywordRepository universitySearchKeywordRepository;
+
+    public Map<String, List<String>> getKeywordsByUniversityName(Collection<String> universityNames) {
+        if (universityNames.isEmpty()) {
+            return Map.of();
+        }
+
+        return universitySearchKeywordRepository.findAllByUniversityNames(universityNames)
+            .stream()
+            .collect(Collectors.groupingBy(
+                keyword -> keyword.getUniversity().getKoreanName(),
+                Collectors.mapping(UniversitySearchKeyword::getKeyword, Collectors.toList())
+            ));
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
@@ -2,6 +2,7 @@ package gg.agit.konect.domain.university.service;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -58,7 +59,9 @@ public class UniversitySearchMatcher {
 
     private Stream<String> getSearchTokens(String universityName, List<String> managedKeywords) {
         Set<String> aliases = getDefaultAliases(universityName);
-        aliases.addAll(managedKeywords);
+        if (managedKeywords != null) {
+            aliases.addAll(managedKeywords);
+        }
 
         List<String> normalizedAliases = aliases.stream()
             .map(this::normalize)
@@ -97,7 +100,7 @@ public class UniversitySearchMatcher {
     private String normalize(String value) {
         return expandCompatibilityJamoClusters(value)
             .replaceAll("\\s", "")
-            .toLowerCase();
+            .toLowerCase(Locale.ROOT);
     }
 
     private String expandCompatibilityJamoClusters(String value) {

--- a/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversitySearchMatcher.java
@@ -38,60 +38,27 @@ public class UniversitySearchMatcher {
         Map.entry("ㅄ", "ㅂㅅ")
     );
 
-    private static final Map<String, List<String>> UNIVERSITY_ALIASES = Map.ofEntries(
-        Map.entry("가톨릭대학교", List.of("가대")),
-        Map.entry("건국대학교", List.of("건대")),
-        Map.entry("경북대학교", List.of("경대", "경북대")),
-        Map.entry("경희대학교", List.of("경희대")),
-        Map.entry("고려대학교", List.of("고대")),
-        Map.entry("광주과학기술원", List.of("광주과기원", "지스트", "gist")),
-        Map.entry("단국대학교", List.of("단대")),
-        Map.entry("대구경북과학기술원", List.of("대경과기원", "디지스트", "dgist")),
-        Map.entry("동국대학교", List.of("동대")),
-        Map.entry("부산대학교", List.of("부대", "부산대")),
-        Map.entry("서강대학교", List.of("서강대")),
-        Map.entry("서울과학기술대학교", List.of("과기대", "서울과기대")),
-        Map.entry("서울대학교", List.of("설대", "서울대")),
-        Map.entry("서울시립대학교", List.of("시립대", "서울시립대")),
-        Map.entry("성균관대학교", List.of("성대")),
-        Map.entry("연세대학교", List.of("연대")),
-        Map.entry("울산과학기술원", List.of("울산과기원", "유니스트", "unist")),
-        Map.entry("육군사관학교", List.of("육사")),
-        Map.entry("이화여자대학교", List.of("이대", "이화여대")),
-        Map.entry("전남대학교", List.of("전대", "전남대")),
-        Map.entry("중앙대학교", List.of("중대")),
-        Map.entry("충남대학교", List.of("충대", "충남대")),
-        Map.entry("충북대학교", List.of("충북대")),
-        Map.entry("포항공과대학교", List.of("포공", "포스텍", "postech")),
-        Map.entry("한국공학대학교", List.of("한공대", "한국공대")),
-        Map.entry("한국과학기술원", List.of("카이스트", "kaist")),
-        Map.entry("한국교통대학교", List.of("교통대", "한국교통대")),
-        Map.entry("한국기술교육대학교", List.of("한기대", "코리아텍", "koreatech")),
-        Map.entry("한국외국어대학교", List.of("외대", "한국외대")),
-        Map.entry("한국체육대학교", List.of("한체대")),
-        Map.entry("한국항공대학교", List.of("항공대", "한국항공대")),
-        Map.entry("한국해양대학교", List.of("해양대", "한국해양대")),
-        Map.entry("해군사관학교", List.of("해사")),
-        Map.entry("홍익대학교", List.of("홍대"))
-    );
-
     public boolean matches(University university, String query) {
-        return matches(university.getKoreanName(), query);
+        return matches(university.getKoreanName(), query, List.of());
     }
 
     public boolean matches(String universityName, String query) {
+        return matches(universityName, query, List.of());
+    }
+
+    public boolean matches(String universityName, String query, List<String> managedKeywords) {
         if (!StringUtils.hasText(query)) {
             return true;
         }
 
         String normalizedQuery = normalize(query);
-        return getSearchTokens(universityName)
+        return getSearchTokens(universityName, managedKeywords)
             .anyMatch(token -> token.contains(normalizedQuery));
     }
 
-    private Stream<String> getSearchTokens(String universityName) {
+    private Stream<String> getSearchTokens(String universityName, List<String> managedKeywords) {
         Set<String> aliases = getDefaultAliases(universityName);
-        aliases.addAll(UNIVERSITY_ALIASES.getOrDefault(universityName, List.of()));
+        aliases.addAll(managedKeywords);
 
         List<String> normalizedAliases = aliases.stream()
             .map(this::normalize)

--- a/src/main/java/gg/agit/konect/domain/university/service/UniversityService.java
+++ b/src/main/java/gg/agit/konect/domain/university/service/UniversityService.java
@@ -1,6 +1,7 @@
 package gg.agit.konect.domain.university.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,11 +19,21 @@ public class UniversityService {
 
     private final UniversityRepository universityRepository;
     private final UniversitySearchMatcher universitySearchMatcher;
+    private final UniversitySearchKeywordReader universitySearchKeywordReader;
 
     public UniversitiesResponse getUniversities(String query) {
         List<University> universities = universityRepository.findAllByOrderByKoreanNameAsc();
+        Map<String, List<String>> keywordsByUniversityName = universitySearchKeywordReader.getKeywordsByUniversityName(
+            universities.stream()
+                .map(University::getKoreanName)
+                .toList()
+        );
         List<University> filteredUniversities = universities.stream()
-            .filter(university -> universitySearchMatcher.matches(university, query))
+            .filter(university -> universitySearchMatcher.matches(
+                university.getKoreanName(),
+                query,
+                keywordsByUniversityName.getOrDefault(university.getKoreanName(), List.of())
+            ))
             .toList();
 
         return UniversitiesResponse.from(filteredUniversities);

--- a/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
+++ b/src/main/java/gg/agit/konect/domain/website/service/WebsiteService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.university.service.UniversitySearchKeywordReader;
 import gg.agit.konect.domain.university.service.UniversitySearchMatcher;
 import gg.agit.konect.domain.website.dto.WebsiteClubDetailResponse;
 import gg.agit.konect.domain.website.dto.WebsiteClubListCondition;
@@ -32,14 +33,26 @@ public class WebsiteService {
 
     private final WebsiteQueryRepository websiteQueryRepository;
     private final UniversitySearchMatcher universitySearchMatcher;
+    private final UniversitySearchKeywordReader universitySearchKeywordReader;
 
     public WebsiteHomeResponse getHome(String query, UniversityRegion region) {
-        // 초성/약칭 검색은 SQL로 표현하기 어려워 전체 대학을 조회한 뒤 UniversitySearchMatcher로 필터링한다.
         List<WebsiteUniversitySummary> summaries = websiteQueryRepository.findUniversitySummaries(null, region)
             .stream()
-            .filter(summary -> universitySearchMatcher.matches(summary.name(), query))
             .toList();
-        return WebsiteHomeResponse.from(summaries);
+        Map<String, List<String>> keywordsByUniversityName = universitySearchKeywordReader.getKeywordsByUniversityName(
+            summaries.stream()
+                .map(WebsiteUniversitySummary::name)
+                .toList()
+        );
+
+        List<WebsiteUniversitySummary> filteredSummaries = summaries.stream()
+            .filter(summary -> universitySearchMatcher.matches(
+                summary.name(),
+                query,
+                keywordsByUniversityName.getOrDefault(summary.name(), List.of())
+            ))
+            .toList();
+        return WebsiteHomeResponse.from(filteredSummaries);
     }
 
     public WebsiteClubsResponse getUniversityClubs(Integer universityId, WebsiteClubListCondition condition) {

--- a/src/main/resources/db/migration/V86__create_university_search_keyword.sql
+++ b/src/main/resources/db/migration/V86__create_university_search_keyword.sql
@@ -8,6 +8,7 @@ CREATE TABLE university_search_keyword
     created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP                            NOT NULL,
     updated_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
 
+    CONSTRAINT chk_university_search_keyword_keyword_type CHECK (keyword_type IN ('ALIAS', 'ENGLISH_ALIAS')),
     CONSTRAINT fk_university_search_keyword_university FOREIGN KEY (university_id) REFERENCES university (id),
     CONSTRAINT uq_university_search_keyword_university_keyword UNIQUE (university_id, normalized_keyword)
 );

--- a/src/main/resources/db/migration/V86__create_university_search_keyword.sql
+++ b/src/main/resources/db/migration/V86__create_university_search_keyword.sql
@@ -1,0 +1,16 @@
+CREATE TABLE university_search_keyword
+(
+    id                 INT AUTO_INCREMENT PRIMARY KEY,
+    university_id      INT                                                            NOT NULL,
+    keyword            VARCHAR(100)                                                   NOT NULL,
+    normalized_keyword VARCHAR(100)                                                   NOT NULL,
+    keyword_type       VARCHAR(50)                                                    NOT NULL,
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP                            NOT NULL,
+    updated_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+
+    CONSTRAINT fk_university_search_keyword_university FOREIGN KEY (university_id) REFERENCES university (id),
+    CONSTRAINT uq_university_search_keyword_university_keyword UNIQUE (university_id, normalized_keyword)
+);
+
+CREATE INDEX idx_university_search_keyword_normalized_keyword
+    ON university_search_keyword (normalized_keyword);

--- a/src/main/resources/db/migration/V87__seed_university_search_keywords.sql
+++ b/src/main/resources/db/migration/V87__seed_university_search_keywords.sql
@@ -1,232 +1,63 @@
 INSERT INTO university_search_keyword (university_id, keyword, normalized_keyword, keyword_type)
-SELECT id, '가대', '가대', 'ALIAS'
-FROM university
-WHERE korean_name = '가톨릭대학교'
-UNION ALL
-SELECT id, '건대', '건대', 'ALIAS'
-FROM university
-WHERE korean_name = '건국대학교'
-UNION ALL
-SELECT id, '경대', '경대', 'ALIAS'
-FROM university
-WHERE korean_name = '경북대학교'
-UNION ALL
-SELECT id, '경북대', '경북대', 'ALIAS'
-FROM university
-WHERE korean_name = '경북대학교'
-UNION ALL
-SELECT id, '경희대', '경희대', 'ALIAS'
-FROM university
-WHERE korean_name = '경희대학교'
-UNION ALL
-SELECT id, '고대', '고대', 'ALIAS'
-FROM university
-WHERE korean_name = '고려대학교'
-UNION ALL
-SELECT id, '광주과기원', '광주과기원', 'ALIAS'
-FROM university
-WHERE korean_name = '광주과학기술원'
-UNION ALL
-SELECT id, '지스트', '지스트', 'ALIAS'
-FROM university
-WHERE korean_name = '광주과학기술원'
-UNION ALL
-SELECT id, 'gist', 'gist', 'ENGLISH_ALIAS'
-FROM university
-WHERE korean_name = '광주과학기술원'
-UNION ALL
-SELECT id, '단대', '단대', 'ALIAS'
-FROM university
-WHERE korean_name = '단국대학교'
-UNION ALL
-SELECT id, '대경과기원', '대경과기원', 'ALIAS'
-FROM university
-WHERE korean_name = '대구경북과학기술원'
-UNION ALL
-SELECT id, '디지스트', '디지스트', 'ALIAS'
-FROM university
-WHERE korean_name = '대구경북과학기술원'
-UNION ALL
-SELECT id, 'dgist', 'dgist', 'ENGLISH_ALIAS'
-FROM university
-WHERE korean_name = '대구경북과학기술원'
-UNION ALL
-SELECT id, '동대', '동대', 'ALIAS'
-FROM university
-WHERE korean_name = '동국대학교'
-UNION ALL
-SELECT id, '부대', '부대', 'ALIAS'
-FROM university
-WHERE korean_name = '부산대학교'
-UNION ALL
-SELECT id, '부산대', '부산대', 'ALIAS'
-FROM university
-WHERE korean_name = '부산대학교'
-UNION ALL
-SELECT id, '서강대', '서강대', 'ALIAS'
-FROM university
-WHERE korean_name = '서강대학교'
-UNION ALL
-SELECT id, '과기대', '과기대', 'ALIAS'
-FROM university
-WHERE korean_name = '서울과학기술대학교'
-UNION ALL
-SELECT id, '서울과기대', '서울과기대', 'ALIAS'
-FROM university
-WHERE korean_name = '서울과학기술대학교'
-UNION ALL
-SELECT id, '설대', '설대', 'ALIAS'
-FROM university
-WHERE korean_name = '서울대학교'
-UNION ALL
-SELECT id, '서울대', '서울대', 'ALIAS'
-FROM university
-WHERE korean_name = '서울대학교'
-UNION ALL
-SELECT id, '시립대', '시립대', 'ALIAS'
-FROM university
-WHERE korean_name = '서울시립대학교'
-UNION ALL
-SELECT id, '서울시립대', '서울시립대', 'ALIAS'
-FROM university
-WHERE korean_name = '서울시립대학교'
-UNION ALL
-SELECT id, '성대', '성대', 'ALIAS'
-FROM university
-WHERE korean_name = '성균관대학교'
-UNION ALL
-SELECT id, '연대', '연대', 'ALIAS'
-FROM university
-WHERE korean_name = '연세대학교'
-UNION ALL
-SELECT id, '울산과기원', '울산과기원', 'ALIAS'
-FROM university
-WHERE korean_name = '울산과학기술원'
-UNION ALL
-SELECT id, '유니스트', '유니스트', 'ALIAS'
-FROM university
-WHERE korean_name = '울산과학기술원'
-UNION ALL
-SELECT id, 'unist', 'unist', 'ENGLISH_ALIAS'
-FROM university
-WHERE korean_name = '울산과학기술원'
-UNION ALL
-SELECT id, '육사', '육사', 'ALIAS'
-FROM university
-WHERE korean_name = '육군사관학교'
-UNION ALL
-SELECT id, '이대', '이대', 'ALIAS'
-FROM university
-WHERE korean_name = '이화여자대학교'
-UNION ALL
-SELECT id, '이화여대', '이화여대', 'ALIAS'
-FROM university
-WHERE korean_name = '이화여자대학교'
-UNION ALL
-SELECT id, '전대', '전대', 'ALIAS'
-FROM university
-WHERE korean_name = '전남대학교'
-UNION ALL
-SELECT id, '전남대', '전남대', 'ALIAS'
-FROM university
-WHERE korean_name = '전남대학교'
-UNION ALL
-SELECT id, '중대', '중대', 'ALIAS'
-FROM university
-WHERE korean_name = '중앙대학교'
-UNION ALL
-SELECT id, '충대', '충대', 'ALIAS'
-FROM university
-WHERE korean_name = '충남대학교'
-UNION ALL
-SELECT id, '충남대', '충남대', 'ALIAS'
-FROM university
-WHERE korean_name = '충남대학교'
-UNION ALL
-SELECT id, '충북대', '충북대', 'ALIAS'
-FROM university
-WHERE korean_name = '충북대학교'
-UNION ALL
-SELECT id, '포공', '포공', 'ALIAS'
-FROM university
-WHERE korean_name = '포항공과대학교'
-UNION ALL
-SELECT id, '포스텍', '포스텍', 'ALIAS'
-FROM university
-WHERE korean_name = '포항공과대학교'
-UNION ALL
-SELECT id, 'postech', 'postech', 'ENGLISH_ALIAS'
-FROM university
-WHERE korean_name = '포항공과대학교'
-UNION ALL
-SELECT id, '한공대', '한공대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국공학대학교'
-UNION ALL
-SELECT id, '한국공대', '한국공대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국공학대학교'
-UNION ALL
-SELECT id, '카이스트', '카이스트', 'ALIAS'
-FROM university
-WHERE korean_name = '한국과학기술원'
-UNION ALL
-SELECT id, 'kaist', 'kaist', 'ENGLISH_ALIAS'
-FROM university
-WHERE korean_name = '한국과학기술원'
-UNION ALL
-SELECT id, '교통대', '교통대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국교통대학교'
-UNION ALL
-SELECT id, '한국교통대', '한국교통대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국교통대학교'
-UNION ALL
-SELECT id, '한기대', '한기대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국기술교육대학교'
-UNION ALL
-SELECT id, '코리아텍', '코리아텍', 'ALIAS'
-FROM university
-WHERE korean_name = '한국기술교육대학교'
-UNION ALL
-SELECT id, 'koreatech', 'koreatech', 'ENGLISH_ALIAS'
-FROM university
-WHERE korean_name = '한국기술교육대학교'
-UNION ALL
-SELECT id, '외대', '외대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국외국어대학교'
-UNION ALL
-SELECT id, '한국외대', '한국외대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국외국어대학교'
-UNION ALL
-SELECT id, '한체대', '한체대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국체육대학교'
-UNION ALL
-SELECT id, '항공대', '항공대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국항공대학교'
-UNION ALL
-SELECT id, '한국항공대', '한국항공대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국항공대학교'
-UNION ALL
-SELECT id, '해양대', '해양대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국해양대학교'
-UNION ALL
-SELECT id, '한국해양대', '한국해양대', 'ALIAS'
-FROM university
-WHERE korean_name = '한국해양대학교'
-UNION ALL
-SELECT id, '해사', '해사', 'ALIAS'
-FROM university
-WHERE korean_name = '해군사관학교'
-UNION ALL
-SELECT id, '홍대', '홍대', 'ALIAS'
-FROM university
-WHERE korean_name = '홍익대학교';
+SELECT university.id, expected_keyword.keyword, expected_keyword.normalized_keyword, expected_keyword.keyword_type
+FROM (
+    SELECT '가톨릭대학교' AS university_name, '가대' AS keyword, '가대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '건국대학교' AS university_name, '건대' AS keyword, '건대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '경북대학교' AS university_name, '경대' AS keyword, '경대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '경북대학교' AS university_name, '경북대' AS keyword, '경북대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '경희대학교' AS university_name, '경희대' AS keyword, '경희대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '고려대학교' AS university_name, '고대' AS keyword, '고대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '광주과학기술원' AS university_name, '광주과기원' AS keyword, '광주과기원' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '광주과학기술원' AS university_name, '지스트' AS keyword, '지스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '광주과학기술원' AS university_name, 'gist' AS keyword, 'gist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '단국대학교' AS university_name, '단대' AS keyword, '단대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '대구경북과학기술원' AS university_name, '대경과기원' AS keyword, '대경과기원' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '대구경북과학기술원' AS university_name, '디지스트' AS keyword, '디지스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '대구경북과학기술원' AS university_name, 'dgist' AS keyword, 'dgist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '동국대학교' AS university_name, '동대' AS keyword, '동대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '부산대학교' AS university_name, '부대' AS keyword, '부대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '부산대학교' AS university_name, '부산대' AS keyword, '부산대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서강대학교' AS university_name, '서강대' AS keyword, '서강대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울과학기술대학교' AS university_name, '과기대' AS keyword, '과기대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울과학기술대학교' AS university_name, '서울과기대' AS keyword, '서울과기대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울대학교' AS university_name, '설대' AS keyword, '설대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울대학교' AS university_name, '서울대' AS keyword, '서울대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울시립대학교' AS university_name, '시립대' AS keyword, '시립대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울시립대학교' AS university_name, '서울시립대' AS keyword, '서울시립대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '성균관대학교' AS university_name, '성대' AS keyword, '성대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '연세대학교' AS university_name, '연대' AS keyword, '연대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '울산과학기술원' AS university_name, '울산과기원' AS keyword, '울산과기원' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '울산과학기술원' AS university_name, '유니스트' AS keyword, '유니스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '울산과학기술원' AS university_name, 'unist' AS keyword, 'unist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '육군사관학교' AS university_name, '육사' AS keyword, '육사' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '이화여자대학교' AS university_name, '이대' AS keyword, '이대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '이화여자대학교' AS university_name, '이화여대' AS keyword, '이화여대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '전남대학교' AS university_name, '전대' AS keyword, '전대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '전남대학교' AS university_name, '전남대' AS keyword, '전남대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '중앙대학교' AS university_name, '중대' AS keyword, '중대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '충남대학교' AS university_name, '충대' AS keyword, '충대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '충남대학교' AS university_name, '충남대' AS keyword, '충남대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '충북대학교' AS university_name, '충북대' AS keyword, '충북대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '포항공과대학교' AS university_name, '포공' AS keyword, '포공' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '포항공과대학교' AS university_name, '포스텍' AS keyword, '포스텍' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '포항공과대학교' AS university_name, 'postech' AS keyword, 'postech' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '한국공학대학교' AS university_name, '한공대' AS keyword, '한공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국공학대학교' AS university_name, '한국공대' AS keyword, '한국공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국과학기술원' AS university_name, '카이스트' AS keyword, '카이스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국과학기술원' AS university_name, 'kaist' AS keyword, 'kaist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '한국교통대학교' AS university_name, '교통대' AS keyword, '교통대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국교통대학교' AS university_name, '한국교통대' AS keyword, '한국교통대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국기술교육대학교' AS university_name, '한기대' AS keyword, '한기대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국기술교육대학교' AS university_name, '코리아텍' AS keyword, '코리아텍' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국기술교육대학교' AS university_name, 'koreatech' AS keyword, 'koreatech' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '한국외국어대학교' AS university_name, '외대' AS keyword, '외대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국외국어대학교' AS university_name, '한국외대' AS keyword, '한국외대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국체육대학교' AS university_name, '한체대' AS keyword, '한체대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국항공대학교' AS university_name, '항공대' AS keyword, '항공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국항공대학교' AS university_name, '한국항공대' AS keyword, '한국항공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국해양대학교' AS university_name, '해양대' AS keyword, '해양대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국해양대학교' AS university_name, '한국해양대' AS keyword, '한국해양대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '해군사관학교' AS university_name, '해사' AS keyword, '해사' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '홍익대학교' AS university_name, '홍대' AS keyword, '홍대' AS normalized_keyword, 'ALIAS' AS keyword_type
+) expected_keyword
+LEFT JOIN university ON university.korean_name = expected_keyword.university_name;

--- a/src/main/resources/db/migration/V87__seed_university_search_keywords.sql
+++ b/src/main/resources/db/migration/V87__seed_university_search_keywords.sql
@@ -1,0 +1,232 @@
+INSERT INTO university_search_keyword (university_id, keyword, normalized_keyword, keyword_type)
+SELECT id, '가대', '가대', 'ALIAS'
+FROM university
+WHERE korean_name = '가톨릭대학교'
+UNION ALL
+SELECT id, '건대', '건대', 'ALIAS'
+FROM university
+WHERE korean_name = '건국대학교'
+UNION ALL
+SELECT id, '경대', '경대', 'ALIAS'
+FROM university
+WHERE korean_name = '경북대학교'
+UNION ALL
+SELECT id, '경북대', '경북대', 'ALIAS'
+FROM university
+WHERE korean_name = '경북대학교'
+UNION ALL
+SELECT id, '경희대', '경희대', 'ALIAS'
+FROM university
+WHERE korean_name = '경희대학교'
+UNION ALL
+SELECT id, '고대', '고대', 'ALIAS'
+FROM university
+WHERE korean_name = '고려대학교'
+UNION ALL
+SELECT id, '광주과기원', '광주과기원', 'ALIAS'
+FROM university
+WHERE korean_name = '광주과학기술원'
+UNION ALL
+SELECT id, '지스트', '지스트', 'ALIAS'
+FROM university
+WHERE korean_name = '광주과학기술원'
+UNION ALL
+SELECT id, 'gist', 'gist', 'ENGLISH_ALIAS'
+FROM university
+WHERE korean_name = '광주과학기술원'
+UNION ALL
+SELECT id, '단대', '단대', 'ALIAS'
+FROM university
+WHERE korean_name = '단국대학교'
+UNION ALL
+SELECT id, '대경과기원', '대경과기원', 'ALIAS'
+FROM university
+WHERE korean_name = '대구경북과학기술원'
+UNION ALL
+SELECT id, '디지스트', '디지스트', 'ALIAS'
+FROM university
+WHERE korean_name = '대구경북과학기술원'
+UNION ALL
+SELECT id, 'dgist', 'dgist', 'ENGLISH_ALIAS'
+FROM university
+WHERE korean_name = '대구경북과학기술원'
+UNION ALL
+SELECT id, '동대', '동대', 'ALIAS'
+FROM university
+WHERE korean_name = '동국대학교'
+UNION ALL
+SELECT id, '부대', '부대', 'ALIAS'
+FROM university
+WHERE korean_name = '부산대학교'
+UNION ALL
+SELECT id, '부산대', '부산대', 'ALIAS'
+FROM university
+WHERE korean_name = '부산대학교'
+UNION ALL
+SELECT id, '서강대', '서강대', 'ALIAS'
+FROM university
+WHERE korean_name = '서강대학교'
+UNION ALL
+SELECT id, '과기대', '과기대', 'ALIAS'
+FROM university
+WHERE korean_name = '서울과학기술대학교'
+UNION ALL
+SELECT id, '서울과기대', '서울과기대', 'ALIAS'
+FROM university
+WHERE korean_name = '서울과학기술대학교'
+UNION ALL
+SELECT id, '설대', '설대', 'ALIAS'
+FROM university
+WHERE korean_name = '서울대학교'
+UNION ALL
+SELECT id, '서울대', '서울대', 'ALIAS'
+FROM university
+WHERE korean_name = '서울대학교'
+UNION ALL
+SELECT id, '시립대', '시립대', 'ALIAS'
+FROM university
+WHERE korean_name = '서울시립대학교'
+UNION ALL
+SELECT id, '서울시립대', '서울시립대', 'ALIAS'
+FROM university
+WHERE korean_name = '서울시립대학교'
+UNION ALL
+SELECT id, '성대', '성대', 'ALIAS'
+FROM university
+WHERE korean_name = '성균관대학교'
+UNION ALL
+SELECT id, '연대', '연대', 'ALIAS'
+FROM university
+WHERE korean_name = '연세대학교'
+UNION ALL
+SELECT id, '울산과기원', '울산과기원', 'ALIAS'
+FROM university
+WHERE korean_name = '울산과학기술원'
+UNION ALL
+SELECT id, '유니스트', '유니스트', 'ALIAS'
+FROM university
+WHERE korean_name = '울산과학기술원'
+UNION ALL
+SELECT id, 'unist', 'unist', 'ENGLISH_ALIAS'
+FROM university
+WHERE korean_name = '울산과학기술원'
+UNION ALL
+SELECT id, '육사', '육사', 'ALIAS'
+FROM university
+WHERE korean_name = '육군사관학교'
+UNION ALL
+SELECT id, '이대', '이대', 'ALIAS'
+FROM university
+WHERE korean_name = '이화여자대학교'
+UNION ALL
+SELECT id, '이화여대', '이화여대', 'ALIAS'
+FROM university
+WHERE korean_name = '이화여자대학교'
+UNION ALL
+SELECT id, '전대', '전대', 'ALIAS'
+FROM university
+WHERE korean_name = '전남대학교'
+UNION ALL
+SELECT id, '전남대', '전남대', 'ALIAS'
+FROM university
+WHERE korean_name = '전남대학교'
+UNION ALL
+SELECT id, '중대', '중대', 'ALIAS'
+FROM university
+WHERE korean_name = '중앙대학교'
+UNION ALL
+SELECT id, '충대', '충대', 'ALIAS'
+FROM university
+WHERE korean_name = '충남대학교'
+UNION ALL
+SELECT id, '충남대', '충남대', 'ALIAS'
+FROM university
+WHERE korean_name = '충남대학교'
+UNION ALL
+SELECT id, '충북대', '충북대', 'ALIAS'
+FROM university
+WHERE korean_name = '충북대학교'
+UNION ALL
+SELECT id, '포공', '포공', 'ALIAS'
+FROM university
+WHERE korean_name = '포항공과대학교'
+UNION ALL
+SELECT id, '포스텍', '포스텍', 'ALIAS'
+FROM university
+WHERE korean_name = '포항공과대학교'
+UNION ALL
+SELECT id, 'postech', 'postech', 'ENGLISH_ALIAS'
+FROM university
+WHERE korean_name = '포항공과대학교'
+UNION ALL
+SELECT id, '한공대', '한공대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국공학대학교'
+UNION ALL
+SELECT id, '한국공대', '한국공대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국공학대학교'
+UNION ALL
+SELECT id, '카이스트', '카이스트', 'ALIAS'
+FROM university
+WHERE korean_name = '한국과학기술원'
+UNION ALL
+SELECT id, 'kaist', 'kaist', 'ENGLISH_ALIAS'
+FROM university
+WHERE korean_name = '한국과학기술원'
+UNION ALL
+SELECT id, '교통대', '교통대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국교통대학교'
+UNION ALL
+SELECT id, '한국교통대', '한국교통대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국교통대학교'
+UNION ALL
+SELECT id, '한기대', '한기대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국기술교육대학교'
+UNION ALL
+SELECT id, '코리아텍', '코리아텍', 'ALIAS'
+FROM university
+WHERE korean_name = '한국기술교육대학교'
+UNION ALL
+SELECT id, 'koreatech', 'koreatech', 'ENGLISH_ALIAS'
+FROM university
+WHERE korean_name = '한국기술교육대학교'
+UNION ALL
+SELECT id, '외대', '외대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국외국어대학교'
+UNION ALL
+SELECT id, '한국외대', '한국외대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국외국어대학교'
+UNION ALL
+SELECT id, '한체대', '한체대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국체육대학교'
+UNION ALL
+SELECT id, '항공대', '항공대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국항공대학교'
+UNION ALL
+SELECT id, '한국항공대', '한국항공대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국항공대학교'
+UNION ALL
+SELECT id, '해양대', '해양대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국해양대학교'
+UNION ALL
+SELECT id, '한국해양대', '한국해양대', 'ALIAS'
+FROM university
+WHERE korean_name = '한국해양대학교'
+UNION ALL
+SELECT id, '해사', '해사', 'ALIAS'
+FROM university
+WHERE korean_name = '해군사관학교'
+UNION ALL
+SELECT id, '홍대', '홍대', 'ALIAS'
+FROM university
+WHERE korean_name = '홍익대학교';

--- a/src/test/java/gg/agit/konect/integration/domain/university/UniversityApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/university/UniversityApiTest.java
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import gg.agit.konect.domain.university.enums.Campus;
+import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.support.IntegrationTestSupport;
+import gg.agit.konect.support.fixture.UniversitySearchKeywordFixture;
 import gg.agit.konect.support.fixture.UniversityFixture;
 
 class UniversityApiTest extends IntegrationTestSupport {
@@ -98,9 +100,11 @@ class UniversityApiTest extends IntegrationTestSupport {
         @DisplayName("query가 대학교 약칭이면 일치하는 대학 목록을 조회한다")
         void getUniversitiesByAliasQuery() throws Exception {
             // given
-            persist(UniversityFixture.create("한국기술교육대학교", Campus.MAIN));
-            persist(UniversityFixture.create("서울과학기술대학교", Campus.MAIN));
+            University koreatech = persist(UniversityFixture.create("한국기술교육대학교", Campus.MAIN));
+            University seoulTech = persist(UniversityFixture.create("서울과학기술대학교", Campus.MAIN));
             persist(UniversityFixture.create("서울대학교", Campus.MAIN));
+            persist(UniversitySearchKeywordFixture.createAlias(koreatech, "한기대"));
+            persist(UniversitySearchKeywordFixture.createAlias(seoulTech, "과기대"));
             clearPersistenceContext();
 
             // when & then

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -18,9 +18,12 @@ import org.junit.jupiter.api.Test;
 import gg.agit.konect.domain.club.enums.ClubCategory;
 import gg.agit.konect.domain.university.enums.Campus;
 import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.domain.website.model.WebClub;
 import gg.agit.konect.domain.website.model.WebUniversity;
 import gg.agit.konect.support.IntegrationTestSupport;
+import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.UniversitySearchKeywordFixture;
 import gg.agit.konect.support.fixture.WebClubFixture;
 import gg.agit.konect.support.fixture.WebUniversityFixture;
 
@@ -78,6 +81,16 @@ class WebsiteApiTest extends IntegrationTestSupport {
         @DisplayName("대학교 이름 초성과 약칭으로 웹사이트 대학 목록을 검색한다")
         void getHomeSearchesUniversitiesByChoseongAndAlias() throws Exception {
             // given
+            University koreatech = persist(UniversityFixture.create(
+                "한국기술교육대학교",
+                Campus.MAIN,
+                UniversityRegion.CHUNGCHEONG
+            ));
+            University seoulTech = persist(UniversityFixture.create(
+                "서울과학기술대학교",
+                Campus.MAIN,
+                UniversityRegion.SEOUL
+            ));
             persist(WebUniversityFixture.create(
                 "한국기술교육대학교",
                 Campus.MAIN,
@@ -89,6 +102,8 @@ class WebsiteApiTest extends IntegrationTestSupport {
                 Campus.MAIN,
                 UniversityRegion.SEOUL
             ));
+            persist(UniversitySearchKeywordFixture.createAlias(koreatech, "한기대"));
+            persist(UniversitySearchKeywordFixture.createAlias(seoulTech, "과기대"));
             clearPersistenceContext();
 
             // when & then

--- a/src/test/java/gg/agit/konect/support/fixture/UniversitySearchKeywordFixture.java
+++ b/src/test/java/gg/agit/konect/support/fixture/UniversitySearchKeywordFixture.java
@@ -1,0 +1,17 @@
+package gg.agit.konect.support.fixture;
+
+import gg.agit.konect.domain.university.enums.UniversitySearchKeywordType;
+import gg.agit.konect.domain.university.model.University;
+import gg.agit.konect.domain.university.model.UniversitySearchKeyword;
+
+public class UniversitySearchKeywordFixture {
+
+    public static UniversitySearchKeyword createAlias(University university, String keyword) {
+        return UniversitySearchKeyword.builder()
+            .university(university)
+            .keyword(keyword)
+            .normalizedKeyword(keyword.replaceAll("\\s", "").toLowerCase())
+            .keywordType(UniversitySearchKeywordType.ALIAS)
+            .build();
+    }
+}

--- a/src/test/java/gg/agit/konect/support/fixture/UniversitySearchKeywordFixture.java
+++ b/src/test/java/gg/agit/konect/support/fixture/UniversitySearchKeywordFixture.java
@@ -1,5 +1,7 @@
 package gg.agit.konect.support.fixture;
 
+import java.util.Locale;
+
 import gg.agit.konect.domain.university.enums.UniversitySearchKeywordType;
 import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.domain.university.model.UniversitySearchKeyword;
@@ -10,7 +12,7 @@ public class UniversitySearchKeywordFixture {
         return UniversitySearchKeyword.builder()
             .university(university)
             .keyword(keyword)
-            .normalizedKeyword(keyword.replaceAll("\\s", "").toLowerCase())
+            .normalizedKeyword(keyword.replaceAll("\\s", "").toLowerCase(Locale.ROOT))
             .keywordType(UniversitySearchKeywordType.ALIAS)
             .build();
     }

--- a/src/test/java/gg/agit/konect/unit/domain/university/UniversitySearchKeywordMigrationTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/university/UniversitySearchKeywordMigrationTest.java
@@ -1,0 +1,141 @@
+package gg.agit.konect.unit.domain.university;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+class UniversitySearchKeywordMigrationTest {
+
+    private static final List<String> SEEDED_UNIVERSITY_NAMES = List.of(
+        "가톨릭대학교",
+        "건국대학교",
+        "경북대학교",
+        "경희대학교",
+        "고려대학교",
+        "광주과학기술원",
+        "단국대학교",
+        "대구경북과학기술원",
+        "동국대학교",
+        "부산대학교",
+        "서강대학교",
+        "서울과학기술대학교",
+        "서울대학교",
+        "서울시립대학교",
+        "성균관대학교",
+        "연세대학교",
+        "울산과학기술원",
+        "육군사관학교",
+        "이화여자대학교",
+        "전남대학교",
+        "중앙대학교",
+        "충남대학교",
+        "충북대학교",
+        "포항공과대학교",
+        "한국공학대학교",
+        "한국과학기술원",
+        "한국교통대학교",
+        "한국기술교육대학교",
+        "한국외국어대학교",
+        "한국체육대학교",
+        "한국항공대학교",
+        "한국해양대학교",
+        "해군사관학교",
+        "홍익대학교"
+    );
+
+    private static final int EXPECTED_KEYWORD_COUNT = 58;
+
+    @Test
+    void seedUniversitySearchKeywords() throws Exception {
+        JdbcTemplate jdbcTemplate = createJdbcTemplate("seedSuccess");
+        createUniversityTable(jdbcTemplate);
+        insertUniversities(jdbcTemplate, SEEDED_UNIVERSITY_NAMES);
+
+        executeMigration(jdbcTemplate, "db/migration/V86__create_university_search_keyword.sql");
+        executeMigration(jdbcTemplate, "db/migration/V87__seed_university_search_keywords.sql");
+
+        Integer keywordCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM university_search_keyword",
+            Integer.class
+        );
+        Integer koreatechAliasCount = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(*)
+                FROM university_search_keyword keyword
+                JOIN university ON university.id = keyword.university_id
+                WHERE university.korean_name = '한국기술교육대학교'
+                    AND keyword.keyword IN ('한기대', '코리아텍', 'koreatech')
+                """,
+            Integer.class
+        );
+        Integer seoulTechAliasCount = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(*)
+                FROM university_search_keyword keyword
+                JOIN university ON university.id = keyword.university_id
+                WHERE university.korean_name = '서울과학기술대학교'
+                    AND keyword.keyword IN ('과기대', '서울과기대')
+                """,
+            Integer.class
+        );
+
+        assertThat(keywordCount).isEqualTo(EXPECTED_KEYWORD_COUNT);
+        assertThat(koreatechAliasCount).isEqualTo(3);
+        assertThat(seoulTechAliasCount).isEqualTo(2);
+    }
+
+    @Test
+    void failWhenSeedTargetUniversityIsMissing() throws Exception {
+        JdbcTemplate jdbcTemplate = createJdbcTemplate("seedMissingUniversity");
+        createUniversityTable(jdbcTemplate);
+        insertUniversities(jdbcTemplate, SEEDED_UNIVERSITY_NAMES.stream()
+            .filter(universityName -> !universityName.equals("한국기술교육대학교"))
+            .toList());
+        executeMigration(jdbcTemplate, "db/migration/V86__create_university_search_keyword.sql");
+
+        assertThatThrownBy(() ->
+            executeMigration(jdbcTemplate, "db/migration/V87__seed_university_search_keywords.sql"))
+            .isInstanceOf(Exception.class);
+    }
+
+    private JdbcTemplate createJdbcTemplate(String databaseName) {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:" + databaseName + ";MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return new JdbcTemplate(dataSource);
+    }
+
+    private void createUniversityTable(JdbcTemplate jdbcTemplate) {
+        jdbcTemplate.execute("""
+            CREATE TABLE university
+            (
+                id          INT AUTO_INCREMENT PRIMARY KEY,
+                korean_name VARCHAR(255) NOT NULL
+            )
+            """);
+    }
+
+    private void insertUniversities(JdbcTemplate jdbcTemplate, List<String> universityNames) {
+        for (String universityName : universityNames) {
+            jdbcTemplate.update("INSERT INTO university (korean_name) VALUES (?)", universityName);
+        }
+    }
+
+    private void executeMigration(JdbcTemplate jdbcTemplate, String path) throws SQLException {
+        try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
+            ScriptUtils.executeSqlScript(connection, new EncodedResource(new ClassPathResource(path), "UTF-8"));
+        }
+    }
+}


### PR DESCRIPTION
### 📌 개요

* 대학 약칭 검색어를 코드 상수에서 분리해 DB 검색 키워드 데이터로 관리하도록 리팩터링했습니다.

---

### ✅ 주요 변경 내용

* `university_search_keyword` 테이블과 JPA 엔티티/리포지토리를 추가했습니다.
* 기존 하드코딩 약칭 목록을 Flyway seed 데이터로 이전했습니다.
* `/universities`, `/konect/home` 검색에서 대학별 관리형 키워드를 한 번에 조회해 초성/약칭 매칭에 사용하도록 변경했습니다.
* 약칭 검색 통합 테스트가 DB 키워드 데이터를 직접 검증하도록 보강했습니다.

---

### 🧠 참고 사항

* 초성, 캠퍼스 제거, `대학교` 축약 같은 규칙 기반 토큰은 기존 matcher에서 계속 생성합니다.
* 학교별 특수 약칭과 영문 약칭만 `university_search_keyword` 데이터로 관리합니다.
* `checkstyleTest`는 기존 테스트 파일의 긴 줄 이슈로 실패하며, 이번 변경 파일 문제는 아닙니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)
