### PR TITLE
fix: 웹 동아리 한 줄 소개를 100자로 확장

### DIFF
--- a/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportConfirmRequest.java
+++ b/src/main/java/gg/agit/konect/admin/website/dto/AdminWebsiteClubSheetImportConfirmRequest.java
@@ -30,7 +30,7 @@ public record AdminWebsiteClubSheetImportConfirmRequest(
         String topic,
 
         @NotBlank
-        @Size(max = 30)
+        @Size(max = 100)
         String description,
 
         @NotNull

--- a/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
+++ b/src/main/java/gg/agit/konect/admin/website/service/AdminWebsiteClubSheetImportService.java
@@ -44,7 +44,7 @@ public class AdminWebsiteClubSheetImportService {
     private static final int DEFAULT_HEADER_INDEX = 3;
     private static final int NAME_MAX_LENGTH = 50;
     private static final int TOPIC_MAX_LENGTH = 20;
-    private static final int DESCRIPTION_MAX_LENGTH = 30;
+    private static final int DESCRIPTION_MAX_LENGTH = 100;
     private static final int CATEGORY_EMOJI_MAX_LENGTH = 255;
     private static final String EMPTY_INTRODUCE = "";
     private static final int NAME_COLUMN_INDEX = 0;

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubInformationUpdateRequestDto.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubInformationUpdateRequestDto.java
@@ -32,12 +32,12 @@ public record ClubInformationUpdateRequestDto(
     String clubTopic,
 
     @Schema(
-        description = "한 줄 소개 (최대 30자)",
+        description = "한 줄 소개 (최대 100자)",
         example = "코딩 동아리입니다.",
         requiredMode = REQUIRED
     )
     @NotBlank(message = "한 줄 소개는 필수입니다.")
-    @Size(max = 30, message = "한 줄 소개는 최대 30자입니다.")
+    @Size(max = 100, message = "한 줄 소개는 최대 100자입니다.")
     String shortDescription,
 
     @Schema(

--- a/src/main/java/gg/agit/konect/domain/club/dto/ClubRegistrationRequestDto.java
+++ b/src/main/java/gg/agit/konect/domain/club/dto/ClubRegistrationRequestDto.java
@@ -37,9 +37,9 @@ public record ClubRegistrationRequestDto(
     @Size(max = 10, message = "동아리 이모지는 최대 10자입니다.")
     String clubEmoji,
 
-    @Schema(description = "한 줄 소개 (최대 30자)", example = "코딩 동아리입니다.", requiredMode = REQUIRED)
+    @Schema(description = "한 줄 소개 (최대 100자)", example = "코딩 동아리입니다.", requiredMode = REQUIRED)
     @NotBlank(message = "한 줄 소개는 필수입니다.")
-    @Size(max = 30, message = "한 줄 소개는 최대 30자입니다.")
+    @Size(max = 100, message = "한 줄 소개는 최대 100자입니다.")
     String shortDescription,
 
     @Schema(description = "동아리 소개 (최대 2000자)", example = "상세한 동아리 소개 내용...", requiredMode = REQUIRED)

--- a/src/main/java/gg/agit/konect/domain/club/model/ClubInformationUpdateRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/model/ClubInformationUpdateRequest.java
@@ -64,7 +64,7 @@ public class ClubInformationUpdateRequest extends BaseEntity {
     private String clubTopic;
 
     @NotNull
-    @Column(name = "short_description", length = 30, nullable = false)
+    @Column(name = "short_description", length = 100, nullable = false)
     private String shortDescription;
 
     @NotNull

--- a/src/main/java/gg/agit/konect/domain/club/model/ClubRegistrationRequest.java
+++ b/src/main/java/gg/agit/konect/domain/club/model/ClubRegistrationRequest.java
@@ -56,7 +56,7 @@ public class ClubRegistrationRequest extends BaseEntity {
     private String clubEmoji;
 
     @NotNull
-    @Column(name = "short_description", length = 30, nullable = false)
+    @Column(name = "short_description", length = 100, nullable = false)
     private String shortDescription;
 
     @NotNull

--- a/src/main/java/gg/agit/konect/domain/website/model/WebClub.java
+++ b/src/main/java/gg/agit/konect/domain/website/model/WebClub.java
@@ -46,7 +46,7 @@ public class WebClub extends BaseEntity {
     @Column(name = "topic", length = 20, nullable = false)
     private String topic;
 
-    @Column(name = "description", length = 30, nullable = false)
+    @Column(name = "description", length = 100, nullable = false)
     private String description;
 
     @Column(name = "introduce", columnDefinition = "TEXT", nullable = false)

--- a/src/main/resources/db/migration/V89__expand_web_club_short_description.sql
+++ b/src/main/resources/db/migration/V89__expand_web_club_short_description.sql
@@ -1,0 +1,8 @@
+ALTER TABLE web_club
+    MODIFY COLUMN description VARCHAR(100) NOT NULL;
+
+ALTER TABLE club_registration_request
+    MODIFY COLUMN short_description VARCHAR(100) NOT NULL;
+
+ALTER TABLE club_information_update_request
+    MODIFY COLUMN short_description VARCHAR(100) NOT NULL;

--- a/src/test/java/gg/agit/konect/integration/domain/club/ClubRegistrationRequestApiTest.java
+++ b/src/test/java/gg/agit/konect/integration/domain/club/ClubRegistrationRequestApiTest.java
@@ -127,6 +127,42 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
     }
 
     @Test
+    @DisplayName("한 줄 소개는 100자까지 등록할 수 있다")
+    void registerClubWithHundredCharacterShortDescription() throws Exception {
+        ClubRegistrationRequestDto request = new ClubRegistrationRequestDto(
+            "한국기술교육대학교",
+            "BCSD Lab",
+            ClubCategory.ACADEMIC,
+            "코딩",
+            "💻",
+            "가".repeat(100),
+            "상세한 동아리 소개 내용입니다.",
+            List.of()
+        );
+
+        performPost("/konect/clubs/registration-requests", request)
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("한 줄 소개가 100자를 초과하면 등록 요청을 거절한다")
+    void registerClubWithTooLongShortDescription() throws Exception {
+        ClubRegistrationRequestDto request = new ClubRegistrationRequestDto(
+            "한국기술교육대학교",
+            "BCSD Lab",
+            ClubCategory.ACADEMIC,
+            "코딩",
+            "💻",
+            "가".repeat(101),
+            "상세한 동아리 소개 내용입니다.",
+            List.of()
+        );
+
+        performPost("/konect/clubs/registration-requests", request)
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("비로그인 사용자도 기존 동아리 정보 수정 요청을 보낼 수 있다")
     void requestClubInformationUpdateWithoutLogin() throws Exception {
         // given
@@ -167,6 +203,44 @@ class ClubRegistrationRequestApiTest extends IntegrationTestSupport {
         );
 
         // when & then
+        performPost("/konect/clubs/" + club.getId() + "/information-update-requests", request)
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("한 줄 소개는 100자까지 정보 수정을 요청할 수 있다")
+    void requestClubInformationUpdateWithHundredCharacterShortDescription() throws Exception {
+        WebUniversity university = persist(WebUniversityFixture.create());
+        WebClub club = persist(WebClubFixture.create(university));
+        ClubInformationUpdateRequestDto request = new ClubInformationUpdateRequestDto(
+            "한국기술교육대학교",
+            "BCSD Lab",
+            ClubCategory.ACADEMIC,
+            "코딩",
+            "가".repeat(100),
+            "수정 상세 소개입니다.",
+            List.of()
+        );
+
+        performPost("/konect/clubs/" + club.getId() + "/information-update-requests", request)
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("한 줄 소개가 100자를 초과하면 정보 수정 요청을 거절한다")
+    void requestClubInformationUpdateWithTooLongShortDescription() throws Exception {
+        WebUniversity university = persist(WebUniversityFixture.create());
+        WebClub club = persist(WebClubFixture.create(university));
+        ClubInformationUpdateRequestDto request = new ClubInformationUpdateRequestDto(
+            "한국기술교육대학교",
+            "BCSD Lab",
+            ClubCategory.ACADEMIC,
+            "코딩",
+            "가".repeat(101),
+            "수정 상세 소개입니다.",
+            List.of()
+        );
+
         performPost("/konect/clubs/" + club.getId() + "/information-update-requests", request)
             .andExpect(status().isBadRequest());
     }

--- a/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
+++ b/src/test/java/gg/agit/konect/unit/admin/website/service/AdminWebsiteClubSheetImportServiceTest.java
@@ -110,6 +110,29 @@ class AdminWebsiteClubSheetImportServiceTest extends ServiceTestSupport {
     }
 
     @Test
+    void previewClubsPreservesDescriptionUpToHundredCharacters() throws Exception {
+        String description = "가".repeat(100);
+        given(webUniversityRepository.getById(UNIVERSITY_ID)).willReturn(university());
+        given(googleSheetsService.spreadsheets()).willReturn(spreadsheets);
+        given(spreadsheets.values()).willReturn(values);
+        given(values.get("sheet-id", "'작성 시트'!A1:F1000")).willReturn(getRequest);
+        given(getRequest.setValueRenderOption("FORMATTED_VALUE")).willReturn(getRequest);
+        given(getRequest.execute()).willReturn(new ValueRange().setValues(List.of(
+            List.of("동아리명", "동아리 분과", "기타 분과", "동아리 주제", "대표 이모지", "한 줄 소개"),
+            List.of("BCSD", "학술분과", "", "개발", "💻", description)
+        )));
+
+        AdminWebsiteClubSheetImportPreviewResponse preview = service.previewClubs(
+            UNIVERSITY_ID,
+            "https://docs.google.com/spreadsheets/d/sheet-id/edit"
+        );
+
+        assertThat(preview.clubs()).singleElement()
+            .extracting(AdminWebsiteClubSheetImportPreviewResponse.PreviewClub::description)
+            .isEqualTo(description);
+    }
+
+    @Test
     void confirmImportSavesEnabledAndNonDuplicateClubsOnly() {
         List<AdminWebsiteClubSheetImportConfirmRequest.ConfirmClub> clubs = List.of(
             confirmClub(5, "BCSD", ClubCategory.ACADEMIC, true),


### PR DESCRIPTION
### 📋 개요

* 웹 동아리 한 줄 소개가 30자에서 강제로 잘리는 문제를 해결하기 위해 길이 제한을 100자로 확장합니다.


---

### 🔧 주요 변경 내용

* 기존의 동아리 한 줄 소개 30자 제한으로 인해 크롤링했던 내용이 잘리는 현상이 있어 우선 100자로 늘렸습니다.


---

### 📝 참고 사항

* 


---

### ✅ Checklist (완료 조건)
- [x] 코드 스타일 / 가이드 준수
- [x] 테스트 코드 포함
- [x] Reviewers / Assignees / Labels 지정 완료
- [x] 보안 및 민감 정보 검증(API 키, 환경 변수, 개인정보 등)