### PR TITLE
fix: 웹 동아리 등록 URI 수정

### DIFF
--- a/src/main/java/gg/agit/konect/domain/club/controller/ClubRegistrationRequestController.java
+++ b/src/main/java/gg/agit/konect/domain/club/controller/ClubRegistrationRequestController.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Club Registration", description = "동아리 등록 요청 API")
 @RestController
-@RequestMapping("/clubs")
+@RequestMapping("/konect/clubs")
 @RequiredArgsConstructor
 public class ClubRegistrationRequestController implements ClubRegistrationRequestApi {
 

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubRegistrationRequestApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubRegistrationRequestApiTest.java
@@ -34,7 +34,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         );
 
         // when & then
-        performPost("/clubs/registration-requests", request)
+        performPost("/konect/clubs/registration-requests", request)
             .andExpect(status().isCreated());
     }
 
@@ -54,7 +54,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         );
 
         // when & then
-        performPost("/clubs/registration-requests", request)
+        performPost("/konect/clubs/registration-requests", request)
             .andExpect(status().isCreated());
     }
 
@@ -74,7 +74,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         );
 
         // when & then
-        performPost("/clubs/registration-requests", request)
+        performPost("/konect/clubs/registration-requests", request)
             .andExpect(status().isBadRequest());
     }
 
@@ -101,7 +101,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         );
 
         // when & then
-        performPost("/clubs/registration-requests", request)
+        performPost("/konect/clubs/registration-requests", request)
             .andExpect(status().isBadRequest());
     }
 
@@ -122,7 +122,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         );
 
         // when & then
-        performPost("/clubs/registration-requests", request)
+        performPost("/konect/clubs/registration-requests", request)
             .andExpect(status().isBadRequest());
     }
 
@@ -135,7 +135,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         ClubInformationUpdateRequestDto request = createInformationUpdateRequest();
 
         // when & then
-        performPost("/clubs/" + club.getId() + "/information-update-requests", request)
+        performPost("/konect/clubs/" + club.getId() + "/information-update-requests", request)
             .andExpect(status().isCreated());
     }
 
@@ -146,7 +146,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         ClubInformationUpdateRequestDto request = createInformationUpdateRequest();
 
         // when & then
-        performPost("/clubs/" + Integer.MAX_VALUE + "/information-update-requests", request)
+        performPost("/konect/clubs/" + Integer.MAX_VALUE + "/information-update-requests", request)
             .andExpect(status().isNotFound());
     }
 
@@ -167,7 +167,7 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         );
 
         // when & then
-        performPost("/clubs/" + club.getId() + "/information-update-requests", request)
+        performPost("/konect/clubs/" + club.getId() + "/information-update-requests", request)
             .andExpect(status().isBadRequest());
     }
 


### PR DESCRIPTION
### 🔍 개요

* 웹에서 사용하는 동아리 등록 요청 및 동아리 정보 수정 요청 API 경로 앞에 `/konect` prefix를 추가했습니다.


---

### 🚀 주요 변경 내용

* `ClubRegistrationRequestController`의 기본 URI를 `/clubs`에서 `/konect/clubs`로 변경했습니다.
* 동아리 등록 요청 통합 테스트의 호출 경로를 새 URI 기준으로 갱신했습니다.


---

### 💬 참고 사항

* 기존 `/clubs/registration-requests`, `/clubs/{clubId}/information-update-requests`는 각각 `/konect/clubs/registration-requests`, `/konect/clubs/{clubId}/information-update-requests`로 변경됩니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)