### PR TITLE
feat: 웹사이트 동아리 시트 가져오기 추가

### DIFF
--- a/src/main/java/gg/agit/konect/admin/website/controller/AdminWebsiteClubSheetImportApi.java
+++ b/src/main/java/gg/agit/konect/admin/website/controller/AdminWebsiteClubSheetImportApi.java
@@ -1,0 +1,46 @@
+package gg.agit.konect.admin.website.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportConfirmRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportPreviewResponse;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "(Admin) Website Club Sheet Import", description = "konect.space 대학별 동아리 목록 시트 등록 API")
+@RequestMapping("/admin/konect/universities")
+public interface AdminWebsiteClubSheetImportApi {
+
+    @Operation(
+        summary = "Google Sheets 동아리 등록 양식을 분석하고 미리보기 JSON을 반환한다.",
+        description = """
+            작성 시트의 동아리 목록을 읽고 Claude Haiku로 KONECT 웹사이트용 동아리 JSON을 생성합니다.
+            이 API는 DB에 저장하지 않고, 사용자가 확인/수정할 수 있는 중간 결과만 반환합니다.
+            """
+    )
+    @PostMapping("/{universityId}/clubs/sheet/import/preview")
+    ResponseEntity<AdminWebsiteClubSheetImportPreviewResponse> previewClubs(
+        @PathVariable(name = "universityId") Integer universityId,
+        @Valid @RequestBody AdminWebsiteClubSheetImportRequest request
+    );
+
+    @Operation(
+        summary = "미리보기 JSON을 최종 동아리 목록으로 저장한다.",
+        description = """
+            preview 응답을 그대로 보내거나 수정한 뒤 보내면 web_club에 저장합니다.
+            enabled=false인 항목과 이미 같은 대학에 등록된 같은 이름의 동아리는 저장하지 않습니다.
+            """
+    )
+    @PostMapping("/{universityId}/clubs/sheet/import/confirm")
+    ResponseEntity<AdminWebsiteClubSheetImportResponse> confirmImport(
+        @PathVariable(name = "universityId") Integer universityId,
+        @Valid @RequestBody AdminWebsiteClubSheetImportConfirmRequest request
+    );
+}

