### PR TITLE
fix: Redis TTL 조회 실패 시 rate limit 응답 안정화

### DIFF
--- a/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/gg/agit/konect/global/ratelimit/aspect/RateLimitAspect.java
@@ -71,10 +71,7 @@ public class RateLimitAspect {
 
         // 제한 초과 확인 - 초과 시에만 TTL 조회
         if (currentCount > maxRequests) {
-            Long remainingSeconds = redisTemplate.getExpire(key);
-            long remaining = remainingSeconds != null && remainingSeconds > 0
-                ? remainingSeconds
-                : timeWindowSeconds;
+            long remaining = resolveRemainingSeconds(key, timeWindowSeconds);
             throw RateLimitExceededException.withRemainingTime(remaining);
         }
 
@@ -126,5 +123,19 @@ public class RateLimitAspect {
 
         HttpServletRequest request = attributes.getRequest();
         return request.getRemoteAddr();
+    }
+
+    private long resolveRemainingSeconds(String key, int timeWindowSeconds) {
+        try {
+            Long remainingSeconds = redisTemplate.getExpire(key);
+            return remainingSeconds != null && remainingSeconds > 0
+                ? remainingSeconds
+                : timeWindowSeconds;
+        } catch (Exception e) {
+            // 제한 초과 판단은 이미 완료되었으므로 TTL 조회 실패만 기본 window 값으로 대체한다.
+            log.warn("Rate limit TTL lookup failed for key={}: {}. Using default remaining time.",
+                key, e.getMessage());
+            return timeWindowSeconds;
+        }
     }
 }

--- a/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
@@ -156,6 +156,7 @@ class RateLimitAspectTest {
             .satisfies(ex -> {
                 CustomException customEx = (CustomException)ex;
                 assertThat(customEx.getErrorCode()).isEqualTo(ApiResponseCode.TOO_MANY_REQUESTS);
+                assertThat(customEx.getDetail()).contains("60");
             });
     }
 

--- a/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
+++ b/src/test/java/gg/agit/konect/unit/global/ratelimit/aspect/RateLimitAspectTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
@@ -119,6 +120,35 @@ class RateLimitAspectTest {
         when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
             .thenReturn(11L);
         given(redisTemplate.getExpire("ratelimit:test.method:user123")).willReturn(30L);
+
+        // when & then
+        assertThatThrownBy(() -> rateLimitAspect.around(joinPoint, rateLimit))
+            .isInstanceOf(CustomException.class)
+            .satisfies(ex -> {
+                CustomException customEx = (CustomException)ex;
+                assertThat(customEx.getErrorCode()).isEqualTo(ApiResponseCode.TOO_MANY_REQUESTS);
+            });
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("제한 초과 후 TTL 조회가 실패해도 기본 시간으로 429를 반환한다")
+    void throwsRateLimitExceptionWhenRemainingTimeLookupFails() {
+        // given
+        given(rateLimit.maxRequests()).willReturn(10);
+        given(rateLimit.timeWindowSeconds()).willReturn(60);
+        given(rateLimit.keyExpression()).willReturn("#userId");
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getDeclaringTypeName()).willReturn("test");
+        given(methodSignature.getName()).willReturn("method");
+        given(methodSignature.getParameterNames()).willReturn(new String[] {"userId"});
+        given(joinPoint.getArgs()).willReturn(new Object[] {"user123"});
+
+        // 카운터 증가는 성공했으므로 제한 초과 상태는 유지하고, 남은 시간 조회 실패만 격리한다.
+        when(redisTemplate.execute(any(DefaultRedisScript.class), any(List.class), any(String.class)))
+            .thenReturn(11L);
+        given(redisTemplate.getExpire("ratelimit:test.method:user123"))
+            .willThrow(new QueryTimeoutException("Redis command timed out"));
 
         // when & then
         assertThatThrownBy(() -> rateLimitAspect.around(joinPoint, rateLimit))


### PR DESCRIPTION
### 🔍 개요

* Rate limit 제한 초과 응답이 Redis TTL 조회 timeout 때문에 500으로 전파될 수 있던 경로를 막습니다.
* 카운터 증가로 제한 초과가 확인된 뒤에는 TTL 조회가 실패해도 기본 window 시간으로 429 응답을 유지합니다.

---

### 🚀 주요 변경 내용

* 제한 초과 후 남은 시간 조회를 별도 메서드로 분리하고, Redis 조회 실패 시 `timeWindowSeconds`를 fallback 값으로 사용했습니다.
* 카운터 증가 자체가 실패한 경우의 기존 fail-open 정책은 유지했습니다.
* TTL 조회 timeout이 발생해도 `TOO_MANY_REQUESTS` 응답이 유지되는 단위 테스트를 추가했습니다.

---

### 💬 참고 사항

* 검증 완료: `CI=true ./gradlew test --tests '*RateLimitAspectTest'`
* 검증 완료: `./gradlew checkstyleMain`
* 검증 완료: `git diff --check`
* push 전 hook에서 IntelliJ formatter, `checkstyleMain`, `compileJava`가 통과했습니다.
* `./gradlew checkstyleTest`는 기존 unrelated 테스트 파일의 line length 위반으로 실패합니다.

---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [ ] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)
