### PR TITLE
fix: 웹 대학 기준 검색 키워드 보정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/university/model/UniversitySearchKeyword.java
+++ b/src/main/java/gg/agit/konect/domain/university/model/UniversitySearchKeyword.java
@@ -6,6 +6,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import gg.agit.konect.domain.university.enums.UniversitySearchKeywordType;
+import gg.agit.konect.domain.website.model.WebUniversity;
 import gg.agit.konect.global.model.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -44,7 +45,7 @@ public class UniversitySearchKeyword extends BaseEntity {
     @ToString.Exclude
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "university_id", nullable = false)
-    private University university;
+    private WebUniversity university;
 
     @NotNull
     @Column(name = "keyword", length = 100, nullable = false)
@@ -62,7 +63,7 @@ public class UniversitySearchKeyword extends BaseEntity {
     @Builder
     private UniversitySearchKeyword(
         Integer id,
-        University university,
+        WebUniversity university,
         String keyword,
         String normalizedKeyword,
         UniversitySearchKeywordType keywordType

--- a/src/main/resources/db/migration/V88__move_university_search_keywords_to_web_university.sql
+++ b/src/main/resources/db/migration/V88__move_university_search_keywords_to_web_university.sql
@@ -1,14 +1,18 @@
-ALTER TABLE university_search_keyword
-    DROP FOREIGN KEY fk_university_search_keyword_university;
+CREATE TABLE university_search_keyword_web_university_seed
+(
+    university_id      INT          NOT NULL,
+    keyword            VARCHAR(100) NOT NULL,
+    normalized_keyword VARCHAR(100) NOT NULL,
+    keyword_type       VARCHAR(50)  NOT NULL,
 
-DELETE FROM university_search_keyword;
-
-ALTER TABLE university_search_keyword
-    ADD CONSTRAINT fk_university_search_keyword_web_university
-        FOREIGN KEY (university_id) REFERENCES web_university (id);
+    CONSTRAINT fk_university_search_keyword_seed_web_university
+        FOREIGN KEY (university_id) REFERENCES web_university (id),
+    CONSTRAINT uq_university_search_keyword_seed_university_keyword
+        UNIQUE (university_id, normalized_keyword)
+);
 
 -- Search keywords are used by the public website, so seed them from web_university.
-INSERT INTO university_search_keyword (university_id, keyword, normalized_keyword, keyword_type)
+INSERT INTO university_search_keyword_web_university_seed (university_id, keyword, normalized_keyword, keyword_type)
 SELECT web_university.id, expected_keyword.keyword, expected_keyword.normalized_keyword, expected_keyword.keyword_type
 FROM (
     SELECT '가톨릭대학교' AS university_name, '가대' AS keyword, '가대' AS normalized_keyword, 'ALIAS' AS keyword_type
@@ -73,4 +77,20 @@ FROM (
 JOIN web_university ON web_university.korean_name = expected_keyword.university_name
 ON DUPLICATE KEY UPDATE
     keyword = VALUES(keyword),
+    normalized_keyword = VALUES(normalized_keyword),
     keyword_type = VALUES(keyword_type);
+
+ALTER TABLE university_search_keyword
+    DROP FOREIGN KEY fk_university_search_keyword_university;
+
+DELETE FROM university_search_keyword;
+
+ALTER TABLE university_search_keyword
+    ADD CONSTRAINT fk_university_search_keyword_web_university
+        FOREIGN KEY (university_id) REFERENCES web_university (id);
+
+INSERT INTO university_search_keyword (university_id, keyword, normalized_keyword, keyword_type)
+SELECT university_id, keyword, normalized_keyword, keyword_type
+FROM university_search_keyword_web_university_seed;
+
+DROP TABLE university_search_keyword_web_university_seed;

--- a/src/main/resources/db/migration/V88__move_university_search_keywords_to_web_university.sql
+++ b/src/main/resources/db/migration/V88__move_university_search_keywords_to_web_university.sql
@@ -1,0 +1,76 @@
+ALTER TABLE university_search_keyword
+    DROP FOREIGN KEY fk_university_search_keyword_university;
+
+DELETE FROM university_search_keyword;
+
+ALTER TABLE university_search_keyword
+    ADD CONSTRAINT fk_university_search_keyword_web_university
+        FOREIGN KEY (university_id) REFERENCES web_university (id);
+
+-- Search keywords are used by the public website, so seed them from web_university.
+INSERT INTO university_search_keyword (university_id, keyword, normalized_keyword, keyword_type)
+SELECT web_university.id, expected_keyword.keyword, expected_keyword.normalized_keyword, expected_keyword.keyword_type
+FROM (
+    SELECT '가톨릭대학교' AS university_name, '가대' AS keyword, '가대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '건국대학교' AS university_name, '건대' AS keyword, '건대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '경북대학교' AS university_name, '경대' AS keyword, '경대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '경북대학교' AS university_name, '경북대' AS keyword, '경북대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '경희대학교' AS university_name, '경희대' AS keyword, '경희대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '고려대학교' AS university_name, '고대' AS keyword, '고대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '광주과학기술원' AS university_name, '광주과기원' AS keyword, '광주과기원' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '광주과학기술원' AS university_name, '지스트' AS keyword, '지스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '광주과학기술원' AS university_name, 'gist' AS keyword, 'gist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '단국대학교' AS university_name, '단대' AS keyword, '단대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '대구경북과학기술원' AS university_name, '대경과기원' AS keyword, '대경과기원' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '대구경북과학기술원' AS university_name, '디지스트' AS keyword, '디지스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '대구경북과학기술원' AS university_name, 'dgist' AS keyword, 'dgist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '동국대학교' AS university_name, '동대' AS keyword, '동대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '부산대학교' AS university_name, '부대' AS keyword, '부대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '부산대학교' AS university_name, '부산대' AS keyword, '부산대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서강대학교' AS university_name, '서강대' AS keyword, '서강대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울과학기술대학교' AS university_name, '과기대' AS keyword, '과기대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울과학기술대학교' AS university_name, '서울과기대' AS keyword, '서울과기대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울대학교' AS university_name, '설대' AS keyword, '설대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울대학교' AS university_name, '서울대' AS keyword, '서울대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울시립대학교' AS university_name, '시립대' AS keyword, '시립대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '서울시립대학교' AS university_name, '서울시립대' AS keyword, '서울시립대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '성균관대학교' AS university_name, '성대' AS keyword, '성대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '연세대학교' AS university_name, '연대' AS keyword, '연대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '울산과학기술원' AS university_name, '울산과기원' AS keyword, '울산과기원' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '울산과학기술원' AS university_name, '유니스트' AS keyword, '유니스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '울산과학기술원' AS university_name, 'unist' AS keyword, 'unist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '육군사관학교' AS university_name, '육사' AS keyword, '육사' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '이화여자대학교' AS university_name, '이대' AS keyword, '이대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '이화여자대학교' AS university_name, '이화여대' AS keyword, '이화여대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '전남대학교' AS university_name, '전대' AS keyword, '전대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '전남대학교' AS university_name, '전남대' AS keyword, '전남대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '중앙대학교' AS university_name, '중대' AS keyword, '중대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '충남대학교' AS university_name, '충대' AS keyword, '충대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '충남대학교' AS university_name, '충남대' AS keyword, '충남대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '충북대학교' AS university_name, '충북대' AS keyword, '충북대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '포항공과대학교' AS university_name, '포공' AS keyword, '포공' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '포항공과대학교' AS university_name, '포스텍' AS keyword, '포스텍' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '포항공과대학교' AS university_name, 'postech' AS keyword, 'postech' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '한국공학대학교' AS university_name, '한공대' AS keyword, '한공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국공학대학교' AS university_name, '한국공대' AS keyword, '한국공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국과학기술원' AS university_name, '카이스트' AS keyword, '카이스트' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국과학기술원' AS university_name, 'kaist' AS keyword, 'kaist' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '한국교통대학교' AS university_name, '교통대' AS keyword, '교통대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국교통대학교' AS university_name, '한국교통대' AS keyword, '한국교통대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국기술교육대학교' AS university_name, '한기대' AS keyword, '한기대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국기술교육대학교' AS university_name, '코리아텍' AS keyword, '코리아텍' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국기술교육대학교' AS university_name, 'koreatech' AS keyword, 'koreatech' AS normalized_keyword, 'ENGLISH_ALIAS' AS keyword_type
+    UNION ALL SELECT '한국외국어대학교' AS university_name, '외대' AS keyword, '외대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국외국어대학교' AS university_name, '한국외대' AS keyword, '한국외대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국체육대학교' AS university_name, '한체대' AS keyword, '한체대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국항공대학교' AS university_name, '항공대' AS keyword, '항공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국항공대학교' AS university_name, '한국항공대' AS keyword, '한국항공대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국해양대학교' AS university_name, '해양대' AS keyword, '해양대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '한국해양대학교' AS university_name, '한국해양대' AS keyword, '한국해양대' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '해군사관학교' AS university_name, '해사' AS keyword, '해사' AS normalized_keyword, 'ALIAS' AS keyword_type
+    UNION ALL SELECT '홍익대학교' AS university_name, '홍대' AS keyword, '홍대' AS normalized_keyword, 'ALIAS' AS keyword_type
+) expected_keyword
+JOIN web_university ON web_university.korean_name = expected_keyword.university_name
+ON DUPLICATE KEY UPDATE
+    keyword = VALUES(keyword),
+    keyword_type = VALUES(keyword_type);

--- a/src/test/java/gg/agit/konect/integration/domain/university/UniversityApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/university/UniversityApiTest.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.Test;
 
 import gg.agit.konect.domain.university.enums.Campus;
 import gg.agit.konect.domain.university.model.University;
+import gg.agit.konect.domain.website.model.WebUniversity;
 import gg.agit.konect.support.IntegrationTestSupport;
 import gg.agit.konect.support.fixture.UniversitySearchKeywordFixture;
 import gg.agit.konect.support.fixture.UniversityFixture;
+import gg.agit.konect.support.fixture.WebUniversityFixture;
 
 class UniversityApiTest extends IntegrationTestSupport {
 
@@ -103,8 +105,10 @@ class UniversityApiTest extends IntegrationTestSupport {
             University koreatech = persist(UniversityFixture.create("한국기술교육대학교", Campus.MAIN));
             University seoulTech = persist(UniversityFixture.create("서울과학기술대학교", Campus.MAIN));
             persist(UniversityFixture.create("서울대학교", Campus.MAIN));
-            persist(UniversitySearchKeywordFixture.createAlias(koreatech, "한기대"));
-            persist(UniversitySearchKeywordFixture.createAlias(seoulTech, "과기대"));
+            WebUniversity webKoreatech = persist(WebUniversityFixture.create(koreatech.getKoreanName(), Campus.MAIN));
+            WebUniversity webSeoulTech = persist(WebUniversityFixture.create(seoulTech.getKoreanName(), Campus.MAIN));
+            persist(UniversitySearchKeywordFixture.createAlias(webKoreatech, "한기대"));
+            persist(UniversitySearchKeywordFixture.createAlias(webSeoulTech, "과기대"));
             clearPersistenceContext();
 
             // when & then

--- a/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/website/WebsiteApiTest.java
@@ -18,11 +18,9 @@ import org.junit.jupiter.api.Test;
 import gg.agit.konect.domain.club.enums.ClubCategory;
 import gg.agit.konect.domain.university.enums.Campus;
 import gg.agit.konect.domain.university.enums.UniversityRegion;
-import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.domain.website.model.WebClub;
 import gg.agit.konect.domain.website.model.WebUniversity;
 import gg.agit.konect.support.IntegrationTestSupport;
-import gg.agit.konect.support.fixture.UniversityFixture;
 import gg.agit.konect.support.fixture.UniversitySearchKeywordFixture;
 import gg.agit.konect.support.fixture.WebClubFixture;
 import gg.agit.konect.support.fixture.WebUniversityFixture;
@@ -81,23 +79,13 @@ class WebsiteApiTest extends IntegrationTestSupport {
         @DisplayName("대학교 이름 초성과 약칭으로 웹사이트 대학 목록을 검색한다")
         void getHomeSearchesUniversitiesByChoseongAndAlias() throws Exception {
             // given
-            University koreatech = persist(UniversityFixture.create(
-                "한국기술교육대학교",
-                Campus.MAIN,
-                UniversityRegion.CHUNGCHEONG
-            ));
-            University seoulTech = persist(UniversityFixture.create(
-                "서울과학기술대학교",
-                Campus.MAIN,
-                UniversityRegion.SEOUL
-            ));
-            persist(WebUniversityFixture.create(
+            WebUniversity koreatech = persist(WebUniversityFixture.create(
                 "한국기술교육대학교",
                 Campus.MAIN,
                 UniversityRegion.CHUNGCHEONG,
                 "https://example.com/koreatech-logo.png"
             ));
-            persist(WebUniversityFixture.create(
+            WebUniversity seoulTech = persist(WebUniversityFixture.create(
                 "서울과학기술대학교",
                 Campus.MAIN,
                 UniversityRegion.SEOUL

--- a/src/test/java/gg/agit/konect/support/fixture/UniversitySearchKeywordFixture.java
+++ b/src/test/java/gg/agit/konect/support/fixture/UniversitySearchKeywordFixture.java
@@ -3,12 +3,12 @@ package gg.agit.konect.support.fixture;
 import java.util.Locale;
 
 import gg.agit.konect.domain.university.enums.UniversitySearchKeywordType;
-import gg.agit.konect.domain.university.model.University;
 import gg.agit.konect.domain.university.model.UniversitySearchKeyword;
+import gg.agit.konect.domain.website.model.WebUniversity;
 
 public class UniversitySearchKeywordFixture {
 
-    public static UniversitySearchKeyword createAlias(University university, String keyword) {
+    public static UniversitySearchKeyword createAlias(WebUniversity university, String keyword) {
         return UniversitySearchKeyword.builder()
             .university(university)
             .keyword(keyword)

--- a/src/test/java/gg/agit/konect/unit/domain/university/UniversitySearchKeywordMigrationTest.java
+++ b/src/test/java/gg/agit/konect/unit/domain/university/UniversitySearchKeywordMigrationTest.java
@@ -120,6 +120,36 @@ class UniversitySearchKeywordMigrationTest {
         assertThat(keywords).containsExactlyInAnyOrder("한기대", "코리아텍", "koreatech");
     }
 
+    @Test
+    void moveUniversitySearchKeywordsToWebUniversity() throws Exception {
+        JdbcTemplate jdbcTemplate = createJdbcTemplate("moveToWebUniversity");
+        createUniversityTable(jdbcTemplate);
+        createWebUniversityTable(jdbcTemplate);
+        insertUniversities(jdbcTemplate, List.of("한국기술교육대학교"));
+        insertWebUniversities(jdbcTemplate, List.of("한국기술교육대학교", "포항공과대학교"));
+
+        executeMigration(jdbcTemplate, "db/migration/V86__create_university_search_keyword.sql");
+        executeMigration(jdbcTemplate, "db/migration/V87__seed_university_search_keywords.sql");
+        executeMigration(jdbcTemplate, "db/migration/V88__move_university_search_keywords_to_web_university.sql");
+
+        Integer keywordCount = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM university_search_keyword",
+            Integer.class
+        );
+        List<String> postechKeywords = jdbcTemplate.queryForList(
+            """
+                SELECT keyword.keyword
+                FROM university_search_keyword keyword
+                JOIN web_university university ON university.id = keyword.university_id
+                WHERE university.korean_name = '포항공과대학교'
+                """,
+            String.class
+        );
+
+        assertThat(keywordCount).isEqualTo(6);
+        assertThat(postechKeywords).containsExactlyInAnyOrder("포공", "포스텍", "postech");
+    }
+
     private JdbcTemplate createJdbcTemplate(String databaseName) {
         DriverManagerDataSource dataSource = new DriverManagerDataSource();
         dataSource.setDriverClassName("org.h2.Driver");
@@ -139,9 +169,25 @@ class UniversitySearchKeywordMigrationTest {
             """);
     }
 
+    private void createWebUniversityTable(JdbcTemplate jdbcTemplate) {
+        jdbcTemplate.execute("""
+            CREATE TABLE web_university
+            (
+                id          INT AUTO_INCREMENT PRIMARY KEY,
+                korean_name VARCHAR(255) NOT NULL
+            )
+            """);
+    }
+
     private void insertUniversities(JdbcTemplate jdbcTemplate, List<String> universityNames) {
         for (String universityName : universityNames) {
             jdbcTemplate.update("INSERT INTO university (korean_name) VALUES (?)", universityName);
+        }
+    }
+
+    private void insertWebUniversities(JdbcTemplate jdbcTemplate, List<String> universityNames) {
+        for (String universityName : universityNames) {
+            jdbcTemplate.update("INSERT INTO web_university (korean_name) VALUES (?)", universityName);
         }
     }
 


### PR DESCRIPTION
### 🔍 개요

* 대학 검색 키워드가 앱용 `university`가 아니라 웹 공개 목록 기준인 `web_university`와 연결되도록 보정합니다.
* Public Website 홈 검색에서 `web_university`에 존재하는 대학 약칭이 정상 seed/조회되도록 맞췄습니다.


---

### 🚀 주요 변경 내용

* `UniversitySearchKeyword`의 연관 엔티티를 `University`에서 `WebUniversity`로 변경했습니다.
* `V88__move_university_search_keywords_to_web_university.sql`을 추가했습니다.
* 기존 `university_search_keyword` FK를 `university`에서 `web_university`로 교체합니다.
* 기존 키워드를 비우고 `web_university` 기준으로 다시 seed합니다.
* `포항공과대학교`가 `web_university`에 존재하면 `포스텍`, `postech`, `포공` 키워드도 함께 seed됩니다.
* 웹/대학 검색 테스트 fixture를 `WebUniversity` 기준으로 정리했습니다.
* V88 마이그레이션 테스트를 추가해 `web_university` 기준으로 포스텍 키워드가 들어가는지 확인했습니다.


---

### 💬 참고 사항

* 현재 stage에서 V87까지 성공한 상태라면, 이번 배포 후 V88이 실행되면서 키워드 FK와 seed 데이터가 `web_university` 기준으로 재구성됩니다.
* 검증 명령어는 다음과 같습니다.
* `./gradlew.bat test --tests "gg.agit.konect.unit.domain.university.UniversitySearchKeywordMigrationTest" --rerun-tasks`
* `./gradlew.bat test --tests "gg.agit.konect.integration.domain.website.WebsiteApiTest" --tests "gg.agit.konect.integration.domain.university.UniversityApiTest"`
* `./gradlew.bat checkstyleMain`


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)