--- a/src/main/java/gg/agit/konect/admin/website/controller/AdminWebsiteClubSheetImportController.java
+++ b/src/main/java/gg/agit/konect/admin/website/controller/AdminWebsiteClubSheetImportController.java
@@ -1,0 +1,43 @@
+package gg.agit.konect.admin.website.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportConfirmRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportPreviewResponse;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportResponse;
+import gg.agit.konect.admin.website.service.AdminWebsiteClubSheetImportService;
+import gg.agit.konect.domain.user.enums.UserRole;
+import gg.agit.konect.global.auth.annotation.Auth;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/konect/universities")
+@Auth(roles = {UserRole.ADMIN})
+public class AdminWebsiteClubSheetImportController implements AdminWebsiteClubSheetImportApi {
+
+    private final AdminWebsiteClubSheetImportService adminWebsiteClubSheetImportService;
+
+    @Override
+    public ResponseEntity<AdminWebsiteClubSheetImportPreviewResponse> previewClubs(
+        Integer universityId,
+        AdminWebsiteClubSheetImportRequest request
+    ) {
+        AdminWebsiteClubSheetImportPreviewResponse response =
+            adminWebsiteClubSheetImportService.previewClubs(universityId, request.spreadsheetUrl());
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<AdminWebsiteClubSheetImportResponse> confirmImport(
+        Integer universityId,
+        AdminWebsiteClubSheetImportConfirmRequest request
+    ) {
+        AdminWebsiteClubSheetImportResponse response =
+            adminWebsiteClubSheetImportService.confirmImport(universityId, request.clubs());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportConfirmRequest.java
+++ b/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportConfirmRequest.java
@@ -1,0 +1,46 @@
+package gg.agit.konect.admin.website.dto;
+
+import java.util.List;
+
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AdminWebsiteClubSheetImportConfirmRequest(
+
+    @NotEmpty
+    List<@Valid ConfirmClub> clubs
+) {
+
+    public record ConfirmClub(
+        int rowNumber,
+
+        @NotBlank
+        @Size(max = 50)
+        String name,
+
+        @NotNull
+        ClubCategory clubCategory,
+
+        @NotBlank
+        @Size(max = 20)
+        String topic,
+
+        @NotBlank
+        @Size(max = 30)
+        String description,
+
+        @NotBlank
+        String introduce,
+
+        @NotBlank
+        @Size(max = 255)
+        String categoryEmoji,
+
+        boolean enabled
+    ) {
+    }
+}

--- a/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportPreviewResponse.java
+++ b/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportPreviewResponse.java
@@ -1,0 +1,38 @@
+package gg.agit.konect.admin.website.dto;
+
+import java.util.List;
+
+import gg.agit.konect.domain.club.enums.ClubCategory;
+
+public record AdminWebsiteClubSheetImportPreviewResponse(
+    Integer universityId,
+    int previewCount,
+    List<PreviewClub> clubs,
+    List<String> warnings
+) {
+
+    public static AdminWebsiteClubSheetImportPreviewResponse of(
+        Integer universityId,
+        List<PreviewClub> clubs,
+        List<String> warnings
+    ) {
+        return new AdminWebsiteClubSheetImportPreviewResponse(
+            universityId,
+            clubs.size(),
+            clubs,
+            warnings == null ? List.of() : warnings
+        );
+    }
+
+    public record PreviewClub(
+        int rowNumber,
+        String name,
+        ClubCategory clubCategory,
+        String topic,
+        String description,
+        String introduce,
+        String categoryEmoji,
+        boolean enabled
+    ) {
+    }
+}

--- a/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportRequest.java
+++ b/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportRequest.java
@@ -1,0 +1,17 @@
+package gg.agit.konect.admin.website.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record AdminWebsiteClubSheetImportRequest(
+
+    @Schema(
+        description = "동아리 등록 양식 Google Sheets URL",
+        example = "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit"
+    )
+    @NotBlank
+    @Pattern(regexp = "^https://docs\\.google\\.com/spreadsheets/(?:u/\\d+/)?d/[A-Za-z0-9_-]+.*")
+    String spreadsheetUrl
+) {
+}

--- a/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportResponse.java
+++ b/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportResponse.java
@@ -1,0 +1,22 @@
+package gg.agit.konect.admin.website.dto;
+
+import java.util.List;
+
+public record AdminWebsiteClubSheetImportResponse(
+    int importedCount,
+    int skippedCount,
+    List<String> warnings
+) {
+
+    public static AdminWebsiteClubSheetImportResponse of(
+        int importedCount,
+        int skippedCount,
+        List<String> warnings
+    ) {
+        return new AdminWebsiteClubSheetImportResponse(
+            importedCount,
+            skippedCount,
+            warnings == null ? List.of() : warnings
+        );
+    }
+}

--- a/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
+++ b/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -115,6 +116,9 @@ public class AdminWebsiteClubSheetImportService {
         Set<String> existingNames = requestNames.isEmpty()
             ? Set.of()
             : webClubRepository.findExistingNamesByUniversityId(universityId, requestNames);
+        Set<String> normalizedExistingNames = existingNames.stream()
+            .map(name -> name.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toSet());
 
         Set<String> seenNames = new LinkedHashSet<>();
         List<WebClub> clubsToSave = new ArrayList<>();
@@ -130,7 +134,7 @@ public class AdminWebsiteClubSheetImportService {
                 warnings.add(String.format("%d행: 요청 안에서 중복된 동아리명 '%s'을 제외했습니다.", club.rowNumber(), name));
                 continue;
             }
-            if (existingNames.contains(name)) {
+            if (normalizedExistingNames.contains(normalizedName)) {
                 warnings.add(String.format("%d행: 이미 등록된 동아리명 '%s'을 제외했습니다.", club.rowNumber(), name));
                 continue;
             }
@@ -231,7 +235,7 @@ public class AdminWebsiteClubSheetImportService {
                 .body(String.class);
 
             JsonNode root = objectMapper.readTree(response);
-            String rawJson = root.path("content").get(0).path("text").asText();
+            String rawJson = extractClaudeText(root, response);
             return parseClaudeResult(rawJson);
         } catch (Exception e) {
             log.error("Failed to analyze website club import sheet with Claude.", e);
@@ -286,6 +290,19 @@ public class AdminWebsiteClubSheetImportService {
         } catch (IOException e) {
             throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
         }
+    }
+
+    private String extractClaudeText(JsonNode root, String response) {
+        JsonNode content = root.path("content");
+        if (!content.isArray() || content.isEmpty()) {
+            throw new IllegalArgumentException("Claude API returned empty content. response=" + response);
+        }
+
+        String text = content.get(0).path("text").asText();
+        if (text.isBlank()) {
+            throw new IllegalArgumentException("Claude API returned blank text. response=" + response);
+        }
+        return text;
     }
 
     private AnalyzedClubSheet parseClaudeResult(String rawJson) throws IOException {

--- a/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
+++ b/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
@@ -1,0 +1,421 @@
+package gg.agit.konect.admin.website.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.ValueRange;
+
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportConfirmRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportPreviewResponse;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportResponse;
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import gg.agit.konect.domain.club.service.GoogleSheetApiExceptionHelper;
+import gg.agit.konect.domain.club.service.SpreadsheetUrlParser;
+import gg.agit.konect.domain.website.model.WebClub;
+import gg.agit.konect.domain.website.model.WebUniversity;
+import gg.agit.konect.domain.website.repository.WebClubRepository;
+import gg.agit.konect.domain.website.repository.WebUniversityRepository;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+import gg.agit.konect.infrastructure.claude.config.ClaudeProperties;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class AdminWebsiteClubSheetImportService {
+
+    private static final String API_URL = "https://api.anthropic.com/v1/messages";
+    private static final String ANTHROPIC_VERSION = "2023-06-01";
+    private static final String MODEL = "claude-haiku-4-5-20251001";
+    private static final String INPUT_SHEET_RANGE = "'작성 시트'!A1:F1000";
+    private static final int MAX_TOKENS = 4096;
+    private static final int DEFAULT_HEADER_INDEX = 3;
+    private static final int NAME_MAX_LENGTH = 50;
+    private static final int TOPIC_MAX_LENGTH = 20;
+    private static final int DESCRIPTION_MAX_LENGTH = 30;
+    private static final int CATEGORY_EMOJI_MAX_LENGTH = 255;
+    private static final int NAME_COLUMN_INDEX = 0;
+    private static final int CATEGORY_COLUMN_INDEX = 1;
+    private static final int CUSTOM_CATEGORY_COLUMN_INDEX = 2;
+    private static final int TOPIC_COLUMN_INDEX = 3;
+    private static final int CATEGORY_EMOJI_COLUMN_INDEX = 4;
+    private static final int DESCRIPTION_COLUMN_INDEX = 5;
+
+    private final Sheets googleSheetsService;
+    private final ClaudeProperties claudeProperties;
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient;
+    private final WebUniversityRepository webUniversityRepository;
+    private final WebClubRepository webClubRepository;
+
+    public AdminWebsiteClubSheetImportService(
+        Sheets googleSheetsService,
+        ClaudeProperties claudeProperties,
+        ObjectMapper objectMapper,
+        RestClient.Builder restClientBuilder,
+        WebUniversityRepository webUniversityRepository,
+        WebClubRepository webClubRepository
+    ) {
+        this.googleSheetsService = googleSheetsService;
+        this.claudeProperties = claudeProperties;
+        this.objectMapper = objectMapper;
+        this.restClient = restClientBuilder.build();
+        this.webUniversityRepository = webUniversityRepository;
+        this.webClubRepository = webClubRepository;
+    }
+
+    public AdminWebsiteClubSheetImportPreviewResponse previewClubs(
+        Integer universityId,
+        String spreadsheetUrl
+    ) {
+        webUniversityRepository.getById(universityId);
+        String spreadsheetId = SpreadsheetUrlParser.extractId(spreadsheetUrl);
+        List<RawClubRow> rows = readClubRows(spreadsheetId);
+        AnalyzedClubSheet analyzedSheet = analyzeRowsWithClaude(rows);
+        return AdminWebsiteClubSheetImportPreviewResponse.of(
+            universityId,
+            analyzedSheet.clubs(),
+            analyzedSheet.warnings()
+        );
+    }
+
+    @Transactional
+    public AdminWebsiteClubSheetImportResponse confirmImport(
+        Integer universityId,
+        List<AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub> clubs
+    ) {
+        WebUniversity university = webUniversityRepository.getById(universityId);
+        List<String> warnings = new ArrayList<>();
+        List<AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub> enabledClubs = clubs == null
+            ? List.of()
+            : clubs.stream()
+                .filter(AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub::enabled)
+                .toList();
+
+        Set<String> requestNames = new LinkedHashSet<>();
+        enabledClubs.stream()
+            .map(AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub::name)
+            .map(String::trim)
+            .filter(name -> !name.isBlank())
+            .forEach(requestNames::add);
+
+        Set<String> existingNames = requestNames.isEmpty()
+            ? Set.of()
+            : webClubRepository.findExistingNamesByUniversityId(universityId, requestNames);
+
+        Set<String> seenNames = new LinkedHashSet<>();
+        List<WebClub> clubsToSave = new ArrayList<>();
+
+        for (AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub club : enabledClubs) {
+            String name = club.name().trim();
+            String normalizedName = name.toLowerCase(Locale.ROOT);
+            if (name.isBlank()) {
+                warnings.add(String.format("%d행: 동아리명이 비어 있어 제외했습니다.", club.rowNumber()));
+                continue;
+            }
+            if (!seenNames.add(normalizedName)) {
+                warnings.add(String.format("%d행: 요청 안에서 중복된 동아리명 '%s'을 제외했습니다.", club.rowNumber(), name));
+                continue;
+            }
+            if (existingNames.contains(name)) {
+                warnings.add(String.format("%d행: 이미 등록된 동아리명 '%s'을 제외했습니다.", club.rowNumber(), name));
+                continue;
+            }
+
+            clubsToSave.add(WebClub.builder()
+                .university(university)
+                .clubCategory(club.clubCategory())
+                .name(name)
+                .topic(limit(requiredText(club.topic(), "기타"), TOPIC_MAX_LENGTH))
+                .description(limit(requiredText(club.description(), name), DESCRIPTION_MAX_LENGTH))
+                .introduce(requiredText(club.introduce(), club.description()))
+                .categoryEmoji(limit(
+                    requiredText(club.categoryEmoji(), emojiOf(club.clubCategory())),
+                    CATEGORY_EMOJI_MAX_LENGTH
+                ))
+                .build());
+        }
+
+        List<WebClub> savedClubs = clubsToSave.isEmpty()
+            ? List.of()
+            : webClubRepository.saveAll(clubsToSave);
+
+        return AdminWebsiteClubSheetImportResponse.of(
+            savedClubs.size(),
+            enabledClubs.size() - savedClubs.size(),
+            warnings
+        );
+    }
+
+    private List<RawClubRow> readClubRows(String spreadsheetId) {
+        try {
+            ValueRange response = googleSheetsService.spreadsheets().values()
+                .get(spreadsheetId, INPUT_SHEET_RANGE)
+                .setValueRenderOption("FORMATTED_VALUE")
+                .execute();
+
+            List<List<Object>> values = response.getValues();
+            if (values == null || values.isEmpty()) {
+                return List.of();
+            }
+
+            int headerIndex = findHeaderIndex(values);
+            List<RawClubRow> rows = new ArrayList<>();
+            for (int rowIndex = headerIndex + 1; rowIndex < values.size(); rowIndex++) {
+                List<Object> row = values.get(rowIndex);
+                RawClubRow rawClubRow = new RawClubRow(
+                    rowIndex + 1,
+                    cell(row, NAME_COLUMN_INDEX),
+                    cell(row, CATEGORY_COLUMN_INDEX),
+                    cell(row, CUSTOM_CATEGORY_COLUMN_INDEX),
+                    cell(row, TOPIC_COLUMN_INDEX),
+                    cell(row, CATEGORY_EMOJI_COLUMN_INDEX),
+                    cell(row, DESCRIPTION_COLUMN_INDEX)
+                );
+                if (!rawClubRow.isEmpty()) {
+                    rows.add(rawClubRow);
+                }
+            }
+            return rows;
+        } catch (IOException e) {
+            if (GoogleSheetApiExceptionHelper.isAccessDenied(e)) {
+                throw GoogleSheetApiExceptionHelper.accessDenied();
+            }
+            log.error("Failed to read website club import sheet. spreadsheetId={}", spreadsheetId, e);
+            throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
+        }
+    }
+
+    private int findHeaderIndex(List<List<Object>> values) {
+        for (int i = 0; i < values.size(); i++) {
+            if ("동아리명".equals(cell(values.get(i), 0))) {
+                return i;
+            }
+        }
+        return DEFAULT_HEADER_INDEX;
+    }
+
+    private AnalyzedClubSheet analyzeRowsWithClaude(List<RawClubRow> rows) {
+        if (rows.isEmpty()) {
+            return new AnalyzedClubSheet(List.of(), List.of("분석할 동아리 행이 없습니다."));
+        }
+
+        String prompt = buildPrompt(rows);
+        Map<String, Object> request = Map.of(
+            "model", MODEL,
+            "max_tokens", MAX_TOKENS,
+            "messages", List.of(Map.of("role", "user", "content", prompt))
+        );
+
+        try {
+            String response = restClient.post()
+                .uri(API_URL)
+                .header("x-api-key", claudeProperties.apiKey())
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(String.class);
+
+            JsonNode root = objectMapper.readTree(response);
+            String rawJson = root.path("content").get(0).path("text").asText();
+            return parseClaudeResult(rawJson);
+        } catch (Exception e) {
+            log.error("Failed to analyze website club import sheet with Claude.", e);
+            throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
+        }
+    }
+
+    private String buildPrompt(List<RawClubRow> rows) {
+        try {
+            String rowsJson = objectMapper.writeValueAsString(rows);
+            return """
+                You normalize Korean university club registration sheet rows for KONECT.
+
+                Respond ONLY with JSON:
+                {
+                  "clubs": [
+                    {
+                      "rowNumber": 5,
+                      "name": "BCSD",
+                      "clubCategory": "ACADEMIC",
+                      "topic": "개발",
+                      "description": "30자 이내 한 줄 소개",
+                      "introduce": "서비스에 표시할 상세 소개",
+                      "categoryEmoji": "💻"
+                    }
+                  ],
+                  "warnings": ["row-specific warning in Korean"]
+                }
+
+                Club category enum mapping:
+                - 공연분과 -> PERFORMANCE
+                - 사회/봉사분과 -> SOCIAL_SERVICE
+                - 전시/창작분과 -> EXHIBITION_CREATION
+                - 종교분과 -> RELIGION
+                - 체육(운동)분과 -> SPORTS
+                - 취미분과 -> HOBBY
+                - 학술분과 -> ACADEMIC
+                - 기타분과, 기타, unknown -> ETC
+
+                Rules:
+                - Skip example rows and blank rows.
+                - Keep name within 50 characters.
+                - Keep topic within 20 characters.
+                - Keep description within 30 Korean characters. If blank, create one from name/topic/category.
+                - introduce is required. If no detailed content is available, reuse description.
+                - categoryEmoji is required. If blank or unsuitable, choose one relevant emoji.
+                - Add warnings for missing or corrected important fields.
+
+                Rows:
+                %s
+                """.formatted(rowsJson);
+        } catch (IOException e) {
+            throw CustomException.of(ApiResponseCode.FAILED_SYNC_GOOGLE_SHEET);
+        }
+    }
+
+    private AnalyzedClubSheet parseClaudeResult(String rawJson) throws IOException {
+        String cleaned = extractJsonObject(rawJson);
+        JsonNode root = objectMapper.readTree(cleaned);
+        List<AdminWebsiteClubSheetImportPreviewResponse.PreviewClub> clubs = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+
+        for (JsonNode warning : root.path("warnings")) {
+            warnings.add(warning.asText());
+        }
+
+        for (JsonNode clubNode : root.path("clubs")) {
+            String name = limit(requiredText(clubNode.path("name").asText(), ""), NAME_MAX_LENGTH);
+            if (name.isBlank() || name.startsWith("예시)")) {
+                continue;
+            }
+
+            ClubCategory category = resolveCategory(clubNode.path("clubCategory").asText());
+            String topic = limit(requiredText(clubNode.path("topic").asText(), "기타"), TOPIC_MAX_LENGTH);
+            String description = limit(
+                requiredText(clubNode.path("description").asText(), name + " 동아리입니다."),
+                DESCRIPTION_MAX_LENGTH
+            );
+            String introduce = requiredText(clubNode.path("introduce").asText(), description);
+            String categoryEmoji = limit(
+                requiredText(clubNode.path("categoryEmoji").asText(), emojiOf(category)),
+                CATEGORY_EMOJI_MAX_LENGTH
+            );
+
+            clubs.add(new AdminWebsiteClubSheetImportPreviewResponse.PreviewClub(
+                clubNode.path("rowNumber").asInt(0),
+                name,
+                category,
+                topic,
+                description,
+                introduce,
+                categoryEmoji,
+                true
+            ));
+        }
+
+        return new AnalyzedClubSheet(clubs, warnings);
+    }
+
+    private ClubCategory resolveCategory(String value) {
+        if (value == null || value.isBlank()) {
+            return ClubCategory.ETC;
+        }
+        String normalized = value.trim();
+        for (ClubCategory category : ClubCategory.values()) {
+            if (category.name().equalsIgnoreCase(normalized)) {
+                return category;
+            }
+        }
+        return switch (normalized) {
+            case "공연분과" -> ClubCategory.PERFORMANCE;
+            case "사회/봉사분과" -> ClubCategory.SOCIAL_SERVICE;
+            case "전시/창작분과" -> ClubCategory.EXHIBITION_CREATION;
+            case "종교분과" -> ClubCategory.RELIGION;
+            case "체육(운동)분과" -> ClubCategory.SPORTS;
+            case "취미분과" -> ClubCategory.HOBBY;
+            case "학술분과" -> ClubCategory.ACADEMIC;
+            default -> ClubCategory.ETC;
+        };
+    }
+
+    private static String cell(List<Object> row, int index) {
+        if (row == null || index >= row.size() || row.get(index) == null) {
+            return "";
+        }
+        return row.get(index).toString().trim();
+    }
+
+    private static String requiredText(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value.trim();
+    }
+
+    private static String limit(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    private static String extractJsonObject(String rawJson) {
+        String cleaned = rawJson == null ? "" : rawJson.trim();
+        int start = cleaned.indexOf('{');
+        int end = cleaned.lastIndexOf('}');
+        if (start < 0 || end < start) {
+            throw new IllegalArgumentException("No JSON object found");
+        }
+        return cleaned.substring(start, end + 1);
+    }
+
+    private static String emojiOf(ClubCategory category) {
+        return switch (category) {
+            case PERFORMANCE -> "🎭";
+            case SOCIAL_SERVICE -> "🤝";
+            case EXHIBITION_CREATION -> "🎨";
+            case RELIGION -> "🙏";
+            case SPORTS -> "⚽";
+            case HOBBY -> "📷";
+            case ACADEMIC -> "📚";
+            case ETC -> "✨";
+        };
+    }
+
+    private record RawClubRow(
+        int rowNumber,
+        String name,
+        String category,
+        String customCategory,
+        String topic,
+        String categoryEmoji,
+        String description
+    ) {
+        private boolean isEmpty() {
+            return name.isBlank()
+                && category.isBlank()
+                && customCategory.isBlank()
+                && topic.isBlank()
+                && categoryEmoji.isBlank()
+                && description.isBlank();
+        }
+    }
+
+    private record AnalyzedClubSheet(
+        List<AdminWebsiteClubSheetImportPreviewResponse.PreviewClub> clubs,
+        List<String> warnings
+    ) {
+    }
+}

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebClubRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebClubRepository.java
@@ -1,0 +1,26 @@
+package gg.agit.konect.domain.website.repository;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import gg.agit.konect.domain.website.model.WebClub;
+
+public interface WebClubRepository extends Repository<WebClub, Integer> {
+
+    @Query("""
+        SELECT c.name
+        FROM WebClub c
+        WHERE c.university.id = :universityId
+        AND c.name IN :names
+        """)
+    Set<String> findExistingNamesByUniversityId(
+        @Param("universityId") Integer universityId,
+        @Param("names") Set<String> names
+    );
+
+    List<WebClub> saveAll(Iterable<WebClub> clubs);
+}

--- a/src/main/java/gg/agit/konect/domain/website/repository/WebUniversityRepository.java
+++ b/src/main/java/gg/agit/konect/domain/website/repository/WebUniversityRepository.java
@@ -1,0 +1,19 @@
+package gg.agit.konect.domain.website.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import gg.agit.konect.domain.website.model.WebUniversity;
+import gg.agit.konect.global.code.ApiResponseCode;
+import gg.agit.konect.global.exception.CustomException;
+
+public interface WebUniversityRepository extends Repository<WebUniversity, Integer> {
+
+    Optional<WebUniversity> findById(Integer id);
+
+    default WebUniversity getById(Integer id) {
+        return findById(id).orElseThrow(() ->
+            CustomException.of(ApiResponseCode.UNIVERSITY_NOT_FOUND));
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/admin/website/controller/AdminWebsiteClubSheetImportControllerTest.java
+++ b/src/test/java/gg/agit/konect/unit/admin/website/controller/AdminWebsiteClubSheetImportControllerTest.java
@@ -1,0 +1,84 @@
+package gg.agit.konect.unit.admin.website.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.ResponseEntity;
+
+import gg.agit.konect.admin.website.controller.AdminWebsiteClubSheetImportController;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportConfirmRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportPreviewResponse;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportResponse;
+import gg.agit.konect.admin.website.service.AdminWebsiteClubSheetImportService;
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import gg.agit.konect.support.ServiceTestSupport;
+
+class AdminWebsiteClubSheetImportControllerTest extends ServiceTestSupport {
+
+    private static final Integer UNIVERSITY_ID = 1;
+    private static final String SPREADSHEET_URL = "https://docs.google.com/spreadsheets/d/sheet-id/edit";
+
+    @Mock
+    private AdminWebsiteClubSheetImportService service;
+
+    @InjectMocks
+    private AdminWebsiteClubSheetImportController controller;
+
+    @Test
+    void previewClubsReturnsServiceResponse() {
+        AdminWebsiteClubSheetImportPreviewResponse serviceResponse =
+            AdminWebsiteClubSheetImportPreviewResponse.of(
+                UNIVERSITY_ID,
+                List.of(new AdminWebsiteClubSheetImportPreviewResponse.PreviewClub(
+                    5,
+                    "BCSD",
+                    ClubCategory.ACADEMIC,
+                    "dev",
+                    "dev club",
+                    "dev club",
+                    "IT",
+                    true
+                )),
+                List.of()
+            );
+        given(service.previewClubs(UNIVERSITY_ID, SPREADSHEET_URL)).willReturn(serviceResponse);
+
+        ResponseEntity<AdminWebsiteClubSheetImportPreviewResponse> response = controller.previewClubs(
+            UNIVERSITY_ID,
+            new AdminWebsiteClubSheetImportRequest(SPREADSHEET_URL)
+        );
+
+        assertThat(response.getBody()).isSameAs(serviceResponse);
+    }
+
+    @Test
+    void confirmImportReturnsServiceResponse() {
+        AdminWebsiteClubSheetImportResponse serviceResponse =
+            AdminWebsiteClubSheetImportResponse.of(1, 0, List.of());
+        AdminWebsiteClubSheetImportConfirmRequest request =
+            new AdminWebsiteClubSheetImportConfirmRequest(List.of(
+                new AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub(
+                    5,
+                    "BCSD",
+                    ClubCategory.ACADEMIC,
+                    "dev",
+                    "dev club",
+                    "dev club",
+                    "IT",
+                    true
+                )
+            ));
+        given(service.confirmImport(UNIVERSITY_ID, request.clubs())).willReturn(serviceResponse);
+
+        ResponseEntity<AdminWebsiteClubSheetImportResponse> response =
+            controller.confirmImport(UNIVERSITY_ID, request);
+
+        assertThat(response.getBody()).isSameAs(serviceResponse);
+    }
+}

--- a/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
@@ -6,6 +6,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.util.List;
 import java.util.Set;
@@ -13,12 +16,17 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.ValueRange;
 
 import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportConfirmRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportPreviewResponse;
 import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportResponse;
 import gg.agit.konect.admin.website.service.AdminWebsiteClubSheetImportService;
 import gg.agit.konect.domain.club.enums.ClubCategory;
@@ -39,23 +47,96 @@ class AdminWebsiteClubSheetImportServiceTest extends ServiceTestSupport {
     private Sheets googleSheetsService;
 
     @Mock
+    private Sheets.Spreadsheets spreadsheets;
+
+    @Mock
+    private Sheets.Spreadsheets.Values values;
+
+    @Mock
+    private Sheets.Spreadsheets.Values.Get getRequest;
+
+    @Mock
     private WebUniversityRepository webUniversityRepository;
 
     @Mock
     private WebClubRepository webClubRepository;
 
     private AdminWebsiteClubSheetImportService service;
+    private MockRestServiceServer mockServer;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
+        RestClient.Builder restClientBuilder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(restClientBuilder).build();
         service = new AdminWebsiteClubSheetImportService(
             googleSheetsService,
             new ClaudeProperties("test-api-key", "test-model"),
-            new ObjectMapper(),
-            RestClient.builder(),
+            objectMapper,
+            restClientBuilder,
             webUniversityRepository,
             webClubRepository
         );
+    }
+
+    @Test
+    void previewClubsReadsSheetAndReturnsClaudeAnalysis() throws Exception {
+        WebUniversity university = WebUniversity.builder()
+            .id(UNIVERSITY_ID)
+            .koreanName("Koreatech")
+            .campus(Campus.MAIN)
+            .region(UniversityRegion.CHUNGCHEONG)
+            .imageUrl("https://example.com/logo.png")
+            .build();
+
+        given(webUniversityRepository.getById(UNIVERSITY_ID)).willReturn(university);
+        given(googleSheetsService.spreadsheets()).willReturn(spreadsheets);
+        given(spreadsheets.values()).willReturn(values);
+        given(values.get("sheet-id", "'작성 시트'!A1:F1000")).willReturn(getRequest);
+        given(getRequest.setValueRenderOption("FORMATTED_VALUE")).willReturn(getRequest);
+        given(getRequest.execute()).willReturn(new ValueRange().setValues(List.of(
+            List.of("title"),
+            List.of("description"),
+            List.of(),
+            List.of("동아리명", "동아리 분과", "기타 분과", "동아리 주제", "대표 이모지", "한 줄 소개"),
+            List.of("BCSD", "학술분과", "", "dev", "IT", "dev club")
+        )));
+
+        String claudeText = """
+            {
+              "clubs": [
+                {
+                  "rowNumber": 5,
+                  "name": "BCSD",
+                  "clubCategory": "ACADEMIC",
+                  "topic": "dev",
+                  "description": "dev club",
+                  "introduce": "dev club",
+                  "categoryEmoji": "IT"
+                }
+              ],
+              "warnings": ["checked"]
+            }
+            """;
+        String response = """
+            {"content":[{"type":"text","text":%s}]}
+            """.formatted(objectMapper.writeValueAsString(claudeText));
+
+        mockServer.expect(requestTo("https://api.anthropic.com/v1/messages"))
+            .andExpect(method(HttpMethod.POST))
+            .andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+
+        AdminWebsiteClubSheetImportPreviewResponse preview = service.previewClubs(
+            UNIVERSITY_ID,
+            "https://docs.google.com/spreadsheets/d/sheet-id/edit"
+        );
+
+        assertThat(preview.previewCount()).isEqualTo(1);
+        assertThat(preview.clubs()).singleElement()
+            .extracting(AdminWebsiteClubSheetImportPreviewResponse.PreviewClub::name)
+            .isEqualTo("BCSD");
+        assertThat(preview.warnings()).containsExactly("checked");
+        mockServer.verify();
     }
 
     @Test

--- a/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
@@ -129,4 +129,42 @@ class AdminWebsiteClubSheetImportServiceTest extends ServiceTestSupport {
         ));
         verifyNoInteractions(googleSheetsService);
     }
+
+    @Test
+    void confirmImportSkipsExistingClubNameCaseInsensitively() {
+        WebUniversity university = WebUniversity.builder()
+            .id(UNIVERSITY_ID)
+            .koreanName("한국기술교육대학교")
+            .campus(Campus.MAIN)
+            .region(UniversityRegion.CHUNGCHEONG)
+            .imageUrl("https://example.com/logo.png")
+            .build();
+
+        List<AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub> clubs = List.of(
+            new AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub(
+                5,
+                "BCSD",
+                ClubCategory.ACADEMIC,
+                "개발",
+                "IT 동아리입니다.",
+                "IT 동아리입니다.",
+                "💻",
+                true
+            )
+        );
+
+        given(webUniversityRepository.getById(UNIVERSITY_ID)).willReturn(university);
+        given(webClubRepository.findExistingNamesByUniversityId(eq(UNIVERSITY_ID), anySet()))
+            .willReturn(Set.of("bcsd"));
+
+        AdminWebsiteClubSheetImportResponse response = service.confirmImport(UNIVERSITY_ID, clubs);
+
+        assertThat(response.importedCount()).isZero();
+        assertThat(response.skippedCount()).isEqualTo(1);
+        assertThat(response.warnings()).singleElement()
+            .asString()
+            .contains("BCSD");
+        verify(webClubRepository, org.mockito.Mockito.never()).saveAll(org.mockito.ArgumentMatchers.anyList());
+        verifyNoInteractions(googleSheetsService);
+    }
 }

--- a/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
@@ -1,0 +1,132 @@
+package gg.agit.konect.unit.admin.website.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.web.client.RestClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.services.sheets.v4.Sheets;
+
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportConfirmRequest;
+import gg.agit.konect.admin.website.dto.AdminWebsiteClubSheetImportResponse;
+import gg.agit.konect.admin.website.service.AdminWebsiteClubSheetImportService;
+import gg.agit.konect.domain.club.enums.ClubCategory;
+import gg.agit.konect.domain.university.enums.Campus;
+import gg.agit.konect.domain.university.enums.UniversityRegion;
+import gg.agit.konect.domain.website.model.WebClub;
+import gg.agit.konect.domain.website.model.WebUniversity;
+import gg.agit.konect.domain.website.repository.WebClubRepository;
+import gg.agit.konect.domain.website.repository.WebUniversityRepository;
+import gg.agit.konect.infrastructure.claude.config.ClaudeProperties;
+import gg.agit.konect.support.ServiceTestSupport;
+
+class AdminWebsiteClubSheetImportServiceTest extends ServiceTestSupport {
+
+    private static final Integer UNIVERSITY_ID = 1;
+
+    @Mock
+    private Sheets googleSheetsService;
+
+    @Mock
+    private WebUniversityRepository webUniversityRepository;
+
+    @Mock
+    private WebClubRepository webClubRepository;
+
+    private AdminWebsiteClubSheetImportService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminWebsiteClubSheetImportService(
+            googleSheetsService,
+            new ClaudeProperties("test-api-key", "test-model"),
+            new ObjectMapper(),
+            RestClient.builder(),
+            webUniversityRepository,
+            webClubRepository
+        );
+    }
+
+    @Test
+    void confirmImportSavesEnabledAndNonDuplicateClubsOnly() {
+        WebUniversity university = WebUniversity.builder()
+            .id(UNIVERSITY_ID)
+            .koreanName("한국기술교육대학교")
+            .campus(Campus.MAIN)
+            .region(UniversityRegion.CHUNGCHEONG)
+            .imageUrl("https://example.com/logo.png")
+            .build();
+
+        List<AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub> clubs = List.of(
+            new AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub(
+                5,
+                "BCSD",
+                ClubCategory.ACADEMIC,
+                "개발",
+                "IT 동아리입니다.",
+                "IT 동아리입니다.",
+                "💻",
+                true
+            ),
+            new AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub(
+                6,
+                "농구동아리",
+                ClubCategory.SPORTS,
+                "농구",
+                "농구 동아리입니다.",
+                "농구 동아리입니다.",
+                "🏀",
+                true
+            ),
+            new AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub(
+                7,
+                "댄스동아리",
+                ClubCategory.PERFORMANCE,
+                "댄스",
+                "댄스 동아리입니다.",
+                "댄스 동아리입니다.",
+                "💃",
+                false
+            ),
+            new AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub(
+                8,
+                "BCSD",
+                ClubCategory.ACADEMIC,
+                "개발",
+                "중복 동아리입니다.",
+                "중복 동아리입니다.",
+                "💻",
+                true
+            )
+        );
+
+        given(webUniversityRepository.getById(UNIVERSITY_ID)).willReturn(university);
+        given(webClubRepository.findExistingNamesByUniversityId(eq(UNIVERSITY_ID), anySet()))
+            .willReturn(Set.of("농구동아리"));
+        given(webClubRepository.saveAll(org.mockito.ArgumentMatchers.<List<WebClub>>any()))
+            .willAnswer(invocation -> invocation.getArgument(0));
+
+        AdminWebsiteClubSheetImportResponse response = service.confirmImport(UNIVERSITY_ID, clubs);
+
+        assertThat(response.importedCount()).isEqualTo(1);
+        assertThat(response.skippedCount()).isEqualTo(2);
+        assertThat(response.warnings()).hasSize(2);
+        assertThat(response.warnings()).anyMatch(warning -> warning.contains("농구동아리"));
+        assertThat(response.warnings()).anyMatch(warning -> warning.contains("BCSD"));
+        verify(webClubRepository).saveAll(org.mockito.ArgumentMatchers.<List<WebClub>>argThat(savedClubs ->
+            savedClubs.size() == 1 && savedClubs.getFirst().getName().equals("BCSD")
+        ));
+        verifyNoInteractions(googleSheetsService);
+    }
+}


### PR DESCRIPTION
### 🧾 개요

* konect.space 대학별 동아리 목록을 Google Sheets 등록 양식에서 분석한 뒤, 미리보기 JSON 확인 과정을 거쳐 최종 저장할 수 있도록 관리자 API를 추가했습니다.

---

### 🔧 주요 변경 내용

* 관리자용 동아리 시트 import preview/confirm API 추가
* Google Sheets 작성 시트 읽기 및 Claude Haiku 기반 동아리 데이터 정규화 로직 추가
* web_university/web_club 저장용 repository 추가
* confirm 단계에서 비활성 항목, 요청 내 중복, 기존 등록 동아리명을 제외하도록 처리
* confirm 저장 로직 단위 테스트 추가

---

### 📝 참고 사항

* preview API는 DB에 저장하지 않고 중간 JSON만 반환합니다.
* checkstyleTest는 기존 테스트 파일의 LineLength 위반으로 실패하지만, 이번 변경 파일 때문은 아닙니다.

---

### ✅Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함
- [x] 보안 및 민감 정보 검증