### PR TITLE
fix: 시트 동아리 등록 상세 소개 빈 값 저장

### DIFF
--- a/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportConfirmRequest.java
+++ b/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportConfirmRequest.java
@@ -33,7 +33,7 @@ public record AdminWebsiteClubSheetImportConfirmRequest(
         @Size(max = 30)
         String description,
 
-        @NotBlank
+        @NotNull
         String introduce,
 
         @NotBlank

--- a/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
+++ b/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
@@ -42,6 +42,7 @@ public class AdminWebsiteClubSheetImportService {
     private static final int TOPIC_MAX_LENGTH = 20;
     private static final int DESCRIPTION_MAX_LENGTH = 30;
     private static final int CATEGORY_EMOJI_MAX_LENGTH = 255;
+    private static final String EMPTY_INTRODUCE = "";
     private static final int NAME_COLUMN_INDEX = 0;
     private static final int CATEGORY_COLUMN_INDEX = 1;
     private static final int CUSTOM_CATEGORY_COLUMN_INDEX = 2;
@@ -119,7 +120,7 @@ public class AdminWebsiteClubSheetImportService {
                 .name(name)
                 .topic(limit(requiredText(club.topic(), "기타"), TOPIC_MAX_LENGTH))
                 .description(limit(requiredText(club.description(), name), DESCRIPTION_MAX_LENGTH))
-                .introduce(requiredText(club.introduce(), club.description()))
+                .introduce(optionalText(club.introduce()))
                 .categoryEmoji(limit(
                     requiredText(club.categoryEmoji(), emojiOf(club.clubCategory())),
                     CATEGORY_EMOJI_MAX_LENGTH
@@ -166,7 +167,7 @@ public class AdminWebsiteClubSheetImportService {
                 category,
                 topic,
                 description,
-                description,
+                EMPTY_INTRODUCE,
                 categoryEmoji,
                 true
             ));
@@ -282,6 +283,10 @@ public class AdminWebsiteClubSheetImportService {
 
     private static String requiredText(String value, String fallback) {
         return value == null || value.isBlank() ? fallback : value.trim();
+    }
+
+    private static String optionalText(String value) {
+        return value == null ? "" : value.trim();
     }
 
     private static String limit(String value, int maxLength) {

--- a/src/test/java/gg/agit/konect/unit/admin/website/controller/AdminWebsiteClubSheetImportControllerTest.java
+++ b/src/test/java/gg/agit/konect/unit/admin/website/controller/AdminWebsiteClubSheetImportControllerTest.java
@@ -41,7 +41,7 @@ class AdminWebsiteClubSheetImportControllerTest extends ServiceTestSupport {
                     ClubCategory.ACADEMIC,
                     "dev",
                     "dev club",
-                    "dev club",
+                    "",
                     "IT",
                     true
                 )),
@@ -69,7 +69,7 @@ class AdminWebsiteClubSheetImportControllerTest extends ServiceTestSupport {
                     ClubCategory.ACADEMIC,
                     "dev",
                     "dev club",
-                    "dev club",
+                    "",
                     "IT",
                     true
                 )

--- a/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
@@ -95,6 +95,9 @@ class AdminWebsiteClubSheetImportServiceTest extends ServiceTestSupport {
         assertThat(preview.clubs().get(1).topic()).isEqualTo("기타");
         assertThat(preview.clubs().get(1).categoryEmoji()).isEqualTo("⚽");
         assertThat(preview.clubs().get(1).description()).isEqualTo("농구동아리 동아리입니다.");
+        assertThat(preview.clubs())
+            .extracting(AdminWebsiteClubSheetImportPreviewResponse.PreviewClub::introduce)
+            .containsExactly("", "");
         assertThat(preview.warnings()).hasSize(3);
     }
 
@@ -121,7 +124,9 @@ class AdminWebsiteClubSheetImportServiceTest extends ServiceTestSupport {
         assertThat(response.warnings()).anyMatch(warning -> warning.contains("농구동아리"));
         assertThat(response.warnings()).anyMatch(warning -> warning.contains("BCSD"));
         verify(webClubRepository).saveAll(org.mockito.ArgumentMatchers.<List<WebClub>>argThat(savedClubs ->
-            savedClubs.size() == 1 && savedClubs.getFirst().getName().equals("BCSD")
+            savedClubs.size() == 1
+                && savedClubs.getFirst().getName().equals("BCSD")
+                && savedClubs.getFirst().getIntroduce().isEmpty()
         ));
         verifyNoInteractions(googleSheetsService);
     }
@@ -168,7 +173,7 @@ class AdminWebsiteClubSheetImportServiceTest extends ServiceTestSupport {
             category,
             "dev",
             "dev club",
-            "dev club",
+            "",
             "IT",
             enabled
         );


### PR DESCRIPTION
### 🔍 개요

* 동아리 엑셀 양식에는 상세 소개 컬럼이 없으므로, Google Sheet import preview 및 confirm에서 상세 소개를 빈 값으로 처리하도록 변경했습니다.


---

### 🚀 주요 변경 내용

* 시트 import preview 응답의 `introduce`를 한 줄 소개 복사값이 아닌 빈 문자열로 반환합니다.
* 시트 import confirm 시 `WebClub.introduce`에 빈 문자열을 저장할 수 있도록 DTO 검증과 저장 로직을 조정했습니다.
* 관련 서비스/컨트롤러 단위 테스트를 갱신했습니다.


---

### 💬 참고 사항

* `WebClub.introduce` 컬럼은 `nullable=false`이므로 `null`이 아닌 빈 문자열로 저장합니다.
* `description`은 기존처럼 한 줄 소개로 유지됩니다.


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 가이드 준수
- [x] 테스트 코드 포함됨
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증 (API 키, 환경 변수, 개인정보 등)